### PR TITLE
Dev bgrabitmap

### DIFF
--- a/bgrabitmap/bgrabitmap.inc
+++ b/bgrabitmap/bgrabitmap.inc
@@ -16,6 +16,6 @@
 { Extensions of LCL to be used. Add // at the beginning of the line
   to comment them if the functions are not available }
 {$DEFINE BGRABITMAP_USE_LCL12} { Use functions of Lazarus 1.2 }
-//{$DEFINE BGRABITMAP_USE_LCL15} { Use functions of Lazarus 1.5 }
+{$DEFINE BGRABITMAP_USE_LCL15} { Use functions of Lazarus 1.5 }
 
 {$MODESWITCH ADVANCEDRECORDS}

--- a/bgrabitmap/bgrabitmap.pas
+++ b/bgrabitmap/bgrabitmap.pas
@@ -132,7 +132,7 @@ procedure BGRABitmapDraw(ACanvas: TCanvas; Rect: TRect; AData: Pointer;
   
   begin
     ...
-    BGRAReplace(temp, someBmp.Filter... );
+    BGRAReplace(someBmp, someBmp.Filter... );
   end;
 }
 procedure BGRAReplace(var Destination: TBGRABitmap; Temp: TObject);

--- a/bgrabitmap/bgrabitmappack.lpk
+++ b/bgrabitmap/bgrabitmappack.lpk
@@ -29,7 +29,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="9" Minor="4"/>
+    <Version Major="9" Minor="5"/>
     <Files Count="110">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack.lpk
+++ b/bgrabitmap/bgrabitmappack.lpk
@@ -29,8 +29,8 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="9" Minor="2" Release="3"/>
-    <Files Count="105">
+    <Version Major="9" Minor="3"/>
+    <Files Count="108">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>
         <UnitName Value="BGRAAnimatedGif"/>
@@ -451,6 +451,18 @@
         <Filename Value="bgrafilterblur.pas"/>
         <UnitName Value="BGRAFilterBlur"/>
       </Item105>
+      <Item106>
+        <Filename Value="bgramultifiletype.pas"/>
+        <UnitName Value="bgramultifiletype"/>
+      </Item106>
+      <Item107>
+        <Filename Value="bgrawinresource.pas"/>
+        <UnitName Value="BGRAWinResource"/>
+      </Item107>
+      <Item108>
+        <Filename Value="bgralazresource.pas"/>
+        <UnitName Value="BGRALazResource"/>
+      </Item108>
     </Files>
     <RequiredPkgs Count="2">
       <Item1>

--- a/bgrabitmap/bgrabitmappack.lpk
+++ b/bgrabitmap/bgrabitmappack.lpk
@@ -17,20 +17,15 @@
       </Parsing>
       <CodeGeneration>
         <Optimizations>
-          <OptimizationLevel Value="3"/>
+          <OptimizationLevel Value="0"/>
           <VariablesInRegisters Value="True"/>
         </Optimizations>
       </CodeGeneration>
-      <Linking>
-        <Debugging>
-          <GenerateDebugInfo Value="False"/>
-        </Debugging>
-      </Linking>
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="9" Minor="3"/>
-    <Files Count="109">
+    <Version Major="9" Minor="4"/>
+    <Files Count="110">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>
         <UnitName Value="BGRAAnimatedGif"/>
@@ -467,6 +462,10 @@
         <Filename Value="bgraiconcursor.pas"/>
         <UnitName Value="BGRAIconCursor"/>
       </Item109>
+      <Item110>
+        <Filename Value="bgrablurgl.pas"/>
+        <UnitName Value="BGRABlurGL"/>
+      </Item110>
     </Files>
     <RequiredPkgs Count="2">
       <Item1>

--- a/bgrabitmap/bgrabitmappack.lpk
+++ b/bgrabitmap/bgrabitmappack.lpk
@@ -30,7 +30,7 @@
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
     <Version Major="9" Minor="3"/>
-    <Files Count="108">
+    <Files Count="109">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>
         <UnitName Value="BGRAAnimatedGif"/>
@@ -453,7 +453,7 @@
       </Item105>
       <Item106>
         <Filename Value="bgramultifiletype.pas"/>
-        <UnitName Value="bgramultifiletype"/>
+        <UnitName Value="BGRAMultiFileType"/>
       </Item106>
       <Item107>
         <Filename Value="bgrawinresource.pas"/>
@@ -463,6 +463,10 @@
         <Filename Value="bgralazresource.pas"/>
         <UnitName Value="BGRALazResource"/>
       </Item108>
+      <Item109>
+        <Filename Value="bgraiconcursor.pas"/>
+        <UnitName Value="BGRAIconCursor"/>
+      </Item109>
     </Files>
     <RequiredPkgs Count="2">
       <Item1>

--- a/bgrabitmap/bgrabitmappack.lpk
+++ b/bgrabitmap/bgrabitmappack.lpk
@@ -17,10 +17,15 @@
       </Parsing>
       <CodeGeneration>
         <Optimizations>
-          <OptimizationLevel Value="0"/>
+          <OptimizationLevel Value="3"/>
           <VariablesInRegisters Value="True"/>
         </Optimizations>
       </CodeGeneration>
+      <Linking>
+        <Debugging>
+          <GenerateDebugInfo Value="False"/>
+        </Debugging>
+      </Linking>
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>

--- a/bgrabitmap/bgrabitmappack.pas
+++ b/bgrabitmap/bgrabitmappack.pas
@@ -24,7 +24,7 @@ uses
   BGRAWriteBmpMioMap, BGRAOpenGLType, BGRASpriteGL, BGRAOpenGL, BGRACanvasGL, 
   BGRAFontGL, BGRAOpenGL3D, BGRAPhoxo, BGRAFilterScanner, BGRAFilterType, 
   BGRAFilterBlur, BGRAMultiFileType, BGRAWinResource, BGRALazResource, 
-  BGRAIconCursor;
+  BGRAIconCursor, BGRABlurGL;
 
 implementation
 

--- a/bgrabitmap/bgrabitmappack.pas
+++ b/bgrabitmap/bgrabitmappack.pas
@@ -23,7 +23,7 @@ uses
   BGRAGifFormat, BGRAGraphics, BGRASceneTypes, BGRARenderer3D, 
   BGRAWriteBmpMioMap, BGRAOpenGLType, BGRASpriteGL, BGRAOpenGL, BGRACanvasGL, 
   BGRAFontGL, BGRAOpenGL3D, BGRAPhoxo, BGRAFilterScanner, BGRAFilterType, 
-  BGRAFilterBlur;
+  BGRAFilterBlur, BGRAMultiFileType, BGRAWinResource, BGRALazResource;
 
 implementation
 

--- a/bgrabitmap/bgrabitmappack.pas
+++ b/bgrabitmap/bgrabitmappack.pas
@@ -23,7 +23,8 @@ uses
   BGRAGifFormat, BGRAGraphics, BGRASceneTypes, BGRARenderer3D, 
   BGRAWriteBmpMioMap, BGRAOpenGLType, BGRASpriteGL, BGRAOpenGL, BGRACanvasGL, 
   BGRAFontGL, BGRAOpenGL3D, BGRAPhoxo, BGRAFilterScanner, BGRAFilterType, 
-  BGRAFilterBlur, BGRAMultiFileType, BGRAWinResource, BGRALazResource;
+  BGRAFilterBlur, BGRAMultiFileType, BGRAWinResource, BGRALazResource, 
+  BGRAIconCursor;
 
 implementation
 

--- a/bgrabitmap/bgrabitmappack4fpgui.lpk
+++ b/bgrabitmap/bgrabitmappack4fpgui.lpk
@@ -33,7 +33,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="9" Minor="4"/>
+    <Version Major="9" Minor="5"/>
     <Files Count="96">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack4fpgui.lpk
+++ b/bgrabitmap/bgrabitmappack4fpgui.lpk
@@ -33,7 +33,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="9" Minor="3"/>
+    <Version Major="9" Minor="4"/>
     <Files Count="96">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack4fpgui.lpk
+++ b/bgrabitmap/bgrabitmappack4fpgui.lpk
@@ -33,8 +33,8 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="9" Minor="2" Release="3"/>
-    <Files Count="93">
+    <Version Major="9" Minor="3"/>
+    <Files Count="96">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>
         <UnitName Value="BGRAAnimatedGif"/>
@@ -407,6 +407,18 @@
         <Filename Value="bgrafilterblur.pas"/>
         <UnitName Value="BGRAFilterBlur"/>
       </Item93>
+      <Item94>
+        <Filename Value="bgramultifiletype.pas"/>
+        <UnitName Value="BGRAMultiFileType"/>
+      </Item94>
+      <Item95>
+        <Filename Value="bgrawinresource.pas"/>
+        <UnitName Value="BGRAWinResource"/>
+      </Item95>
+      <Item96>
+        <Filename Value="bgralazresource.pas"/>
+        <UnitName Value="BGRALazResource"/>
+      </Item96>
     </Files>
     <RequiredPkgs Count="3">
       <Item1>

--- a/bgrabitmap/bgrabitmappack4nogui.lpk
+++ b/bgrabitmap/bgrabitmappack4nogui.lpk
@@ -35,7 +35,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="9" Minor="4"/>
+    <Version Major="9" Minor="5"/>
     <Files Count="100">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack4nogui.lpk
+++ b/bgrabitmap/bgrabitmappack4nogui.lpk
@@ -35,7 +35,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="9" Minor="3"/>
+    <Version Major="9" Minor="4"/>
     <Files Count="100">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack4nogui.lpk
+++ b/bgrabitmap/bgrabitmappack4nogui.lpk
@@ -35,8 +35,8 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="9" Minor="2" Release="3"/>
-    <Files Count="97">
+    <Version Major="9" Minor="3"/>
+    <Files Count="100">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>
         <UnitName Value="BGRAAnimatedGif"/>
@@ -425,6 +425,18 @@
         <Filename Value="bgrafilterblur.pas"/>
         <UnitName Value="BGRAFilterBlur"/>
       </Item97>
+      <Item98>
+        <Filename Value="bgramultifiletype.pas"/>
+        <UnitName Value="BGRAMultiFileType"/>
+      </Item98>
+      <Item99>
+        <Filename Value="bgrawinresource.pas"/>
+        <UnitName Value="BGRAWinResource"/>
+      </Item99>
+      <Item100>
+        <Filename Value="bgralazresource.pas"/>
+        <UnitName Value="BGRALazResource"/>
+      </Item100>
     </Files>
     <RequiredPkgs Count="2">
       <Item1>

--- a/bgrabitmap/bgrabitmaptypes.pas
+++ b/bgrabitmap/bgrabitmaptypes.pas
@@ -79,6 +79,10 @@ type
   TTextLayout = BGRAGraphics.TTextLayout;
 
 const
+  RadialBlurTypeToStr: array[TRadialBlurType] of string =
+  ('Normal','Disk','Corona','Precise','Fast','Box');
+
+
   tlTop = BGRAGraphics.tlTop;
   tlCenter = BGRAGraphics.tlCenter;
   tlBottom = BGRAGraphics.tlBottom;

--- a/bgrabitmap/bgrabitmaptypes.pas
+++ b/bgrabitmap/bgrabitmaptypes.pas
@@ -32,9 +32,11 @@ interface
 
 uses
   Classes, Types, BGRAGraphics,
-  FPImage, FPImgCanv{$IFDEF BGRABITMAP_USE_LCL}, GraphType{$ENDIF};
+  FPImage, FPImgCanv{$IFDEF BGRABITMAP_USE_LCL}, GraphType{$ENDIF},
+  BGRAMultiFileType;
 
 type
+  TMultiFileContainer = BGRAMultiFileType.TMultiFileContainer;
   Int32or64 = {$IFDEF CPU64}Int64{$ELSE}LongInt{$ENDIF};
   UInt32or64 = {$IFDEF CPU64}UInt64{$ELSE}LongWord{$ENDIF};
 

--- a/bgrabitmap/bgrabitmaptypes.pas
+++ b/bgrabitmap/bgrabitmaptypes.pas
@@ -397,8 +397,12 @@ type
         not supported by all BMP readers so it is not recommended to avoid
         storing images with transparency in this format }
     ifBmp,
+    {** iGO BMP (16-bit, rudimentary lossless compression) }
+    ifBmpMioMap,
     {** ICO format, contains different sizes of the same image }
     ifIco,
+    {** CUR format, has hotspot, contains different sizes of the same image }
+    ifCur,
     {** PCX format, opaque, rudimentary lossless compression }
     ifPcx,
     {** Paint.NET format, layers, lossless compression }
@@ -418,9 +422,7 @@ type
     {** X-Window capture, limited support }
     ifXwd,
     {** X-Pixmap, text encoded image, limited support }
-    ifXPixMap,
-    {** iGO BMP, limited support }
-    ifBmpMioMap);
+    ifXPixMap);
 
   {* Options when loading an image }
   TBGRALoadingOption = (
@@ -824,8 +826,14 @@ var
       if (magic[2] in[0,1]) and (magic[3] = 0) then inc(scores[ifBmpMioMap]);
     end;
 
-    if (magic[0] = $00) and (magic[1] = $00) and (magic[2] in[$01,$02]) and (magic[3] = $00) and
-      (magic[4] + (magic[5] shl 8) > 0) then inc(scores[ifIco]);
+    if (magic[0] = $00) and (magic[1] = $00) and (magic[3] = $00) and
+      (magic[4] + (magic[5] shl 8) > 0) then
+    begin
+      if magic[2] = $01 then
+        inc(scores[ifIco])
+      else if magic[2] = $02 then
+        inc(scores[ifCur]);
+    end;
 
     if (copy(magicAsText,1,4) = 'PDN3') then
     begin
@@ -914,7 +922,8 @@ begin
   if (ext = '.gif') then result := ifGif else
   if (ext = '.pcx') then result := ifPcx else
   if (ext = '.bmp') then result := ifBmp else
-  if (ext = '.ico') or (ext = '.cur') then result := ifIco else
+  if (ext = '.ico') then result := ifIco else
+  if (ext = '.cur') then result := ifCur else
   if (ext = '.pdn') then result := ifPaintDotNet else
   if (ext = '.lzp') then result := ifLazPaint else
   if (ext = '.ora') then result := ifOpenRaster else
@@ -934,6 +943,7 @@ begin
     ifGif: result := 'gif';
     ifBmp: result := 'bmp';
     ifIco: result := 'ico';
+    ifCur: result := 'ico';
     ifPcx: result := 'pcx';
     ifPaintDotNet: result := 'pdn';
     ifLazPaint: result := 'lzp';

--- a/bgrabitmap/bgrabitmaptypes.pas
+++ b/bgrabitmap/bgrabitmaptypes.pas
@@ -424,6 +424,22 @@ type
     {** X-Pixmap, text encoded image, limited support }
     ifXPixMap);
 
+  {* Image information from superficial analysis }
+  TQuickImageInfo = record
+    {** Width in pixels }
+    Width,
+    {** Height in pixels }
+    Height,
+    {** Bitdepth for colors (1, 2, 4, 8 for images with palette/grayscale, 16, 24 or 48 if each channel is present) }
+    ColorDepth,
+    {** Bitdepth for alpha (0 if no alpha channel, 1 if bit mask, 8 or 16 if alpha channel) }
+    AlphaDepth: integer;
+  end;
+
+  TBGRAImageReader = class(TFPCustomImageReader)
+    function GetQuickInfo(AStream: TStream): TQuickImageInfo; virtual; abstract;
+  end;
+
   {* Options when loading an image }
   TBGRALoadingOption = (
      {** Do not clear RGB channels when alpha is zero (not recommended) }

--- a/bgrabitmap/bgrablurgl.pas
+++ b/bgrabitmap/bgrablurgl.pas
@@ -1,0 +1,199 @@
+unit BGRABlurGL;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, BGRAOpenGL3D, BGRABitmapTypes, BGRACanvasGL, BGRAOpenGLType;
+
+type
+
+  { TBGLBlurShader }
+
+  TBGLBlurShader = class(TBGLShader3D)
+  private
+    function GetDirection: TPointF;
+    function GetImageIndex: integer;
+    function GetRadius: Single;
+    function GetTextureSize: TPoint;
+    procedure SetDirection(AValue: TPointF);
+    procedure SetImageIndex(AValue: integer);
+    procedure SetRadius(AValue: Single);
+    procedure SetTextureSize(AValue: TPoint);
+  protected
+    FTextureSize: TUniformVariablePoint;
+    FImageIndex: TUniformVariableInteger;
+    FDirection: TUniformVariablePointF;
+    FRadius: TUniformVariableSingle;
+    FBlurType: TRadialBlurType;
+    procedure StartUse; override;
+  public
+    constructor Create(ACanvas: TBGLCustomCanvas; ABlurType: TRadialBlurType);
+    function FilterBlurMotion(ATexture: IBGLTexture): IBGLTexture;
+    function FilterBlurMotion(ATexture: IBGLTexture; ADirection: TPointF): IBGLTexture;
+    function FilterBlurRadial(ATexture: IBGLTexture): IBGLTexture;
+    property ImageIndex: integer read GetImageIndex write SetImageIndex;
+    property TextureSize: TPoint read GetTextureSize write SetTextureSize;
+    property Direction: TPointF read GetDirection write SetDirection;
+    property Radius: Single read GetRadius write SetRadius;
+    property BlurType: TRadialBlurType read FBlurType;
+  end;
+
+implementation
+
+{ TBGLBlurShader }
+
+function TBGLBlurShader.GetDirection: TPointF;
+begin
+  result := FDirection.Value;
+end;
+
+function TBGLBlurShader.GetImageIndex: integer;
+begin
+  result := FImageIndex.Value;
+end;
+
+function TBGLBlurShader.GetRadius: Single;
+begin
+  result := FRadius.Value;
+  if FBlurType = rbPrecise then result *= 10;
+end;
+
+function TBGLBlurShader.GetTextureSize: TPoint;
+begin
+  result := FTextureSize.Value;
+end;
+
+procedure TBGLBlurShader.SetDirection(AValue: TPointF);
+begin
+  FDirection.Value := AValue;
+end;
+
+procedure TBGLBlurShader.SetImageIndex(AValue: integer);
+begin
+  FImageIndex.Value := AValue;
+end;
+
+procedure TBGLBlurShader.SetRadius(AValue: Single);
+begin
+  if FBlurType = rbPrecise then AValue /= 10;
+  FRadius.Value := AValue;
+end;
+
+procedure TBGLBlurShader.SetTextureSize(AValue: TPoint);
+begin
+  FTextureSize.Value:= AValue;
+end;
+
+constructor TBGLBlurShader.Create(ACanvas: TBGLCustomCanvas; ABlurType: TRadialBlurType);
+var weightFunc: string;
+begin
+  FBlurType:= ABlurType;
+  case ABlurType of
+  rbNormal,rbPrecise: weightFunc:=
+'   float sigma = max(0.1,radius/1.8);'#10+
+'	float normalized = x/sigma;'#10 +
+'	return 1/(2.506628274631*sigma)*exp(-0.5*normalized*normalized);';
+  rbCorona: weightFunc := 'return max(0, 1-abs(x-radius));';
+  rbFast: weightFunc := 'return max(0,radius+1-x);';
+  else {rbBox,rbDisk}
+    weightFunc := 'if (x <= radius) return 1; else return max(0,radius+1-x);';
+  end;
+
+  inherited Create(ACanvas,
+'void main(void) {'#10 +
+'	gl_Position = gl_ProjectionMatrix * gl_Vertex;'#10 +
+'    texCoord = vec2(gl_MultiTexCoord0);'#10 +
+'}',
+
+'uniform sampler2D image;'#10 +
+'uniform ivec2 textureSize;'#10 +
+'uniform vec2 direction;'#10 +
+'uniform float radius;'#10 +
+'out vec4 FragmentColor;'#10 +
+
+'float computeWeight(float x)'#10 +
+'{'#10 +
+weightFunc + #10 +
+'}'#10 +
+
+'void main(void)'#10 +
+'{'#10 +
+'	int range = int(radius+1.5);'#10 +
+
+'	float weight = computeWeight(0);'#10 +
+'	float totalWeight = weight;'#10 +
+'	FragmentColor = texture2D( image, texCoord ) * weight;'#10 +
+
+'	for (int i=1; i<=range; i++) {'#10 +
+'		weight = computeWeight(i);'#10 +
+'		FragmentColor += texture2D( image, texCoord + i*direction/textureSize ) * weight;'#10 +
+'		FragmentColor += texture2D( image, texCoord - i*direction/textureSize ) * weight;'#10 +
+'		totalWeight += 2*weight;'#10 +
+'	}'#10 +
+
+'	FragmentColor /= totalWeight;'#10 +
+'}',
+
+'varying vec2 texCoord;', '130');
+
+  FImageIndex := UniformInteger['image'];
+  FTextureSize := UniformPoint['textureSize'];
+  FDirection := UniformPointF['direction'];
+  FRadius := UniformSingle['radius'];
+
+  ImageIndex:= 0;
+  Direction := PointF(1,0);
+  TextureSize := Point(1,1);
+  Radius := 0;
+end;
+
+function TBGLBlurShader.FilterBlurRadial(ATexture: IBGLTexture): IBGLTexture;
+var horiz: IBGLTexture;
+begin
+  horiz := FilterBlurMotion(ATexture, PointF(1,0));
+  result := FilterBlurMotion(horiz, PointF(0,1));
+end;
+
+function TBGLBlurShader.FilterBlurMotion(ATexture: IBGLTexture): IBGLTexture;
+var previousBuf,buf: TBGLCustomFrameBuffer;
+  previousShader: TBGLCustomShader;
+begin
+  previousBuf := Canvas.ActiveFrameBuffer;
+  buf := Canvas.CreateFrameBuffer(ATexture.Width, ATexture.Height);
+  Canvas.ActiveFrameBuffer := buf;
+
+  TextureSize := Point(ATexture.Width,ATexture.Height);
+  previousShader := Canvas.Lighting.ActiveShader;
+  Canvas.Lighting.ActiveShader := self;
+
+  ATexture.Draw(0, 0); //perform horiz blur
+
+  Canvas.Lighting.ActiveShader := previousShader;
+  Canvas.ActiveFrameBuffer := previousBuf;
+  result := buf.MakeTextureAndFree;
+end;
+
+function TBGLBlurShader.FilterBlurMotion(ATexture: IBGLTexture;
+  ADirection: TPointF): IBGLTexture;
+var prevDir: TPointF;
+begin
+  prevDir := Direction;
+  Direction := ADirection;
+  result := FilterBlurMotion(ATexture);
+  Direction := prevDir;
+end;
+
+procedure TBGLBlurShader.StartUse;
+begin
+  inherited StartUse;
+  FImageIndex.Update;
+  FTextureSize.Update;
+  FDirection.Update;
+  FRadius.Update;
+end;
+
+end.
+
+

--- a/bgrabitmap/bgracanvasgl.pas
+++ b/bgrabitmap/bgracanvasgl.pas
@@ -284,6 +284,8 @@ type
     procedure EndZBuffer; virtual;
     procedure WaitForGPU({%H-}AOption: TWaitForGPUOption); virtual;
 
+    function GetImage(x,y,w,h: integer): TBGRACustomBitmap; virtual;
+
     procedure NoClip;
     property ActiveFrameBuffer: TBGLCustomFrameBuffer read FActiveFrameBuffer write SetActiveFrameBuffer;
     property Width: integer read GetWidth write SetWidth;
@@ -1813,6 +1815,11 @@ end;
 procedure TBGLCustomCanvas.WaitForGPU(AOption: TWaitForGPUOption);
 begin
   raise exception.Create('Not implemented');
+end;
+
+function TBGLCustomCanvas.GetImage(x, y, w, h: integer): TBGRACustomBitmap;
+begin
+  result := nil;
 end;
 
 end.

--- a/bgrabitmap/bgracanvasgl.pas
+++ b/bgrabitmap/bgracanvasgl.pas
@@ -284,7 +284,8 @@ type
     procedure EndZBuffer; virtual;
     procedure WaitForGPU({%H-}AOption: TWaitForGPUOption); virtual;
 
-    function GetImage(x,y,w,h: integer): TBGRACustomBitmap; virtual;
+    function GetImage({%H-}x,{%H-}y,{%H-}w,{%H-}h: integer): TBGRACustomBitmap; virtual;
+    function CreateFrameBuffer({%H-}AWidth,{%H-}AHeight: integer): TBGLCustomFrameBuffer; virtual;
 
     procedure NoClip;
     property ActiveFrameBuffer: TBGLCustomFrameBuffer read FActiveFrameBuffer write SetActiveFrameBuffer;
@@ -352,6 +353,7 @@ end;
 function TBGLCustomLighting.GetShader(AName: string): TBGLCustomShader;
 var index: integer;
 begin
+  if ShaderList = nil then ShaderList := TStringList.Create;
   index := ShaderList.IndexOf(AName);
   if index = -1 then
     result := nil
@@ -362,6 +364,7 @@ end;
 procedure TBGLCustomLighting.SetShader(AName: string; AValue: TBGLCustomShader);
 var index: integer;
 begin
+  if ShaderList = nil then ShaderList := TStringList.Create;
   index := ShaderList.IndexOf(AName);
   if AValue = nil then
   begin
@@ -1820,6 +1823,12 @@ end;
 function TBGLCustomCanvas.GetImage(x, y, w, h: integer): TBGRACustomBitmap;
 begin
   result := nil;
+end;
+
+function TBGLCustomCanvas.CreateFrameBuffer(AWidth, AHeight: integer): TBGLCustomFrameBuffer;
+begin
+  result := nil;
+  raise exception.Create('Not implemented');
 end;
 
 end.

--- a/bgrabitmap/bgracanvasgl.pas
+++ b/bgrabitmap/bgracanvasgl.pas
@@ -93,8 +93,8 @@ type
     procedure UseProgram(AProgram: DWord); virtual; abstract;
     function GetUniformVariable(AProgram: DWord; AName: string): DWord; virtual; abstract;
     function GetAttribVariable(AProgram: DWord; AName: string): DWord; virtual; abstract;
-    procedure SetUniformSingle(AVariable: DWord; const AValue; ACount: integer); virtual; abstract;
-    procedure SetUniformInteger(AVariable: DWord; const AValue; ACount: integer); virtual; abstract;
+    procedure SetUniformSingle(AVariable: DWord; const AValue; AElementCount, AComponentCount: integer); virtual; abstract;
+    procedure SetUniformInteger(AVariable: DWord; const AValue; AElementCount, AComponentCount: integer); virtual; abstract;
     procedure BindAttribute(AAttribute: TAttributeVariable); virtual; abstract;
     procedure UnbindAttribute(AAttribute: TAttributeVariable); virtual; abstract;
     procedure FreeShaders;

--- a/bgrabitmap/bgracustombitmap.inc
+++ b/bgrabitmap/bgracustombitmap.inc
@@ -174,9 +174,6 @@ type
      {** Offset to apply when the image is scanned using ''IBGRAScanner'' interface }
      ScanOffset: TPoint;
 
-     {** Cursor hotspot }
-     HotSpot: TPoint;
-
      {** Width of the image in pixels }
      property Width: integer Read GetWidth;
      {** Height of the image in pixels }
@@ -731,7 +728,7 @@ type
      procedure BlendImage(x, y: integer; Source: TBGRACustomBitmap; operation: TBlendOperation); virtual; abstract;
      procedure BlendImageOver(x, y: integer; Source: TBGRACustomBitmap; operation: TBlendOperation; AOpacity: byte = 255;
          ALinearBlend: boolean = false); virtual; abstract;
-     function Duplicate(DuplicateProperties: Boolean = False): TBGRACustomBitmap; virtual; abstract;
+     function Duplicate(DuplicateProperties: Boolean = False; DuplicateXorMask: Boolean = False): TBGRACustomBitmap; virtual; abstract;
      function Equals(comp: TBGRACustomBitmap): boolean; virtual; abstract;
      function Equals(comp: TBGRAPixel): boolean; virtual; abstract;
      function Resample(newWidth, newHeight: integer;

--- a/bgrabitmap/bgracustombitmap.inc
+++ b/bgrabitmap/bgracustombitmap.inc
@@ -174,6 +174,9 @@ type
      {** Offset to apply when the image is scanned using ''IBGRAScanner'' interface }
      ScanOffset: TPoint;
 
+     {** Cursor hotspot }
+     HotSpot: TPoint;
+
      {** Width of the image in pixels }
      property Width: integer Read GetWidth;
      {** Height of the image in pixels }

--- a/bgrabitmap/bgracustombitmap.inc
+++ b/bgrabitmap/bgracustombitmap.inc
@@ -91,7 +91,9 @@ type
     function GetFontAntialias: Boolean;
     procedure SetFontAntialias(const AValue: Boolean);
   protected
-     { accessors to properies }
+    FXorMask: TBGRACustomBitmap;
+
+    { accessors to properies }
      function GetArrowEndRepeat: integer; virtual; abstract;
      function GetArrowStartRepeat: integer; virtual; abstract;
      procedure SetArrowEndRepeat(AValue: integer); virtual; abstract;
@@ -173,6 +175,18 @@ type
      ScanInterpolationFilter: TResampleFilter;
      {** Offset to apply when the image is scanned using ''IBGRAScanner'' interface }
      ScanOffset: TPoint;
+
+     {** Cursor position for mouse pointer }
+     HotSpot: TPoint;
+
+     { ** Free reference to xor mask }
+     procedure DiscardXorMask; virtual; abstract;
+
+     { ** Allocate xor mask }
+     procedure NeedXorMask; virtual; abstract;
+
+     {** Xor mask to be applied when image is drawn }
+     property XorMask: TBGRACustomBitmap read FXorMask;
 
      {** Width of the image in pixels }
      property Width: integer Read GetWidth;

--- a/bgrabitmap/bgradefaultbitmap.pas
+++ b/bgrabitmap/bgradefaultbitmap.pas
@@ -207,8 +207,6 @@ type
 
   public
     {** Cursor hotspot and Xor mask }
-    HotSpot: TPoint;
-    XorMask: TBGRADefaultBitmap;
 
     {** Provides a canvas with opacity and antialiasing }
     property CanvasBGRA: TBGRACanvas read GetCanvasBGRA;
@@ -229,7 +227,12 @@ type
     {** Returns an object with a reference count equal to 1. Duplicate
         this bitmap if necessary }
     function GetUnique: TBGRACustomBitmap;
-    procedure DiscardXorMask;
+
+    { ** Allocate xor mask }
+    procedure NeedXorMask; override;
+
+    { ** Free reference to xor mask }
+    procedure DiscardXorMask; override;
 
     {==== Constructors ====}
 
@@ -1243,12 +1246,22 @@ begin
     Result := self;
 end;
 
+procedure TBGRADefaultBitmap.NeedXorMask;
+begin
+  if FXorMask = nil then
+    FXorMask := BGRABitmapFactory.Create(Width,Height);
+end;
+
 procedure TBGRADefaultBitmap.DiscardXorMask;
 begin
-  if Assigned(XorMask) then
+  if Assigned(FXorMask) then
   begin
-    XorMask.FreeReference;
-    XorMask := nil;
+    if FXorMask is TBGRADefaultBitmap then
+    begin
+      TBGRADefaultBitmap(FXorMask).FreeReference;
+      FXorMask := nil;
+    end else
+      FreeAndNil(FXorMask);
   end;
 end;
 
@@ -1521,7 +1534,10 @@ begin
       if XorMask <> TBGRADefaultBitmap(Source).XorMask then
       begin
         DiscardXorMask;
-        XorMask := TBGRADefaultBitmap(Source).NewReference as TBGRADefaultBitmap;
+        if TBGRADefaultBitmap(Source).XorMask is TBGRADefaultBitmap then
+          FXorMask := TBGRADefaultBitmap(TBGRADefaultBitmap(Source).XorMask).NewReference as TBGRADefaultBitmap
+        else
+          FXorMask := TBGRADefaultBitmap(Source).XorMask.Duplicate;
       end;
     end;
   end else
@@ -4933,7 +4949,7 @@ begin
   if DuplicateProperties then
     CopyPropertiesTo(Temp);
   if DuplicateXorMask and Assigned(XorMask) then
-    Temp.XorMask := XorMask.Duplicate(True) as TBGRADefaultBitmap;
+    Temp.FXorMask := FXorMask.Duplicate(True) as TBGRADefaultBitmap;
   Result := Temp;
 end;
 
@@ -5423,7 +5439,7 @@ begin
     end;
   end;
 
-  if Assigned(XorMask) then TBGRADefaultBitmap(result).XorMask := self.XorMask.RotateCW as TBGRADefaultBitmap;
+  if Assigned(XorMask) then TBGRADefaultBitmap(result).FXorMask := self.XorMask.RotateCW;
 end;
 
 { Return a new bitmap rotated in a counter clock wise direction. }
@@ -5451,7 +5467,7 @@ begin
     end;
   end;
 
-  if Assigned(XorMask) then TBGRADefaultBitmap(result).XorMask := self.XorMask.RotateCCW as TBGRADefaultBitmap;
+  if Assigned(XorMask) then TBGRADefaultBitmap(result).FXorMask := self.XorMask.RotateCCW;
 end;
 
 { Compute negative with gamma correction. A negative contains
@@ -6017,7 +6033,7 @@ begin
   Result := NewBitmap(Width, Height);
   if DuplicateProperties then CopyPropertiesTo(TBGRADefaultBitmap(Result));
   if DuplicateXorMask and Assigned(XorMask) then
-    TBGRADefaultBitmap(Result).XorMask := XorMask.Duplicate(True) as TBGRADefaultBitmap;
+    TBGRADefaultBitmap(Result).FXorMask := FXorMask.Duplicate(True);
 end;
 
 procedure TBGRAPtrBitmap.SetDataPtr(AData: Pointer);

--- a/bgrabitmap/bgradefaultbitmap.pas
+++ b/bgrabitmap/bgradefaultbitmap.pas
@@ -206,6 +206,10 @@ type
       AFillColor: TBGRAPixel; AOptions: TArcOptions; ADrawChord: boolean = false; ATexture: IBGRAScanner = nil); override;
 
   public
+    {** Cursor hotspot and Xor mask }
+    HotSpot: TPoint;
+    XorMask: TBGRADefaultBitmap;
+
     {** Provides a canvas with opacity and antialiasing }
     property CanvasBGRA: TBGRACanvas read GetCanvasBGRA;
     {** Provides a canvas with 2d transformation and similar to HTML5. }
@@ -225,6 +229,7 @@ type
     {** Returns an object with a reference count equal to 1. Duplicate
         this bitmap if necessary }
     function GetUnique: TBGRACustomBitmap;
+    procedure DiscardXorMask;
 
     {==== Constructors ====}
 
@@ -795,7 +800,7 @@ type
 
     function GetPart(ARect: TRect): TBGRACustomBitmap; override;
     function GetPtrBitmap(Top,Bottom: Integer): TBGRACustomBitmap; override;
-    function Duplicate(DuplicateProperties: Boolean = False) : TBGRACustomBitmap; override;
+    function Duplicate(DuplicateProperties: Boolean = False; DuplicateXorMask: Boolean = False) : TBGRACustomBitmap; override;
     procedure CopyPropertiesTo(ABitmap: TBGRADefaultBitmap);
     function Equals(comp: TBGRACustomBitmap): boolean; override;
     function Equals(comp: TBGRAPixel): boolean; override;
@@ -879,7 +884,7 @@ type
       =True): boolean; override; //to override
   public
     constructor Create(AWidth, AHeight: integer; AData: Pointer); overload;
-    function Duplicate(DuplicateProperties: Boolean = False): TBGRACustomBitmap; override;
+    function Duplicate(DuplicateProperties: Boolean = False; DuplicateXorMask: Boolean = False): TBGRACustomBitmap; override;
     procedure SetDataPtr(AData: Pointer);
     property LineOrder: TRawImageLineOrder Read GetLineOrder Write SetLineOrder;
 
@@ -1238,6 +1243,15 @@ begin
     Result := self;
 end;
 
+procedure TBGRADefaultBitmap.DiscardXorMask;
+begin
+  if Assigned(XorMask) then
+  begin
+    XorMask.FreeReference;
+    XorMask := nil;
+  end;
+end;
+
 { Creates a new bitmap with dimensions AWidth and AHeight and filled with
   transparent pixels. Internally, it uses the same type so that if you
   use an optimized version, you get a new bitmap with the same optimizations }
@@ -1308,6 +1322,7 @@ procedure TBGRADefaultBitmap.LoadFromStream(Str: TStream;
 var OldBmpOption: TBMPTransparencyOption;
   OldJpegPerf: TJPEGReadPerformance;
 begin
+  DiscardXorMask;
   if (loBmpAutoOpaque in AOptions) and (Handler is TBGRAReaderBMP) then
   begin
     OldBmpOption := TBGRAReaderBMP(Handler).TransparencyOption;
@@ -1356,6 +1371,7 @@ begin
   FreeBitmap;
   ReallocData;
   NoClip;
+  DiscardXorMask;
 end;
 
 {---------------------- Constructors ---------------------------------}
@@ -1411,6 +1427,7 @@ end;
 { Free the object and all its resources }
 destructor TBGRADefaultBitmap.Destroy;
 begin
+  DiscardXorMask;
   FPenStroker.Free;
   FFontRenderer.Free;
   FCanvasFP.Free;
@@ -1498,7 +1515,15 @@ begin
     DiscardBitmapChange;
     SetSize(TBGRACustomBitmap(Source).Width, TBGRACustomBitmap(Source).Height);
     PutImage(0, 0, TBGRACustomBitmap(Source), dmSet);
-    HotSpot := TBGRACustomBitmap(Source).HotSpot;
+    if Source is TBGRADefaultBitmap then
+    begin
+      HotSpot := TBGRADefaultBitmap(Source).HotSpot;
+      if XorMask <> TBGRADefaultBitmap(Source).XorMask then
+      begin
+        DiscardXorMask;
+        XorMask := TBGRADefaultBitmap(Source).NewReference as TBGRADefaultBitmap;
+      end;
+    end;
   end else
   if Source is TFPCustomImage then
   begin
@@ -4653,6 +4678,8 @@ begin
         Inc(pdest, delta_dest);
       end;
       InvalidateBitmap;
+      if (Source is TBGRADefaultBitmap) and Assigned(TBGRADefaultBitmap(Source).XorMask) then
+        PutImage(x,y,TBGRADefaultBitmap(Source).XorMask,dmXor,AOpacity);
     end;
     dmDrawWithTransparency:
     begin
@@ -4680,6 +4707,8 @@ begin
         Inc(pdest, delta_dest);
       end;
       InvalidateBitmap;
+      if (Source is TBGRADefaultBitmap) and Assigned(TBGRADefaultBitmap(Source).XorMask) then
+        PutImage(x,y,TBGRADefaultBitmap(Source).XorMask,dmXor,AOpacity);
     end;
     dmFastBlend:
     begin
@@ -4706,6 +4735,8 @@ begin
         Inc(pdest, delta_dest);
       end;
       InvalidateBitmap;
+      if (Source is TBGRADefaultBitmap) and Assigned(TBGRADefaultBitmap(Source).XorMask) then
+        PutImage(x,y,TBGRADefaultBitmap(Source).XorMask,dmXor,AOpacity);
     end;
     dmXor:
     begin
@@ -4875,16 +4906,24 @@ end;
 
 procedure TBGRADefaultBitmap.StretchPutImage(ARect: TRect;
   Source: TBGRACustomBitmap; mode: TDrawMode; AOpacity: byte);
+var noTransition: boolean;
 begin
   If (Source = nil) or (AOpacity = 0) then exit;
   if (ARect.Right-ARect.Left = Source.Width) and (ARect.Bottom-ARect.Top = Source.Height) then
      PutImage(ARect.Left,ARect.Top,Source,mode,AOpacity)
   else
-     BGRAResample.StretchPutImage(Source, ARect.Right-ARect.Left, ARect.Bottom-ARect.Top, self, ARect.left,ARect.Top, mode, AOpacity);
+  begin
+     noTransition:= (mode = dmXor) or ((mode in [dmDrawWithTransparency,dmFastBlend,dmSetExceptTransparent]) and
+                                       (Source is TBGRADefaultBitmap) and
+                                       Assigned(TBGRADefaultBitmap(Source).XorMask));
+     BGRAResample.StretchPutImage(Source, ARect.Right-ARect.Left, ARect.Bottom-ARect.Top, self, ARect.left,ARect.Top, mode, AOpacity, noTransition);
+    if (mode in [dmDrawWithTransparency,dmFastBlend,dmSetExceptTransparent]) and Assigned(TBGRADefaultBitmap(Source).XorMask) then
+      BGRAResample.StretchPutImage(TBGRADefaultBitmap(Source).XorMask, ARect.Right-ARect.Left, ARect.Bottom-ARect.Top, self, ARect.left,ARect.Top, dmXor, AOpacity, noTransition);
+  end;
 end;
 
 { Duplicate bitmap content. Optionally, bitmap properties can be also duplicated }
-function TBGRADefaultBitmap.Duplicate(DuplicateProperties: Boolean = False): TBGRACustomBitmap;
+function TBGRADefaultBitmap.Duplicate(DuplicateProperties: Boolean = False; DuplicateXorMask: Boolean = False): TBGRACustomBitmap;
 var Temp: TBGRADefaultBitmap;
 begin
   LoadFromBitmapIfNeeded;
@@ -4893,6 +4932,8 @@ begin
   Temp.Caption := self.Caption;
   if DuplicateProperties then
     CopyPropertiesTo(Temp);
+  if DuplicateXorMask and Assigned(XorMask) then
+    Temp.XorMask := XorMask.Duplicate(True) as TBGRADefaultBitmap;
   Result := Temp;
 end;
 
@@ -5318,6 +5359,8 @@ begin
   end;
   freemem(line);
   InvalidateBitmap;
+
+  if Assigned(XorMask) then XorMask.VerticalFlip(ARect);
 end;
 
 { Flip horizontally. Swap left pixels with right pixels on each line.
@@ -5351,6 +5394,8 @@ begin
     end;
   end;
   InvalidateBitmap;
+
+  if Assigned(XorMask) then XorMask.HorizontalFlip(ARect);
 end;
 
 { Return a new bitmap rotated in a clock wise direction. }
@@ -5377,6 +5422,8 @@ begin
       Inc(pdest, delta);
     end;
   end;
+
+  if Assigned(XorMask) then TBGRADefaultBitmap(result).XorMask := self.XorMask.RotateCW as TBGRADefaultBitmap;
 end;
 
 { Return a new bitmap rotated in a counter clock wise direction. }
@@ -5403,6 +5450,8 @@ begin
       Dec(pdest, delta);
     end;
   end;
+
+  if Assigned(XorMask) then TBGRADefaultBitmap(result).XorMask := self.XorMask.RotateCCW as TBGRADefaultBitmap;
 end;
 
 { Compute negative with gamma correction. A negative contains
@@ -5963,10 +6012,12 @@ begin
   SetDataPtr(AData);
 end;
 
-function TBGRAPtrBitmap.Duplicate(DuplicateProperties: Boolean = False): TBGRACustomBitmap;
+function TBGRAPtrBitmap.Duplicate(DuplicateProperties: Boolean = False; DuplicateXorMask: Boolean = False): TBGRACustomBitmap;
 begin
   Result := NewBitmap(Width, Height);
   if DuplicateProperties then CopyPropertiesTo(TBGRADefaultBitmap(Result));
+  if DuplicateXorMask and Assigned(XorMask) then
+    TBGRADefaultBitmap(Result).XorMask := XorMask.Duplicate(True) as TBGRADefaultBitmap;
 end;
 
 procedure TBGRAPtrBitmap.SetDataPtr(AData: Pointer);

--- a/bgrabitmap/bgradefaultbitmap.pas
+++ b/bgrabitmap/bgradefaultbitmap.pas
@@ -292,7 +292,7 @@ type
     function NewBitmap(AFPImage: TFPCustomImage): TBGRACustomBitmap; override;
 
     {** Load image from a stream. The specified image reader is used }
-    procedure LoadFromStream(Str: TStream; Handler: TFPCustomImageReader; AOptions: TBGRALoadingOptions); override;
+    procedure LoadFromStream(Str: TStream; Handler: TFPCustomImageReader; AOptions: TBGRALoadingOptions); override; overload;
 
     {** Assign the content of the specified ''Source''. It can be a ''TBGRACustomBitmap'' or
         a ''TFPCustomImage'' }
@@ -1498,6 +1498,7 @@ begin
     DiscardBitmapChange;
     SetSize(TBGRACustomBitmap(Source).Width, TBGRACustomBitmap(Source).Height);
     PutImage(0, 0, TBGRACustomBitmap(Source), dmSet);
+    HotSpot := TBGRACustomBitmap(Source).HotSpot;
   end else
   if Source is TFPCustomImage then
   begin

--- a/bgrabitmap/bgraiconcursor.pas
+++ b/bgrabitmap/bgraiconcursor.pas
@@ -1,0 +1,624 @@
+unit BGRAIconCursor;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, BGRAMultiFileType, BGRABitmapTypes;
+
+type
+  { TBGRAIconCursorEntry }
+
+  TBGRAIconCursorEntry = class(TMultiFileEntry)
+  protected
+    FWidth,FHeight,FBitDepth: integer;
+    FExtension: string;
+    FContent: TStream;
+    FHotSpot: TPoint;
+    function GetName: utf8string; override;
+    procedure SetName({%H-}AValue: utf8string); override;
+    function GetExtension: utf8string; override;
+    function GetFileSize: int64; override;
+  public
+    constructor Create(AContainer: TMultiFileContainer; AExtension: string; AInfo: TQuickImageInfo; AContent: TStream);
+    class function TryCreate(AContainer: TMultiFileContainer; AContent: TStream): TBGRAIconCursorEntry;
+    destructor Destroy; override;
+    function CopyTo(ADestination: TStream): integer; override;
+    function GetBitmap: TBGRACustomBitmap;
+    property Width: integer read FWidth;
+    property Height: integer read FHeight;
+    property BitDepth: integer read FBitDepth;
+    property HotSpot: TPoint read FHotSpot write FHotSpot;
+  end;
+
+  { TBGRAIconCursor }
+
+  TBGRAIconCursor = class(TMultiFileContainer)
+  private
+    function GetBitDepthAt(AIndex: integer): integer;
+    function GetHeightAt(AIndex: integer): integer;
+    function GetHotSpotAtAt(AIndex: integer): TPoint;
+    function GetWidthAt(AIndex: integer): integer;
+    procedure SetFileType(AValue: TBGRAImageFormat);
+    procedure SetHotSpotAt(AIndex: integer; AValue: TPoint);
+  protected
+    FFileType : TBGRAImageFormat;
+    function CreateEntry(AName: utf8string; AExtension: utf8string;
+      AContent: TStream): TMultiFileEntry; override;
+    function ExpectedMagic: Word;
+    procedure Init; override;
+  public
+    constructor Create(AFileType: TBGRAImageFormat); overload;
+    function Add(ABitmap: TBGRACustomBitmap; ABitDepth: integer; AOverwrite: boolean = false): integer; overload;
+    function Add(AContent: TStream; AOverwrite: boolean = false; AOwnStream: boolean = true): integer; overload;
+    procedure LoadFromStream(AStream: TStream); override;
+    procedure SaveToStream(ADestination: TStream); override;
+    function GetBitmap(AIndex: integer): TBGRACustomBitmap;
+    function GetBestFitBitmap(AWidth,AHeight: integer): TBGRACustomBitmap;
+    property FileType: TBGRAImageFormat read FFileType write SetFileType;
+    property Width[AIndex: integer]: integer read GetWidthAt;
+    property Height[AIndex: integer]: integer read GetHeightAt;
+    property BitDepth[AIndex: integer]: integer read GetBitDepthAt;
+    property HotSpot[AIndex: integer]: TPoint read GetHotSpotAtAt write SetHotSpotAt;
+  end;
+
+implementation
+
+uses BGRAWinResource, BGRAUTF8, BGRAReadPng, BGRAReadBMP, FPWriteBMP, BGRAPalette;
+
+{ TBGRAIconCursorEntry }
+
+constructor TBGRAIconCursorEntry.Create(AContainer: TMultiFileContainer; AExtension: string; AInfo: TQuickImageInfo;
+  AContent: TStream);
+begin
+  inherited Create(AContainer);
+  FExtension:= AExtension;
+  FWidth := AInfo.Width;
+  FHeight:= AInfo.Height;
+
+  // 16 bit per channel is not relevant for icon depth
+  if AInfo.ColorDepth >= 24 then
+  begin
+    if AInfo.AlphaDepth >= 8 then
+      FBitDepth := 32
+    else
+      FBitDepth := 24;
+  end else
+    FBitDepth := AInfo.ColorDepth;
+
+  FContent := AContent;
+end;
+
+class function TBGRAIconCursorEntry.TryCreate(
+  AContainer: TMultiFileContainer; AContent: TStream): TBGRAIconCursorEntry;
+var
+  format: TBGRAImageFormat;
+  imageInfo: TQuickImageInfo;
+  tempStream: TMemoryStream;
+  reader: TBGRAImageReader;
+  bmp: TBGRACustomBitmap;
+  maskLine: packed array of byte;
+  psrc: PBGRAPixel;
+  maskBit: byte;
+  maskPos,x,y: integer;
+  headerSize: integer;
+begin
+  AContent.Position:= 0;
+  format := DetectFileFormat(AContent);
+  case format of
+  ifBmp:
+    begin
+      reader := TBGRAReaderBMP.Create;
+      bmp := BGRABitmapFactory.Create;
+      try
+        AContent.Position := 0;
+        imageInfo := reader.GetQuickInfo(AContent);
+        if (imageInfo.width <= 0) or (imageInfo.height <= 0) or
+           (imageInfo.width > 256) or (imageInfo.height > 256) then
+          raise exception.Create('Invalid image size');
+        AContent.Position := 0;
+        //load bitmap to build mask
+        bmp.LoadFromStream(AContent);
+
+        tempStream := TMemoryStream.Create;
+        //BMP header is not stored in icon/cursor
+        AContent.Position:= sizeof(TBitMapFileHeader);
+        tempStream.CopyFrom(AContent, AContent.Size - sizeof(TBitMapFileHeader));
+        AContent.Free;
+
+        //fix height
+        tempStream.Position := 0;
+        headerSize := LEtoN(tempStream.ReadDWord);
+        if headerSize = sizeof(TOS2BitmapHeader) then // OS/2 1.x
+        begin
+          tempStream.Position := 6;
+          tempStream.WriteWord(NtoLE(word(bmp.Height*2))); //include mask size
+        end else
+        begin
+          tempStream.Position := 8;
+          tempStream.WriteDWord(NtoLE(dword(bmp.Height*2))); //include mask size
+        end;
+
+        //build mask
+        tempStream.Position := tempStream.Size;
+        setlength(maskLine, (bmp.Width+7) div 8);
+        for y := 0 to bmp.Height-1 do
+        begin
+          maskBit := $80;
+          maskPos := 0;
+          psrc := bmp.ScanLine[y];
+          for x := 0 to bmp.Width-1 do
+          begin
+            if psrc^.alpha = 0 then
+              maskLine[maskPos] := maskLine[maskPos] or maskBit;
+            maskBit := maskBit shr 1;
+            if maskBit = 0 then
+            begin
+              maskBit := $80;
+              maskPos += 1;
+            end;
+            inc(psrc);
+          end;
+          tempStream.WriteBuffer(maskLine[0], length(maskLine));
+        end;
+
+        result := TBGRAIconCursorEntry.Create(AContainer, 'dib', imageInfo, tempStream);
+      finally
+        bmp.Free;
+        reader.Free;
+      end;
+    end;
+  ifPng:
+    begin
+      reader := TBGRAReaderPNG.Create;
+      imageInfo := reader.GetQuickInfo(AContent);
+      reader.Free;
+      result := TBGRAIconCursorEntry.Create(AContainer, 'png', imageInfo, AContent);
+
+    end;
+  ifUnknown, ifLazPaint {a headerless bmp can be confused for a headerless lzp}:
+    begin
+      //assume headerless BMP
+      AContent.Position := 0;
+      reader := TBGRAReaderBMP.Create;
+      imageInfo := reader.GetQuickInfo(AContent);
+      imageInfo.Height:= imageInfo.Height div 2; //mask size is included
+      reader.Free;
+      if (imageInfo.width <= 0) or (imageInfo.height <= 0) or
+         (imageInfo.width > 256) or (imageInfo.height > 256) then
+        raise exception.Create('Invalid image size');
+      result := TBGRAIconCursorEntry.Create(AContainer, 'dib', imageInfo, AContent);
+    end;
+  else
+    raise exception.Create(SuggestImageExtension(format) + ' format is not handled');
+  end;
+end;
+
+destructor TBGRAIconCursorEntry.Destroy;
+begin
+  FContent.Free;
+  inherited Destroy;
+end;
+
+function TBGRAIconCursorEntry.CopyTo(ADestination: TStream): integer;
+begin
+  if FContent.Size = 0 then exit;
+
+  FContent.Position := 0;
+  result := ADestination.CopyFrom(FContent, FContent.Size);
+end;
+
+function TBGRAIconCursorEntry.GetBitmap: TBGRACustomBitmap;
+var reader: TBGRAImageReader;
+begin
+  if Extension = 'dib' then
+  begin
+    reader := TBGRAReaderBMP.Create;
+    TBGRAReaderBMP(reader).Subformat := bsfHeaderlessWithMask;
+  end else
+    reader := TBGRAReaderPNG.create;
+
+  result := BGRABitmapFactory.Create;
+  FContent.Position := 0;
+  try
+    result.LoadFromStream(FContent, reader);
+  except on ex: Exception do
+    begin
+      result.Free;
+      reader.Free;
+      raise ex;
+    end;
+  end;
+  reader.Free;
+
+  result.HotSpot := HotSpot;
+end;
+
+function TBGRAIconCursorEntry.GetName: utf8string;
+begin
+  result := IntToStr(FWidth)+'x'+IntToStr(FHeight)+'x'+IntToStr(FBitDepth);
+end;
+
+procedure TBGRAIconCursorEntry.SetName(AValue: utf8string);
+begin
+  raise exception.Create('Name cannot be changed');
+end;
+
+function TBGRAIconCursorEntry.GetExtension: utf8string;
+begin
+  result := FExtension;
+end;
+
+function TBGRAIconCursorEntry.GetFileSize: int64;
+begin
+  result := FContent.Size;
+end;
+
+{ TBGRAIconCursor }
+
+function TBGRAIconCursor.GetBitDepthAt(AIndex: integer): integer;
+begin
+  if (AIndex < 0) or (AIndex >= Count) then raise ERangeError.Create('Index out of bounds');
+  result := TBGRAIconCursorEntry(Entry[AIndex]).BitDepth;
+end;
+
+function TBGRAIconCursor.GetHeightAt(AIndex: integer): integer;
+begin
+  if (AIndex < 0) or (AIndex >= Count) then raise ERangeError.Create('Index out of bounds');
+  result := TBGRAIconCursorEntry(Entry[AIndex]).Height;
+end;
+
+function TBGRAIconCursor.GetHotSpotAtAt(AIndex: integer): TPoint;
+begin
+  if (AIndex < 0) or (AIndex >= Count) then raise ERangeError.Create('Index out of bounds');
+  result := TBGRAIconCursorEntry(Entry[AIndex]).HotSpot;
+end;
+
+function TBGRAIconCursor.GetWidthAt(AIndex: integer): integer;
+begin
+  if (AIndex < 0) or (AIndex >= Count) then raise ERangeError.Create('Index out of bounds');
+  result := TBGRAIconCursorEntry(Entry[AIndex]).Width;
+end;
+
+procedure TBGRAIconCursor.SetFileType(AValue: TBGRAImageFormat);
+begin
+  if FFileType=AValue then Exit;
+  if not (AValue in [ifIco,ifCur,ifUnknown]) then
+    raise exception.Create('Allowed formats: ICO, CUR or unknown');
+  FFileType:=AValue;
+end;
+
+procedure TBGRAIconCursor.SetHotSpotAt(AIndex: integer; AValue: TPoint);
+begin
+  if (AIndex < 0) or (AIndex >= Count) then raise ERangeError.Create('Index out of bounds');
+  TBGRAIconCursorEntry(Entry[AIndex]).HotSpot := AValue;
+end;
+
+function TBGRAIconCursor.CreateEntry(AName: utf8string;
+  AExtension: utf8string; AContent: TStream): TMultiFileEntry;
+begin
+  AExtension := UTF8LowerCase(AExtension);
+  if (AExtension <> 'png') and (AExtension <> 'dib') then
+    raise exception.Create('The only supported extensions are PNG and DIB');
+
+  result := TBGRAIconCursorEntry.TryCreate(self, AContent);
+  if result.Extension <> AExtension then
+  begin
+    result.Free;
+    raise exception.Create(AExtension + ' file extension expected but ' + result.Extension + ' found');
+  end;
+
+  if result.Name <> AName then
+  begin
+    result.Free;
+    raise exception.Create('"' + AName + '" dimension expected but "' + result.Name + '" found');
+  end;
+end;
+
+function TBGRAIconCursor.ExpectedMagic: Word;
+begin
+  case FFileType of
+  ifIco: result := ICON_OR_CURSOR_FILE_ICON_TYPE;
+  ifCur: result := ICON_OR_CURSOR_FILE_CURSOR_TYPE;
+  else
+    raise exception.Create('Invalid icon/cursor type');
+  end;
+end;
+
+procedure TBGRAIconCursor.Init;
+begin
+  inherited Init;
+  FFileType:= ifUnknown;
+end;
+
+constructor TBGRAIconCursor.Create(AFileType: TBGRAImageFormat);
+begin
+  if not (AFileType in [ifIco,ifCur,ifUnknown]) then
+    raise exception.Create('Allowed formats: ICO, CUR or unknown');
+
+  Init;
+  FFileType := AFileType;
+end;
+
+function TBGRAIconCursor.Add(ABitmap: TBGRACustomBitmap; ABitDepth: integer;
+  AOverwrite: boolean): integer;
+var stream, temp: TStream;
+  writer: TFPWriterBMP;
+  bmpXOR: TBGRACustomBitmap;
+  y: Integer;
+  psrc, pdest: PBGRAPixel;
+  bitAndMask: array of byte;
+  bitAndMaskPos: integer;
+  bitAndMaskBit: byte;
+  bitAndMaskRowSize, x: integer;
+  palette: TBGRAPalette;
+
+begin
+  stream := TMemoryStream.Create;
+  try
+    //PNG format is advised from 256 on but does not handle XOR
+    if ((ABitmap.Width >= 256) or (ABitmap.Height >= 256)) and (ABitDepth >= 8) and
+        ((ABitmap.XorMask = nil) or ABitmap.XorMask.Empty) then
+    begin
+      ABitmap.SaveToStreamAsPng(stream);
+      result := Add(stream, AOverwrite, true);
+      stream := nil;
+    end else
+    if ((ABitmap.XorMask = nil) or ABitmap.XorMask.Empty) and
+      (not ABitmap.HasTransparentPixels or (ABitDepth = 32)) then
+    begin
+      writer := TFPWriterBMP.Create;
+      writer.BitsPerPixel := ABitDepth;
+      try
+        if not ABitmap.UsePalette and (ABitDepth < 24) then
+        begin
+          palette := TBGRAPalette.Create(ABitmap);
+          try
+            palette.AssignTo(ABitmap);
+          finally
+            palette.Free;
+          end;
+          ABitmap.SaveToStream(stream, writer);
+          ABitmap.UsePalette:= false;
+        end
+        else
+          ABitmap.SaveToStream(stream, writer);
+      finally
+        writer.Free;
+      end;
+      result := Add(stream, AOverwrite, true);
+      stream := nil;
+    end else
+    begin
+      bmpXOR := BGRABitmapFactory.Create(ABitmap);
+      try
+        bitAndMaskRowSize := ((bmpXOR.Width+31) div 32)*4;
+        setlength(bitAndMask, bitAndMaskRowSize*bmpXOR.Height);
+        for y := 0 to bmpXOR.Height-1 do
+        begin
+          if assigned(ABitmap.XorMask) then
+            psrc := ABitmap.XorMask.ScanLine[y]
+          else
+            psrc := nil;
+          pdest := bmpXOR.ScanLine[y];
+          bitAndMaskPos := (bmpXOR.Height-1-y)*bitAndMaskRowSize;
+          bitAndMaskBit:= $80;
+          for x := bmpXOR.Width-1 downto 0 do
+          begin
+            //xor mask is either 100% or 0%
+            if assigned(psrc) and (psrc^.alpha > 128) then
+            begin
+              pdest^ := psrc^;
+              pdest^.alpha := 255;
+              bitAndMask[bitAndMaskPos] := bitAndMask[bitAndMaskPos] or bitAndMaskBit;
+            end else
+            if pdest^.alpha = 0 then
+            begin
+              bitAndMask[bitAndMaskPos] := bitAndMask[bitAndMaskPos] or bitAndMaskBit;
+              if ABitDepth <= 24 then //if we cannot save alpha, replace with black.
+              begin                   //mask will task care of making it transparent
+                pdest^ := BGRABlack;
+              end;
+            end;
+
+            bitAndMaskBit := bitAndMaskBit shr 1;
+            if bitAndMaskBit = 0 then
+            begin
+              bitAndMaskBit := $80;
+              bitAndMaskPos += 1;
+            end;
+            if assigned(psrc) then inc(psrc);
+            inc(pdest);
+          end;
+        end;
+        bmpXOR.InvalidateBitmap;
+
+        if ABitDepth < 24 then
+        begin
+          palette := TBGRAPalette.Create(bmpXor);
+          palette.AssignTo(bmpXor);
+          palette.Free;
+        end;
+
+        temp := TMemoryStream.Create;
+        try
+          writer := TFPWriterBMP.Create;
+          writer.BitsPerPixel := ABitDepth;
+          try
+            bmpXOR.SaveToStream(temp, writer);
+            //write double height to include mask
+            temp.Position := 22;
+            temp.WriteDWord(NtoLE(DWord(bmpXOR.Height*2)));
+            //go after the file header
+            temp.Position := 14;
+            //copy bitmap without header
+            stream.CopyFrom(temp, temp.Size-temp.Position);
+          finally
+            writer.Free;
+          end;
+        finally
+          temp.Free;
+        end;
+        //write mask
+        stream.WriteBuffer(bitAndMask[0],length(bitAndMask));
+        result := Add(stream, AOverwrite, true);
+        stream := nil;
+      finally
+        bmpXOR.Free;
+      end;
+    end;
+
+  finally
+    stream.Free;
+  end;
+end;
+
+function TBGRAIconCursor.Add(AContent: TStream; AOverwrite: boolean;
+  AOwnStream: boolean): integer;
+var
+  index: Integer;
+  newEntry: TMultiFileEntry;
+  contentCopy: TMemoryStream;
+begin
+  if not AOwnStream then
+  begin
+    AContent.Position:= 0;
+    contentCopy := TMemoryStream.Create;
+    contentCopy.CopyFrom(AContent, AContent.Size);
+    newEntry := TBGRAIconCursorEntry.TryCreate(self, contentCopy);
+  end else
+    newEntry := TBGRAIconCursorEntry.TryCreate(self, AContent);
+
+  index := IndexOf(newEntry.Name, newEntry.Extension);
+  if index <> -1 then
+  begin
+    if AOverwrite then
+      Delete(index)
+    else
+    begin
+      newEntry.Free;
+      raise Exception.Create('Duplicate entry');
+    end;
+  end;
+  result := AddEntry(newEntry);
+end;
+
+procedure TBGRAIconCursor.LoadFromStream(AStream: TStream);
+var header: TGroupIconHeader;
+  dir: packed array of TIconFileDirEntry;
+  startPos: int64;
+  entryContent: TMemoryStream;
+  entryIndex, i: integer;
+begin
+  startPos := AStream.Position;
+  AStream.ReadBuffer({%H-}header, sizeof(header));
+  header.SwapIfNecessary;
+  if header.Reserved <> 0 then
+    raise exception.Create('Invalid file format');
+  if FileType = ifUnknown then
+  begin
+    case header.ResourceType of
+    ICON_OR_CURSOR_FILE_ICON_TYPE: FFileType := ifIco;
+    ICON_OR_CURSOR_FILE_CURSOR_TYPE: FFileType := ifCur;
+    end;
+  end;
+  if header.ResourceType <> ExpectedMagic then
+    raise exception.Create('Invalid resource type');
+  Clear;
+  setlength(dir, header.ImageCount);
+  AStream.ReadBuffer(dir[0], sizeof(TIconFileDirEntry)*length(dir));
+  for i := 0 to high(dir) do
+  begin
+    AStream.Position:= LEtoN(dir[i].ImageOffset) + startPos;
+    entryContent := TMemoryStream.Create;
+    entryContent.CopyFrom(AStream, LEtoN(dir[i].ImageSize));
+    entryIndex := Add(entryContent, false, true);
+    if ((dir[i].Width = 0) and (Width[entryIndex] < 256)) or
+       ((dir[i].Width > 0) and (Width[entryIndex] <> dir[i].Width)) or
+       ((dir[i].Height = 0) and (Height[entryIndex] < 256)) or
+       ((dir[i].Height > 0) and (Height[entryIndex] <> dir[i].Height)) then
+        raise Exception.Create('Inconsistent image size');
+    if FFileType = ifCur then
+      TBGRAIconCursorEntry(Entry[entryIndex]).HotSpot := Point(LEtoN(dir[i].HotSpotX),LEtoN(dir[i].HotSpotY));
+  end;
+end;
+
+procedure TBGRAIconCursor.SaveToStream(ADestination: TStream);
+var header: TGroupIconHeader;
+  i: integer;
+  accSize: DWord;
+  dir: packed array of TIconFileDirEntry;
+  contentSize: DWord;
+begin
+  if Count = 0 then
+    raise exception.Create('File cannot be empty');
+  if FileType = ifUnknown then
+    raise exception.Create('You need to specify the file type');
+  header.ImageCount:= Count;
+  header.Reserved := 0;
+  header.ResourceType:= ExpectedMagic;
+  header.SwapIfNecessary;
+  accSize := sizeof(header) + sizeof(TIconFileDirEntry)*Count;
+  setlength(dir, Count);
+  for i := 0 to Count-1 do
+  begin
+    dir[i].Width := Width[i];
+    dir[i].Height := Height[i];
+    if BitDepth[i] < 8 then
+      dir[i].Colors := 1 shl BitDepth[i]
+    else
+      dir[i].Colors := 0;
+    dir[i].Reserved := 0;
+    case FFileType of
+    ifCur: begin dir[i].HotSpotX:= NtoLE(Word(HotSpot[i].X)); dir[i].HotSpotY := NtoLE(Word(HotSpot[i].Y)); end;
+    ifIco: begin dir[i].BitsPerPixel:= NtoLE(Word(BitDepth[i])); dir[i].Planes := NtoLE(Word(1)); end;
+    else dir[i].Variable:= 0;
+    end;
+    dir[i].ImageOffset := LEtoN(accSize);
+    contentSize:= Entry[i].FileSize;
+    dir[i].ImageSize := NtoLE(contentSize);
+    inc(accSize,contentSize);
+  end;
+
+  ADestination.WriteBuffer(header, sizeof(header));
+  ADestination.WriteBuffer(dir[0], sizeof(TIconFileDirEntry)*length(dir));
+  for i := 0 to Count-1 do
+    if Entry[i].CopyTo(ADestination) <> Entry[i].FileSize then
+        raise exception.Create('Unable to write data in stream');
+end;
+
+function TBGRAIconCursor.GetBitmap(AIndex: integer): TBGRACustomBitmap;
+begin
+  if (AIndex < 0) or (AIndex >= Count) then raise ERangeError.Create('Index out of bounds');
+  result := TBGRAIconCursorEntry(Entry[AIndex]).GetBitmap;
+end;
+
+function TBGRAIconCursor.GetBestFitBitmap(AWidth, AHeight: integer): TBGRACustomBitmap;
+var bestIndex: integer;
+  bestSizeDiff: integer;
+  bestBPP: integer;
+  sizeDiff, i: integer;
+begin
+  bestBPP := 0;
+  bestSizeDiff := high(integer);
+  bestIndex := -1;
+  for i := 0 to Count-1 do
+  begin
+    sizeDiff := abs(AWidth-Width[i])+abs(AHeight-Height[i]);
+    if (sizeDiff < bestSizeDiff) or
+      ((sizeDiff = bestSizeDiff) and (BitDepth[i] > bestBPP)) then
+    begin
+      bestIndex := i;
+      bestSizeDiff:= sizeDiff;
+      bestBPP:= BitDepth[i];
+    end;
+  end;
+  if bestIndex = -1 then
+    raise Exception.Create('No bitmap found')
+  else
+    result := GetBitmap(bestIndex);
+end;
+
+end.
+

--- a/bgrabitmap/bgraiconcursor.pas
+++ b/bgrabitmap/bgraiconcursor.pas
@@ -203,7 +203,11 @@ end;
 
 function TBGRAIconCursorEntry.CopyTo(ADestination: TStream): integer;
 begin
-  if FContent.Size = 0 then exit;
+  if FContent.Size = 0 then
+  begin
+    result := 0;
+    exit;
+  end;
 
   FContent.Position := 0;
   result := ADestination.CopyFrom(FContent, FContent.Size);

--- a/bgrabitmap/bgralayers.pas
+++ b/bgrabitmap/bgralayers.pas
@@ -412,7 +412,6 @@ end;
 
 procedure TBGRALayeredBitmap.LoadFromFile(const filenameUTF8: string);
 var bmp: TBGRABitmap;
-    index: integer;
     ext: string;
     temp: TBGRACustomLayeredBitmap;
     i: integer;
@@ -434,13 +433,11 @@ begin
   bmp := TBGRABitmap.Create(filenameUTF8, True);
   Clear;
   SetSize(bmp.Width,bmp.Height);
-  index := AddSharedLayer(bmp);
-  FLayers[index].Owner:= true;
+  AddOwnedLayer(bmp);
 end;
 
 procedure TBGRALayeredBitmap.LoadFromStream(stream: TStream);
 var bmp: TBGRABitmap;
-   index: integer;
    temp: TBGRALayeredBitmap;
 begin
   if Assigned(LayeredBitmapLoadFromStreamProc) then
@@ -453,11 +450,11 @@ begin
       exit;
     end;
   end;
+
   bmp := TBGRABitmap.Create(stream);
   Clear;
   SetSize(bmp.Width,bmp.Height);
-  index := AddSharedLayer(bmp);
-  FLayers[index].Owner:= true;
+  AddOwnedLayer(bmp);
 end;
 
 procedure TBGRALayeredBitmap.SetSize(AWidth, AHeight: integer);

--- a/bgrabitmap/bgralayers.pas
+++ b/bgrabitmap/bgralayers.pas
@@ -59,15 +59,16 @@ type
     function ToString: ansistring; override;
     function GetLayerBitmapDirectly(layer: integer): TBGRABitmap; virtual;
     function GetLayerBitmapCopy(layer: integer): TBGRABitmap; virtual; abstract;
-    function ComputeFlatImage: TBGRABitmap; overload;
-    function ComputeFlatImage(firstLayer, lastLayer: integer): TBGRABitmap; overload;
-    function ComputeFlatImage(ARect: TRect): TBGRABitmap; overload;
-    function ComputeFlatImage(ARect: TRect; firstLayer, lastLayer: integer): TBGRABitmap; overload;
+    function ComputeFlatImage(ASeparateXorMask: boolean = false): TBGRABitmap; overload;
+    function ComputeFlatImage(firstLayer, lastLayer: integer; ASeparateXorMask: boolean = false): TBGRABitmap; overload;
+    function ComputeFlatImage(ARect: TRect; ASeparateXorMask: boolean = false): TBGRABitmap; overload;
+    function ComputeFlatImage(ARect: TRect; firstLayer, lastLayer: integer; ASeparateXorMask: boolean = false): TBGRABitmap; overload;
     procedure Draw(ACanvas: TCanvas; const Rect: TRect); override; overload;
     procedure Draw(Canvas: TCanvas; x,y: integer); overload;
     procedure Draw(Canvas: TCanvas; x,y: integer; firstLayer, lastLayer: integer); overload;
     procedure Draw(Dest: TBGRABitmap; x,y: integer); overload;
-    procedure Draw(Dest: TBGRABitmap; AX,AY: integer; firstLayer, lastLayer: integer); overload;
+    procedure Draw(Dest: TBGRABitmap; x,y: integer; ASeparateXorMask: boolean = false); overload;
+    procedure Draw(Dest: TBGRABitmap; AX,AY: integer; firstLayer, lastLayer: integer; ASeparateXorMask: boolean = false); overload;
 
     procedure FreezeExceptOneLayer(layer: integer); overload;
     procedure Freeze(firstLayer, lastLayer: integer); overload;
@@ -208,7 +209,7 @@ procedure UnregisterLoadingHandler(AStart: TOnLayeredBitmapLoadStartProc; AProgr
 
 implementation
 
-uses BGRAUTF8;
+uses BGRAUTF8, BGRABlend;
 
 var
   OnLayeredBitmapLoadStartProc: TOnLayeredBitmapLoadStartProc;
@@ -1006,20 +1007,21 @@ begin
   end;
 end;
 
-function TBGRACustomLayeredBitmap.ComputeFlatImage: TBGRABitmap;
+function TBGRACustomLayeredBitmap.ComputeFlatImage(ASeparateXorMask: boolean): TBGRABitmap;
 begin
-  result := ComputeFlatImage(rect(0,0,Width,Height), 0, NbLayers - 1);
+  result := ComputeFlatImage(rect(0,0,Width,Height), 0, NbLayers - 1, ASeparateXorMask);
 end;
 
 function TBGRACustomLayeredBitmap.ComputeFlatImage(firstLayer,
-  lastLayer: integer): TBGRABitmap;
+  lastLayer: integer; ASeparateXorMask: boolean): TBGRABitmap;
 begin
-  result := ComputeFlatImage(rect(0,0,Width,Height), firstLayer,LastLayer);
+  result := ComputeFlatImage(rect(0,0,Width,Height), firstLayer,LastLayer,ASeparateXorMask);
 end;
 
-function TBGRACustomLayeredBitmap.ComputeFlatImage(ARect: TRect): TBGRABitmap;
+function TBGRACustomLayeredBitmap.ComputeFlatImage(ARect: TRect;
+  ASeparateXorMask: boolean): TBGRABitmap;
 begin
-  result := ComputeFlatImage(ARect,0, NbLayers - 1);
+  result := ComputeFlatImage(ARect,0, NbLayers - 1, ASeparateXorMask);
 end;
 
 destructor TBGRACustomLayeredBitmap.Destroy;
@@ -1027,13 +1029,15 @@ begin
   Clear;
 end;
 
-function TBGRACustomLayeredBitmap.ComputeFlatImage(ARect: TRect; firstLayer, lastLayer: integer): TBGRABitmap;
+function TBGRACustomLayeredBitmap.ComputeFlatImage(ARect: TRect; firstLayer, lastLayer: integer; ASeparateXorMask: boolean): TBGRABitmap;
 var
   tempLayer: TBGRABitmap;
   i,j: integer;
   mustFreeCopy: boolean;
   op: TBlendOperation;
 begin
+  if (firstLayer < 0) or (lastLayer > NbLayers-1) then
+    raise ERangeError.Create('Layer index out of bounds');
   If (ARect.Right <= ARect.Left) or (ARect.Bottom <= ARect.Top) then
   begin
     result := TBGRABitmap.Create(0,0);
@@ -1072,6 +1076,12 @@ begin
       with LayerOffset[i] do
       begin
         op := BlendOperation[i];
+        //XOR mask
+        if (op = boXor) and ASeparateXorMask then
+        begin
+          result.NeedXorMask;
+          result.XorMask.BlendImageOver(x-ARect.Left,y-ARect.Top, tempLayer, op, LayerOpacity[i], LinearBlend);
+        end else
         //first layer is simply the background
         if i = firstLayer then
           Result.PutImage(x-ARect.Left, y-ARect.Top, tempLayer, dmSet, LayerOpacity[i])
@@ -1089,6 +1099,8 @@ begin
     end;
     inc(i);
   end;
+  if result.XorMask <> nil then
+    AlphaFillInline(result.XorMask.Data, 0, result.XorMask.NbPixels);
 end;
 
 procedure TBGRACustomLayeredBitmap.Draw(ACanvas: TCanvas; const Rect: TRect);
@@ -1123,7 +1135,13 @@ begin
   Draw(Dest,x,y,0,NbLayers-1);
 end;
 
-procedure TBGRACustomLayeredBitmap.Draw(Dest: TBGRABitmap; AX, AY: integer; firstLayer, lastLayer: integer);
+procedure TBGRACustomLayeredBitmap.Draw(Dest: TBGRABitmap; x, y: integer;
+  ASeparateXorMask: boolean);
+begin
+  Draw(Dest,x,y,0,NbLayers-1,ASeparateXorMask);
+end;
+
+procedure TBGRACustomLayeredBitmap.Draw(Dest: TBGRABitmap; AX, AY: integer; firstLayer, lastLayer: integer; ASeparateXorMask: boolean);
 var
   temp: TBGRABitmap;
   i,j: integer;
@@ -1139,7 +1157,7 @@ begin
   for i := firstLayer to lastLayer do
     if LayerVisible[i] and not (BlendOperation[i] in[boTransparent,boLinearBlend]) then
     begin
-      temp := ComputeFlatImage(rect(NewClipRect.Left-AX,NewClipRect.Top-AY,NewClipRect.Right-AX,NewClipRect.Bottom-AY));
+      temp := ComputeFlatImage(rect(NewClipRect.Left-AX,NewClipRect.Top-AY,NewClipRect.Right-AX,NewClipRect.Bottom-AY), ASeparateXorMask);
       if self.LinearBlend then
         Dest.PutImage(NewClipRect.Left,NewClipRect.Top,temp,dmLinearBlend)
       else

--- a/bgrabitmap/bgralazresource.pas
+++ b/bgrabitmap/bgralazresource.pas
@@ -1,0 +1,409 @@
+unit BGRALazResource;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, BGRAMultiFileType;
+
+type
+  { TLazResourceEntry }
+
+  TLazResourceEntry = class(TMultiFileEntry)
+  private
+    procedure Serialize(ADestination: TStream);
+  protected
+    FName: utf8string;
+    FValueType: utf8string;
+    FContent: TStream;
+    function GetName: utf8string; override;
+    procedure SetName(AValue: utf8string); override;
+    function GetExtension: utf8string; override;
+    function GetFileSize: int64; override;
+  public
+    constructor Create(AContainer: TMultiFileContainer; AName: utf8string; AValueType: utf8string; AContent: TStream);
+    destructor Destroy; override;
+    function CopyTo(ADestination: TStream): integer; override;
+  end;
+
+  { TFormDataEntry }
+
+  TFormDataEntry = class(TLazResourceEntry)
+  protected
+    FTextContent: TStream;
+    procedure RequireTextContent;
+    function GetExtension: utf8string; override;
+    function GetFileSize: int64; override;
+  public
+    constructor Create(AContainer: TMultiFileContainer; AName: utf8string; ABinaryContent: TStream);
+    destructor Destroy; override;
+    function CopyTo(ADestination: TStream): integer; override;
+  end;
+
+  { TLazResourceContainer }
+
+  TLazResourceContainer = class(TMultiFileContainer)
+  protected
+    function CreateEntry(AName: utf8string; AExtension: utf8string; AContent: TStream): TMultiFileEntry; override;
+  public
+    procedure LoadFromStream(AStream: TStream); override;
+    procedure SaveToStream(ADestination: TStream); override;
+  end;
+
+implementation
+
+uses LResources, BGRAUTF8;
+
+{ TFormDataEntry }
+
+procedure TFormDataEntry.RequireTextContent;
+begin
+  if FTextContent = nil then
+  begin
+    FTextContent:= TMemoryStream.Create;
+    FContent.Position:= 0;
+    LRSObjectBinaryToText(FContent, FTextContent);
+  end;
+end;
+
+function TFormDataEntry.GetExtension: utf8string;
+begin
+  Result:= 'lfm';
+end;
+
+function TFormDataEntry.GetFileSize: int64;
+begin
+  RequireTextContent;
+  Result:= FTextContent.Size;
+end;
+
+constructor TFormDataEntry.Create(AContainer: TMultiFileContainer;
+  AName: utf8string; ABinaryContent: TStream);
+begin
+  inherited Create(AContainer,AName,'FORMDATA',ABinaryContent);
+end;
+
+destructor TFormDataEntry.Destroy;
+begin
+  FreeAndNil(FTextContent);
+  inherited Destroy;
+end;
+
+function TFormDataEntry.CopyTo(ADestination: TStream): integer;
+begin
+  RequireTextContent;
+  if FTextContent.Size = 0 then
+    result := 0
+  else
+  begin
+    FTextContent.Position:= 0;
+    result := ADestination.CopyFrom(FTextContent,FTextContent.Size);
+  end;
+end;
+
+{ TLazResourceEntry }
+
+procedure TLazResourceEntry.Serialize(ADestination: TStream);
+begin
+  FContent.Position := 0;
+  BinaryToLazarusResourceCode(FContent, ADestination, Name, FValueType);
+end;
+
+function TLazResourceEntry.GetName: utf8string;
+begin
+  Result:= FName;
+end;
+
+procedure TLazResourceEntry.SetName(AValue: utf8string);
+begin
+  if AValue = FName then exit;
+  if Container.IndexOf(AVAlue, Extension) <> -1 then
+    raise Exception.Create('Name is already used for this extension');
+  FName := AValue;
+end;
+
+function TLazResourceEntry.GetExtension: utf8string;
+begin
+  Result:= FValueType;
+end;
+
+function TLazResourceEntry.GetFileSize: int64;
+begin
+  Result:= FContent.Size;
+end;
+
+destructor TLazResourceEntry.Destroy;
+begin
+  FreeAndNil(FContent);
+  inherited Destroy;
+end;
+
+constructor TLazResourceEntry.Create(AContainer: TMultiFileContainer; AName: utf8string; AValueType: utf8string;
+  AContent: TStream);
+begin
+  inherited Create(AContainer);
+  FName := AName;
+  FValueType := UTF8UpperCase(AValueType);
+  FContent := AContent;
+end;
+
+function TLazResourceEntry.CopyTo(ADestination: TStream): integer;
+begin
+  if FContent.Size = 0 then
+    result := 0
+  else
+  begin
+    FContent.Position:= 0;
+    result := ADestination.CopyFrom(FContent, FContent.Size);
+  end;
+end;
+
+{ TLazResourceContainer }
+
+procedure TLazResourceContainer.LoadFromStream(AStream: TStream);
+const
+  entryStart = 'LazarusResources.Add(';
+  entryEnd = ');';
+  whiteSpace = [' ',#9,#10,#13,#26];
+var
+  fileContent: String;
+  filePos : integer;
+
+  procedure SkipWhitespace;
+  begin
+    while (filePos <= length(fileContent)) and (fileContent[filePos] in whiteSpace) do inc(filePos);
+  end;
+
+  procedure SkipComma;
+  begin
+    SkipWhitespace;
+    if (filePos <= length(fileContent)) and (fileContent[filePos] = ',') then
+      inc(filePos)
+    else
+      raise Exception.Create('Comma expected');
+  end;
+
+  function ParseString(ignoreCommas: boolean): TStream;
+  var
+    expectPlus: boolean;
+
+    procedure AppendChar(c: char);
+    begin
+      result.WriteByte(ord(c));
+    end;
+
+    function ParseNumber: integer;
+    var numberStart, errPos: integer;
+      s: String;
+    begin
+      numberStart:= filePos;
+      if (filePos <= length(fileContent)) and (fileContent[filePos] = '$') then
+      begin
+        inc(filePos);
+        while (filePos <= length(fileContent)) and (fileContent[filePos] in['0'..'9','a'..'f','A'..'F']) do inc(filePos);
+      end else
+      begin
+        while (filePos <= length(fileContent)) and (fileContent[filePos] in['0'..'9']) do inc(filePos);
+      end;
+      s := copy(fileContent,numberStart,filePos-numberStart);
+      val(s, result, errPos);
+      if errPos <> 0 then
+        raise exception.Create('Invalid number "' + s + '"');
+    end;
+
+    function ParseStringPart: boolean;
+    var charCode: integer;
+    begin
+      SkipWhitespace;
+      if filePos <= length(fileContent) then
+      begin
+        if expectPlus then
+          if fileContent[filePos] <> '+' then
+          begin
+            result := false;
+            expectPlus := false;
+            exit;
+          end else
+          inc(filePos);
+
+        case fileContent[filePos] of
+        '+': raise exception.Create('Unexpected "+"');
+        '''': begin
+            inc(filePos);
+            while (filePos <= length(fileContent)) do
+            begin
+              if fileContent[filePos] = '''' then
+              begin
+                inc(filePos);
+                if (filePos <= length(fileContent)) and (fileContent[filePos] = '''') then
+                begin
+                  AppendChar('''');
+                  inc(filePos);
+                end
+                else break;
+              end else
+              if fileContent[filePos] in[#10,#13] then
+                raise Exception.Create('Unexpected end of line')
+              else
+              begin
+                AppendChar(fileContent[filePos]);
+                inc(filePos);
+              end;
+            end;
+            if (filePos <= length(fileContent)) and (fileContent[filePos] = '#') then
+              expectPlus := false
+            else
+              expectPlus := true;
+            result := true;
+          end;
+        '#': begin
+            inc(filePos);
+            charCode := ParseNumber;
+            if (charCode < 0) or (charCode > 255) then
+              raise exception.Create('Character code out of bounds');
+            AppendChar(chr(charCode));
+            if (filePos <= length(fileContent)) and (fileContent[filePos] in['#','''']) then
+              expectPlus := false
+            else
+              expectPlus := true;
+            result := true;
+          end;
+         else
+         begin
+           result := false;
+           expectPlus := false;
+         end;
+         end;
+      end
+       else
+       begin
+         result := false;
+         expectPlus := false;
+       end;
+    end;
+
+  begin
+    result := TMemoryStream.Create;
+    expectPlus := false;
+    if not ParseStringPart then raise exception.Create('Expecting string');
+    repeat
+      if ignoreCommas then
+      begin
+        SkipWhitespace;
+        if (filePos <= length(fileContent)) and (fileContent[filePos] = ',') then
+        begin
+          inc(filePos);
+          expectPlus := false;
+        end;
+      end;
+    until not ParseStringPart;
+  end;
+
+  procedure ReadContent;
+  var
+    bytesRead: integer;
+  begin
+    setlength(fileContent,AStream.Size-AStream.Position);
+    bytesRead := AStream.Read(fileContent[1],length(fileContent));
+    setlength(fileContent, bytesRead);
+    filePos := 1;
+  end;
+
+  function StreamToUTF8String(AStream: TStream): utf8String;
+  begin
+    setlength(result, AStream.Size);
+    AStream.Position := 0;
+    AStream.Read(result[1], length(result));
+    AStream.Free;
+  end;
+
+var
+  entryName: utf8string;
+  entryType: utf8string;
+  entryContent: TStream;
+  inArray: boolean;
+
+begin
+  Clear;
+  ReadContent;
+  while filePos <= length(fileContent) do
+  begin
+    if (upcase(fileContent[filePos]) = upcase(entryStart[1])) and
+      (CompareText(copy(fileContent,filePos,length(entryStart)),entryStart)=0) then
+    begin
+      inc(filePos, length(entryStart));
+      entryName := StreamToUTF8String(ParseString(false));
+      SkipComma;
+      entryType := StreamToUTF8String(ParseString(false));
+      SkipComma;
+
+      SkipWhitespace;
+      if (filePos <= length(fileContent)) and (fileContent[filePos] = '[') then
+      begin
+        inArray := true;
+        inc(filePos);
+      end else
+        inArray := false;
+      entryContent := ParseString(inArray);
+      SkipWhitespace;
+      if inArray then
+      begin
+        if (filePos <= length(fileContent)) and (fileContent[filePos] = ']') then
+          inc(filePos)
+        else
+          raise exception.Create('Expecting "]"');
+      end;
+
+      if entryType = 'FORMDATA' then
+        AddEntry(TFormDataEntry.Create(self,entryName,entryContent))
+      else
+        AddEntry(TLazResourceEntry.Create(self,entryName,entryType,entryContent));
+
+      if (filePos+length(entryEnd)-1 <= length(fileContent)) and (CompareText(copy(fileContent,filePos,length(entryEnd)),entryEnd)=0) then
+        inc(filePos,length(entryEnd))
+      else
+        raise exception.Create('Expecting "'+entryEnd+'"');
+    end else
+    if fileContent[filePos] in whiteSpace then
+      inc(filePos)
+    else
+      raise exception.Create('Unexpected character "'+fileContent[filePos]+'"');
+  end;
+end;
+
+function TLazResourceContainer.CreateEntry(AName: utf8string; AExtension: utf8string;
+  AContent: TStream): TMultiFileEntry;
+var
+  binContent: TMemoryStream;
+begin
+  if UTF8CompareText(AExtension,'lfm')=0 then
+  begin
+    binContent := TMemoryStream.Create;
+    try
+      AContent.Position:= 0;
+      LRSObjectTextToBinary(AContent, binContent);
+      result := TFormDataEntry.Create(self,AName,binContent);
+    except
+      on ex:Exception do
+      begin
+        binContent.Free;
+        result := nil;
+      end;
+    end;
+    AContent.Free;
+  end
+  else
+    result := TLazResourceEntry.Create(self,AName,UTF8UpperCase(AExtension),AContent);
+end;
+
+procedure TLazResourceContainer.SaveToStream(ADestination: TStream);
+var
+  i: Integer;
+begin
+  for i := 0 to Count-1 do
+    TLazResourceEntry(Entry[i]).Serialize(ADestination);
+end;
+
+end.
+

--- a/bgrabitmap/bgralclbitmap.pas
+++ b/bgrabitmap/bgralclbitmap.pas
@@ -848,7 +848,7 @@ begin
     begin
       if (p^.alpha = 0) and (PDWord(p)^<>0) then
       begin
-        if XorMask = nil then XorMask := NewBitmap(Width,Height) as TBGRADefaultBitmap;
+        NeedXorMask;
         XorMask.SetPixel(x,y, p^);
       end;
       inc(p);

--- a/bgrabitmap/bgralclbitmap.pas
+++ b/bgrabitmap/bgralclbitmap.pas
@@ -382,7 +382,7 @@ procedure ApplyRawImageMask(ADestination: TBGRACustomBitmap; const ARawImage: TR
 var
   copyProc: TCopyPixelProc;
 begin
-  if ARawImage.Description.MaskBitsPerPixel = 1 then
+  if (ARawImage.Description.MaskBitsPerPixel = 1) and (ARawImage.Mask <> nil) then
   begin
     if ARawImage.Description.BitOrder = riboBitsInOrder then
       copyProc := @ApplyMask1bit

--- a/bgrabitmap/bgralclbitmap.pas
+++ b/bgrabitmap/bgralclbitmap.pas
@@ -680,6 +680,11 @@ begin
     AssignRasterImage(TRasterImage(Source));
   end else
     inherited Assign(Source);
+
+  if Source is TCursorImage then
+    HotSpot := TCursorImage(Source).HotSpot
+  else if Source is TIcon then
+    HotSpot := Point(0,0);
 end;
 
 procedure TBGRALCLBitmap.AssignRasterImage(ARaster: TRasterImage);

--- a/bgrabitmap/bgramultifiletype.pas
+++ b/bgrabitmap/bgramultifiletype.pas
@@ -1,0 +1,271 @@
+unit BGRAMultiFileType;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, fgl;
+
+type
+  TMultiFileContainer = class;
+
+  { TMultiFileEntry }
+
+  TMultiFileEntry = class
+  protected
+    FContainer: TMultiFileContainer;
+    function GetName: utf8string; virtual; abstract;
+    procedure SetName(AValue: utf8string); virtual; abstract;
+    function GetFileSize: int64; virtual;
+    function GetExtension: utf8string; virtual;
+  public
+    constructor Create(AContainer: TMultiFileContainer);
+    function CopyTo({%H-}ADestination: TStream): integer; virtual;
+    property Name: utf8string read GetName write SetName;
+    property Extension: utf8string read GetExtension;
+    property FileSize: int64 read GetFileSize;
+    property Container: TMultiFileContainer read FContainer;
+  end;
+
+  TMultiFileEntryList = specialize TFPGList<TMultiFileEntry>;
+
+  { TMultiFileContainer }
+
+  TMultiFileContainer = class
+  private
+    FEntries: TMultiFileEntryList;
+  protected
+    procedure Init; virtual;
+    function AddEntry(AEntry: TMultiFileEntry): integer;
+    function GetCount: integer;
+    function GetEntry(AIndex: integer): TMultiFileEntry;
+    function CreateEntry(AName: utf8string; AExtension: utf8string; AContent: TStream): TMultiFileEntry; virtual; abstract;
+  public
+    constructor Create;
+    constructor Create(AFilename: utf8string);
+    constructor Create(AStream: TStream);
+    constructor Create(AStream: TStream; AStartPos: Int64);
+    function Add(AName: utf8string; AExtension: utf8string; AContent: TStream; AOverwrite: boolean = false; AOwnStream: boolean = true): integer;
+    function Add(AName: utf8string; AExtension: utf8string; AContent: utf8String; AOverwrite: boolean = false): integer;
+    procedure Clear; virtual;
+    destructor Destroy; override;
+    procedure LoadFromFile(AFilename: utf8string);
+    procedure LoadFromStream(AStream: TStream); virtual; abstract;
+    procedure SaveToFile(AFilename: utf8string);
+    procedure SaveToStream(ADestination: TStream); virtual; abstract;
+    procedure Remove(AEntry: TMultiFileEntry); virtual;
+    procedure Delete(AIndex: integer); virtual; overload;
+    function Delete(AName: utf8string; AExtension: utf8string;ACaseSensitive: boolean = True): boolean; overload;
+    function IndexOf(AEntry: TMultiFileEntry): integer;
+    function IndexOf(AName: utf8string; AExtenstion: utf8string; ACaseSensitive: boolean = True): integer; virtual;
+    property Count: integer read GetCount;
+    property Entry[AIndex: integer]: TMultiFileEntry read GetEntry;
+  end;
+
+implementation
+
+uses BGRAUTF8;
+
+{ TMultiFileEntry }
+
+function TMultiFileEntry.GetFileSize: int64;
+begin
+  result := 0;
+end;
+
+function TMultiFileEntry.GetExtension: utf8string;
+begin
+  result := '';
+end;
+
+constructor TMultiFileEntry.Create(AContainer: TMultiFileContainer);
+begin
+  FContainer := AContainer;
+end;
+
+function TMultiFileEntry.CopyTo(ADestination: TStream): integer;
+begin
+  result := 0;
+end;
+
+{ TMultiFileContainer }
+
+function TMultiFileContainer.GetCount: integer;
+begin
+  result := FEntries.Count;
+end;
+
+function TMultiFileContainer.GetEntry(AIndex: integer): TMultiFileEntry;
+begin
+  result := FEntries[AIndex];
+end;
+
+procedure TMultiFileContainer.Init;
+begin
+  FEntries := TMultiFileEntryList.Create;
+end;
+
+function TMultiFileContainer.AddEntry(AEntry: TMultiFileEntry): integer;
+begin
+  result := FEntries.Add(AEntry);
+end;
+
+constructor TMultiFileContainer.Create;
+begin
+  Init;
+end;
+
+constructor TMultiFileContainer.Create(AFilename: utf8string);
+begin
+  Init;
+  LoadFromFile(AFilename);
+end;
+
+constructor TMultiFileContainer.Create(AStream: TStream);
+begin
+  Init;
+  LoadFromStream(AStream);
+end;
+
+constructor TMultiFileContainer.Create(AStream: TStream; AStartPos: Int64);
+begin
+  Init;
+  AStream.Position := AStartPos;
+  LoadFromStream(AStream);
+end;
+
+function TMultiFileContainer.Add(AName: utf8string; AExtension: utf8string;
+  AContent: TStream; AOverwrite: boolean; AOwnStream: boolean): integer;
+var
+  index: Integer;
+  newEntry: TMultiFileEntry;
+  contentCopy: TMemoryStream;
+begin
+  index := IndexOf(AName,AExtension);
+  if index <> -1 then
+  begin
+    if AOverwrite then
+      Delete(index)
+    else
+      raise Exception.Create('Duplicate entry');
+  end;
+  if not AOwnStream then
+  begin
+    AContent.Position:= 0;
+    contentCopy := TMemoryStream.Create;
+    contentCopy.CopyFrom(AContent, AContent.Size);
+    newEntry := CreateEntry(AName, AExtension, contentCopy);
+  end else
+    newEntry := CreateEntry(AName, AExtension, AContent);
+  if Assigned(newEntry) then
+    result := AddEntry(newEntry)
+  else
+    raise exception.Create('Unable to create entry');
+end;
+
+function TMultiFileContainer.Add(AName: utf8string; AExtension: utf8string;
+  AContent: utf8String; AOverwrite: boolean): integer;
+var stream: TMemoryStream;
+begin
+  stream := TMemoryStream.Create;
+  stream.Write(AContent[1],length(AContent));
+  result := Add(AName,AExtension,stream,AOverwrite);
+end;
+
+destructor TMultiFileContainer.Destroy;
+begin
+  Clear;
+  FreeAndNil(FEntries);
+  inherited Destroy;
+end;
+
+procedure TMultiFileContainer.LoadFromFile(AFilename: utf8string);
+var stream: TFileStream;
+begin
+  stream := TFileStream.Create(Utf8ToAnsi(AFilename), fmOpenRead);
+  LoadFromStream(stream);
+  stream.Free;
+end;
+
+procedure TMultiFileContainer.SaveToFile(AFilename: utf8string);
+var stream: TFileStream;
+begin
+  stream := TFileStream.Create(Utf8ToAnsi(AFilename), fmCreate);
+  SaveToStream(stream);
+  stream.Free;
+end;
+
+procedure TMultiFileContainer.Remove(AEntry: TMultiFileEntry);
+var
+  index: Integer;
+begin
+  index := IndexOf(AEntry);
+  if index = -1 then
+    raise exception.Create('Entry not found');
+  Delete(index);
+end;
+
+procedure TMultiFileContainer.Delete(AIndex: integer);
+begin
+  if (AIndex >= 0) and (AIndex < Count) then
+  begin
+    Entry[AIndex].Free;
+    FEntries.Delete(AIndex);
+  end else
+    raise ERangeError.Create('Index out of bounds');
+end;
+
+function TMultiFileContainer.Delete(AName: utf8string; AExtension: utf8string;
+  ACaseSensitive: boolean): boolean;
+var
+  index: Integer;
+begin
+  index := IndexOf(AName, AExtension, ACaseSensitive);
+  if index = -1 then
+    result := false
+  else
+  begin
+    Delete(index);
+    result := true;
+  end;
+end;
+
+function TMultiFileContainer.IndexOf(AEntry: TMultiFileEntry): integer;
+begin
+  result := FEntries.IndexOf(AEntry);
+end;
+
+function TMultiFileContainer.IndexOf(AName: utf8string; AExtenstion: utf8string; ACaseSensitive: boolean): integer;
+var
+  i: Integer;
+begin
+  if ACaseSensitive then
+  begin
+    for i := 0 to Count-1 do
+      if (Entry[i].Name = AName) and (UTF8CompareText(Entry[i].Extension,AExtenstion) = 0) then
+      begin
+        result := i;
+        exit;
+      end;
+  end else
+    for i := 0 to Count-1 do
+      if (UTF8CompareText(Entry[i].Name,AName) = 0) and (UTF8CompareText(Entry[i].Extension,AExtenstion) = 0) then
+      begin
+        result := i;
+        exit;
+      end;
+  result := -1;
+end;
+
+procedure TMultiFileContainer.Clear;
+var
+  i: Integer;
+begin
+  for i := 0 to FEntries.Count-1 do
+    FEntries.Items[i].Free;
+  FEntries.Clear;
+end;
+
+end.
+

--- a/bgrabitmap/bgraopengl.pas
+++ b/bgrabitmap/bgraopengl.pas
@@ -8,7 +8,7 @@ interface
 uses
   Classes, SysUtils, FPimage, BGRAGraphics,
   BGRAOpenGLType, BGRASpriteGL, BGRACanvasGL, GL, GLext, GLU, BGRABitmapTypes,
-  BGRAFontGL, BGRASSE;
+  BGRAFontGL, BGRASSE, BGRAMatrix3D;
 
 type
   TBGLCustomCanvas = BGRACanvasGL.TBGLCustomCanvas;
@@ -42,6 +42,30 @@ type
     Sprites: TBGLCustomSpriteEngine;
     property Width: integer read GetWidth;
     property Height: integer read GetHeight;
+  end;
+
+  { TBGLFrameBuffer }
+
+  TBGLFrameBuffer = class(TBGLCustomFrameBuffer)
+  protected
+    FHeight: integer;
+    FMatrix: TAffineMatrix;
+    FProjectionMatrix: TMatrix4D;
+    FTexture: IBGLTexture;
+    FFrameBufferId, FRenderBufferId: GLuint;
+    FWidth: integer;
+    FSettingMatrices: boolean;
+    function GetTexture: IBGLTexture; override;
+    function GetHandle: pointer; override;
+    function GetHeight: integer; override;
+    function GetMatrix: TAffineMatrix; override;
+    function GetProjectionMatrix: TMatrix4D; override;
+    function GetWidth: integer; override;
+    procedure SetMatrix(AValue: TAffineMatrix); override;
+    procedure SetProjectionMatrix(AValue: TMatrix4D); override;
+  public
+    constructor Create(AWidth,AHeight: integer);
+    destructor Destroy; override;
   end;
 
 const
@@ -119,8 +143,7 @@ type
 
 implementation
 
-uses BGRATransform{$IFDEF BGRABITMAP_USE_LCL}, BGRAText, BGRATextFX{$ENDIF}
-    ,BGRAMatrix3D;
+uses BGRATransform{$IFDEF BGRABITMAP_USE_LCL}, BGRAText, BGRATextFX{$ENDIF};
 
 type
   TBlendFuncSeparateProc = procedure(sfactorRGB: GLenum; dfactorRGB: GLenum; sfactorAlpha: GLenum; dfactorAlpha: GLenum); {$IFDEF Windows} stdcall; {$ELSE} cdecl; {$ENDIF}
@@ -267,6 +290,8 @@ type
 
     function GetBlendMode: TOpenGLBlendMode; override;
     procedure SetBlendMode(AValue: TOpenGLBlendMode); override;
+
+    procedure SetActiveFrameBuffer(AValue: TBGLCustomFrameBuffer); override;
   public
     destructor Destroy; override;
     procedure Fill(AColor: TBGRAPixel); override;
@@ -311,6 +336,105 @@ type
     procedure BindAttribute(AAttribute: TAttributeVariable); override;
     procedure UnbindAttribute(AAttribute: TAttributeVariable); override;
   end;
+
+{ TBGLFrameBuffer }
+
+procedure TBGLFrameBuffer.SetMatrix(AValue: TAffineMatrix);
+begin
+  if FSettingMatrices then Exit;
+  FSettingMatrices := true;
+  FMatrix:=AValue;
+  if FCanvas <> nil then
+    TBGLCustomCanvas(FCanvas).Matrix := AValue;
+  FSettingMatrices := false;
+end;
+
+function TBGLFrameBuffer.GetMatrix: TAffineMatrix;
+begin
+  result := FMatrix;
+end;
+
+function TBGLFrameBuffer.GetTexture: IBGLTexture;
+begin
+  result := FTexture.FlipY;
+end;
+
+function TBGLFrameBuffer.GetHandle: pointer;
+begin
+  result := @FFrameBufferId;
+end;
+
+function TBGLFrameBuffer.GetHeight: integer;
+begin
+  result := FHeight;
+end;
+
+function TBGLFrameBuffer.GetProjectionMatrix: TMatrix4D;
+begin
+  result := FProjectionMatrix;
+end;
+
+function TBGLFrameBuffer.GetWidth: integer;
+begin
+  result := FWidth;
+end;
+
+procedure TBGLFrameBuffer.SetProjectionMatrix(AValue: TMatrix4D);
+begin
+  if FSettingMatrices then Exit;
+  FSettingMatrices := true;
+  FProjectionMatrix:= AValue;
+  if FCanvas <> nil then
+    TBGLCustomCanvas(FCanvas).ProjectionMatrix := AValue;
+  FSettingMatrices := false;
+end;
+
+constructor TBGLFrameBuffer.Create(AWidth, AHeight: integer);
+var frameBufferStatus: GLenum;
+begin
+  if not Load_GL_version_3_0 then
+      raise exception.Create('Cannot load OpenGL 3.0');
+
+  FWidth := AWidth;
+  FHeight := AHeight;
+
+  FTexture := BGLTextureFactory.Create(nil,AWidth,AHeight,AWidth,AHeight);
+
+  //depth and stencil
+  glGenRenderbuffers(1, @FRenderBufferId);
+  glBindRenderbuffer(GL_RENDERBUFFER, FRenderBufferId);
+  glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, AWidth,AHeight);
+  glBindRenderbuffer(GL_RENDERBUFFER, 0);
+
+  glGenFramebuffers(1, @FFrameBufferId);
+  glBindFramebuffer(GL_FRAMEBUFFER, FFrameBufferId);
+
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, PGLuint(FTexture.Handle)^, 0);
+  glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, FFrameBufferId);
+
+  frameBufferStatus:= glCheckFramebufferStatus(GL_FRAMEBUFFER);
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+  if frameBufferStatus <> GL_FRAMEBUFFER_COMPLETE then
+  begin
+    glDeleteFramebuffers(1, @FFrameBufferId);
+    glDeleteRenderbuffers(1, @FRenderBufferId);
+    FTexture := nil;
+    raise exception.Create('Error ' + inttostr(frameBufferStatus) + ' while initializing frame buffer');
+  end;
+
+  UseOrthoProjection;
+  Matrix := AffineMatrixIdentity;
+end;
+
+destructor TBGLFrameBuffer.Destroy;
+begin
+  glDeleteFramebuffers(1, @FFrameBufferId);
+  glDeleteRenderbuffers(1, @FRenderBufferId);
+  FTexture := nil;
+
+  inherited Destroy;
+end;
 
 procedure ApplyBlendMode(ABlendMode: TOpenGLBlendMode);
 var
@@ -848,7 +972,10 @@ end;
 
 function TBGLCanvas.GetMatrix: TAffineMatrix;
 begin
-  result := FMatrix;
+  if ActiveFrameBuffer <> nil then
+    result := ActiveFrameBuffer.Matrix
+  else
+    result := FMatrix;
 end;
 
 procedure TBGLCanvas.SetMatrix(const AValue: TAffineMatrix);
@@ -857,20 +984,31 @@ begin
   glMatrixMode(GL_MODELVIEW);
   m := AffineMatrixToMatrix4D(AValue);
   glLoadMatrixf(@m);
-  FMatrix := AValue;
+
+  if ActiveFrameBuffer <> nil then
+    ActiveFrameBuffer.Matrix := AValue
+  else
+    FMatrix := AValue;
 end;
 
 function TBGLCanvas.GetProjectionMatrix: TMatrix4D;
 begin
-  result := FProjectionMatrix;
+  if ActiveFrameBuffer <> nil then
+    result := ActiveFrameBuffer.ProjectionMatrix
+  else
+    result := FProjectionMatrix;
 end;
 
 procedure TBGLCanvas.SetProjectionMatrix(const AValue: TMatrix4D);
 begin
-  FProjectionMatrix := AValue;
   glMatrixMode(GL_PROJECTION);
   glLoadMatrixf(@AValue);
   glMatrixMode(GL_MODELVIEW);
+
+  if ActiveFrameBuffer <> nil then
+    ActiveFrameBuffer.ProjectionMatrix := AValue
+  else
+    FProjectionMatrix := AValue;
 end;
 
 function TBGLCanvas.GetFaceCulling: TFaceCulling;
@@ -1033,6 +1171,28 @@ end;
 procedure TBGLCanvas.SetBlendMode(AValue: TOpenGLBlendMode);
 begin
   FBlendMode := AValue;
+end;
+
+procedure TBGLCanvas.SetActiveFrameBuffer(AValue: TBGLCustomFrameBuffer);
+var
+  m: TMatrix4D;
+begin
+  if AValue = ActiveFrameBuffer then exit;
+  inherited SetActiveFrameBuffer(AValue);
+  if AValue = nil then
+    glBindFramebuffer(GL_FRAMEBUFFER, 0)
+  else
+    glBindFramebuffer(GL_FRAMEBUFFER, PGLuint(AValue.Handle)^);
+
+  glViewPort(0,0,Width,Height);
+
+  glMatrixMode(GL_PROJECTION);
+  m := ProjectionMatrix;
+  glLoadMatrixf(@m);
+
+  glMatrixMode(GL_MODELVIEW);
+  m := AffineMatrixToMatrix4D(Matrix);
+  glLoadMatrixf(@m);
 end;
 
 destructor TBGLCanvas.Destroy;
@@ -1376,7 +1536,7 @@ end;
 
 procedure TBGLTexture.ToggleFlipY;
 begin
-  FFlipX := not FFlipY;
+  FFlipY := not FFlipY;
 end;
 
 procedure TBGLTexture.Bind(ATextureNumber: integer);

--- a/bgrabitmap/bgraopengl.pas
+++ b/bgrabitmap/bgraopengl.pas
@@ -298,6 +298,7 @@ type
     procedure StartZBuffer; override;
     procedure EndZBuffer; override;
     procedure WaitForGPU(AOption: TWaitForGPUOption); override;
+    function GetImage(x, y, w, h: integer): TBGRACustomBitmap; override;
   end;
 
   { TBGLLighting }
@@ -1166,6 +1167,16 @@ begin
     wfgQueueAllCommands: glFlush;
     wfgFinishAllCommands: glFinish;
   end;
+end;
+
+function TBGLCanvas.GetImage(x, y, w, h: integer): TBGRACustomBitmap;
+begin
+  NeedOpenGL2_0;
+  result := BGRABitmapFactory.Create(w,h);
+  if TBGRAPixel_RGBAOrder then
+    glReadPixels(x,self.Height-y-h, w,h, GL_RGBA, GL_UNSIGNED_BYTE, result.Data)
+  else
+    glReadPixels(x,self.Height-y-h, w,h, GL_BGRA, GL_UNSIGNED_BYTE, result.Data);
 end;
 
 procedure TBGLCanvas.EnableScissor(AValue: TRect);

--- a/bgrabitmap/bgraopengl.pas
+++ b/bgrabitmap/bgraopengl.pas
@@ -331,8 +331,8 @@ type
     procedure DeleteShaderProgram(AProgram: DWord); override;
     function GetUniformVariable(AProgram: DWord; AName: string): DWord; override;
     function GetAttribVariable(AProgram: DWord; AName: string): DWord; override;
-    procedure SetUniformSingle(AVariable: DWord; const AValue; ACount: integer); override;
-    procedure SetUniformInteger(AVariable: DWord; const AValue; ACount: integer); override;
+    procedure SetUniformSingle(AVariable: DWord; const AValue; AElementCount, AComponentCount: integer); override;
+    procedure SetUniformInteger(AVariable: DWord; const AValue; AElementCount, AComponentCount: integer); override;
     procedure BindAttribute(AAttribute: TAttributeVariable); override;
     procedure UnbindAttribute(AAttribute: TAttributeVariable); override;
   end;
@@ -899,17 +899,33 @@ begin
 end;
 
 procedure TBGLLighting.SetUniformSingle(AVariable: DWord;
-  const AValue; ACount: integer);
+  const AValue; AElementCount, AComponentCount: integer);
 begin
   NeedOpenGL2_0;
-  glUniform1fv(AVariable, ACount, @AValue);
+  case AComponentCount of
+    1: glUniform1fv(AVariable, AElementCount, @AValue);
+    2: glUniform2fv(AVariable, AElementCount, @AValue);
+    3: glUniform3fv(AVariable, AElementCount, @AValue);
+    4: glUniform4fv(AVariable, AElementCount, @AValue);
+    9: glUniformMatrix3fv(AVariable, AElementCount, GL_FALSE, @AValue);
+    16: glUniformMatrix4fv(AVariable, AElementCount, GL_FALSE, @AValue);
+  else
+    raise exception.Create('Unexpected number of components');
+  end;
 end;
 
 procedure TBGLLighting.SetUniformInteger(AVariable: DWord;
-  const AValue; ACount: integer);
+  const AValue; AElementCount, AComponentCount: integer);
 begin
   NeedOpenGL2_0;
-  glUniform1iv(AVariable, ACount, @AValue);
+  case AComponentCount of
+    1: glUniform1iv(AVariable, AElementCount, @AValue);
+    2: glUniform2iv(AVariable, AElementCount, @AValue);
+    3: glUniform3iv(AVariable, AElementCount, @AValue);
+    4: glUniform4iv(AVariable, AElementCount, @AValue);
+  else
+    raise exception.Create('Unexpected number of components');
+  end;
 end;
 
 procedure TBGLLighting.BindAttribute(AAttribute: TAttributeVariable);

--- a/bgrabitmap/bgraopengl3d.pas
+++ b/bgrabitmap/bgraopengl3d.pas
@@ -222,10 +222,11 @@ type
     procedure CheckUsage(AUsing: boolean);
     procedure StartUse; override;
     procedure EndUse; override;
+    property Canvas: TBGLCustomCanvas read FCanvas;
   public
     constructor Create(ACanvas: TBGLCustomCanvas; AVertexShaderSource: string;
         AFragmentShaderSource: string; AVaryingVariables: string = '';
-        AVersion: string = '110');
+        AVersion: string = '120');
     destructor Destroy; override;
     property UniformSingle[AName: string]: TUniformVariableSingle read GetUniformVariableSingle;
     property UniformPointF[AName: string]: TUniformVariablePointF read GetUniformVariablePointF;

--- a/bgrabitmap/bgraopengltype.pas
+++ b/bgrabitmap/bgraopengltype.pas
@@ -183,6 +183,8 @@ type
     procedure ToggleFlipX;
     procedure ToggleFlipY;
     procedure ToggleMask;
+    function FilterBlurMotion(ARadius: single; ABlurType: TRadialBlurType; ADirection: TPointF): IBGLTexture;
+    function FilterBlurRadial(ARadius: single; ABlurType: TRadialBlurType): IBGLTexture;
     procedure SetFrame(AIndex: integer);
     procedure FreeMemory;
     procedure Bind(ATextureNumber: integer);
@@ -362,6 +364,8 @@ type
     procedure ToggleFlipX; virtual; abstract;
     procedure ToggleFlipY; virtual; abstract;
     procedure ToggleMask; virtual;
+    function FilterBlurMotion({%H-}ARadius: single; {%H-}ABlurType: TRadialBlurType; {%H-}ADirection: TPointF): IBGLTexture; virtual;
+    function FilterBlurRadial({%H-}ARadius: single; {%H-}ABlurType: TRadialBlurType): IBGLTexture; virtual;
 
     procedure SetFrameSize(x,y: integer);
     procedure Update(ARGBAData: PDWord; AllocatedWidth, AllocatedHeight, ActualWidth,ActualHeight: integer; RGBAOrder: boolean = true);
@@ -443,6 +447,7 @@ type
   public
     procedure UseOrthoProjection; virtual;
     procedure UseOrthoProjection(AMinX,AMinY,AMaxX,AMaxY: single); virtual;
+    function MakeTextureAndFree: IBGLTexture; virtual;
 
     procedure SetCanvas(ACanvas: Pointer); //for internal use
     property Matrix: TAffineMatrix read GetMatrix write SetMatrix;
@@ -476,6 +481,11 @@ end;
 procedure TBGLCustomFrameBuffer.UseOrthoProjection(AMinX, AMinY, AMaxX, AMaxY: single);
 begin
   ProjectionMatrix := OrthoProjectionToOpenGL(AMinX,AMinY,AMaxX,AMaxY);
+end;
+
+function TBGLCustomFrameBuffer.MakeTextureAndFree: IBGLTexture;
+begin
+  raise exception.create('Not implemented');
 end;
 
 procedure TBGLCustomFrameBuffer.SetCanvas(ACanvas: Pointer);
@@ -634,6 +644,17 @@ end;
 procedure TBGLCustomTexture.ToggleMask;
 begin
   FIsMask := not FIsMask;
+end;
+
+function TBGLCustomTexture.FilterBlurMotion(ARadius: single; ABlurType: TRadialBlurType;
+  ADirection: TPointF): IBGLTexture;
+begin
+  raise exception.Create('Not implemented');
+end;
+
+function TBGLCustomTexture.FilterBlurRadial(ARadius: single; ABlurType: TRadialBlurType): IBGLTexture;
+begin
+  raise exception.Create('Not implemented');
 end;
 
 procedure TBGLCustomTexture.Update(ARGBAData: PDWord; AllocatedWidth,
@@ -798,7 +819,9 @@ begin
     with TBGRACustomBitmap(AFPImage) do
     begin
       if not TBGRAPixel_RGBAOrder and not SupportsBGRAOrder then SwapRedBlue;
+      if LineOrder = riloBottomToTop then VerticalFlip;
       InitFromData(PDWord(Data), Width,Height, Width,Height, TBGRAPixel_RGBAOrder or not SupportsBGRAOrder);
+      if LineOrder = riloBottomToTop then VerticalFlip;
       if not TBGRAPixel_RGBAOrder and not SupportsBGRAOrder then SwapRedBlue;
     end;
   end else

--- a/bgrabitmap/bgraopengltype.pas
+++ b/bgrabitmap/bgraopengltype.pas
@@ -426,6 +426,33 @@ type
     property GradientColors: boolean read GetUseGradientColors write SetUseGradientColors;
   end;
 
+  { TBGLCustomFrameBuffer }
+
+  TBGLCustomFrameBuffer = class
+  protected
+    FCanvas: pointer;
+    function GetTexture: IBGLTexture; virtual; abstract;
+    function GetHandle: pointer; virtual; abstract;
+    function GetMatrix: TAffineMatrix; virtual; abstract;
+    function GetHeight: integer; virtual; abstract;
+    function GetProjectionMatrix: TMatrix4D; virtual; abstract;
+    function GetWidth: integer; virtual; abstract;
+    procedure SetMatrix(AValue: TAffineMatrix); virtual; abstract;
+    procedure SetProjectionMatrix(AValue: TMatrix4D); virtual; abstract;
+
+  public
+    procedure UseOrthoProjection; virtual;
+    procedure UseOrthoProjection(AMinX,AMinY,AMaxX,AMaxY: single); virtual;
+
+    procedure SetCanvas(ACanvas: Pointer); //for internal use
+    property Matrix: TAffineMatrix read GetMatrix write SetMatrix;
+    property ProjectionMatrix: TMatrix4D read GetProjectionMatrix write SetProjectionMatrix;
+    property Width: integer read GetWidth;
+    property Height: integer read GetHeight;
+    property Handle: pointer read GetHandle;
+    property Texture: IBGLTexture read GetTexture;
+  end;
+
 type
   TBGLBitmapAny = class of TBGLCustomBitmap;
   TBGLTextureAny = class of TBGLCustomTexture;
@@ -440,6 +467,21 @@ function GetPowerOfTwo( Value : Integer ) : Integer;
 implementation
 
 uses BGRAFilterScanner;
+
+procedure TBGLCustomFrameBuffer.UseOrthoProjection;
+begin
+  ProjectionMatrix := OrthoProjectionToOpenGL(0,0,Width,Height);
+end;
+
+procedure TBGLCustomFrameBuffer.UseOrthoProjection(AMinX, AMinY, AMaxX, AMaxY: single);
+begin
+  ProjectionMatrix := OrthoProjectionToOpenGL(AMinX,AMinY,AMaxX,AMaxY);
+end;
+
+procedure TBGLCustomFrameBuffer.SetCanvas(ACanvas: Pointer);
+begin
+  FCanvas := ACanvas;
+end;
 
 function OrthoProjectionToOpenGL(AMinX, AMinY, AMaxX, AMaxY: Single): TMatrix4D;
 var sx,sy: single;

--- a/bgrabitmap/bgraopenraster.pas
+++ b/bgrabitmap/bgraopenraster.pas
@@ -224,9 +224,9 @@ begin
     begin
       attr := imagenode.Attributes[i];
       if lowercase(attr.NodeName) = 'w' then
-        w := strToInt(attr.NodeValue) else
+        w := strToInt(string(attr.NodeValue)) else
       if lowercase(attr.NodeName) = 'h' then
-        h := strToInt(attr.NodeValue) else
+        h := strToInt(string(attr.NodeValue)) else
       if lowercase(attr.NodeName) = 'gamma-correction' then
         linearBlend := (attr.NodeValue = 'no') or (attr.NodeValue = '0');
     end;
@@ -264,7 +264,7 @@ begin
             end;
           end else
           if lowercase(attr.NodeName) = 'gamma-correction' then
-            gammastr := attr.NodeValue else
+            gammastr := string(attr.NodeValue) else
           if lowercase(attr.NodeName) = 'visibility' then
             LayerVisible[idx] := (attr.NodeValue = 'visible') or (attr.NodeValue = 'yes') or (attr.NodeValue = '1') else
           if (lowercase(attr.NodeName) = 'x') or (lowercase(attr.NodeName) = 'y') then
@@ -282,7 +282,7 @@ begin
             LayerName[idx] := UTF8Encode(attr.NodeValue) else
           if lowercase(attr.NodeName) = 'composite-op' then
           begin
-            opstr := StringReplace(lowercase(attr.NodeValue),'_','-',[rfReplaceAll]);
+            opstr := StringReplace(lowercase(string(attr.NodeValue)),'_','-',[rfReplaceAll]);
             if (pos(':',opstr) = 0) and (opstr <> 'xor') then opstr := 'svg:'+opstr;
             //parse composite op
             if (opstr = 'svg:src-over') or (opstr = 'krita:dissolve') then
@@ -372,8 +372,8 @@ begin
   FStackXML := TXMLDocument.Create;
   imageNode := TDOMElement(StackXML.CreateElement('image'));
   StackXML.AppendChild(imageNode);
-  imageNode.SetAttribute('w',inttostr(Width));
-  imageNode.SetAttribute('h',inttostr(Height));
+  imageNode.SetAttribute('w',widestring(inttostr(Width)));
+  imageNode.SetAttribute('h',widestring(inttostr(Height)));
   if LinearBlend then
     imageNode.SetAttribute('gamma-correction','no')
   else
@@ -394,14 +394,14 @@ begin
       stackNode.AppendChild(layerNode);
       layerNode.SetAttribute('name', UTF8Decode(LayerName[i]));
       str(LayerOpacity[i]/255:0:3,strval);
-      layerNode.SetAttribute('opacity',strval);
-      layerNode.SetAttribute('src',layerFilename);
+      layerNode.SetAttribute('opacity',widestring(strval));
+      layerNode.SetAttribute('src',widestring(layerFilename));
       if LayerVisible[i] then
         layerNode.SetAttribute('visibility','visible')
       else
         layerNode.SetAttribute('visibility','hidden');
-      layerNode.SetAttribute('x',inttostr(LayerOffset[i].x));
-      layerNode.SetAttribute('y',inttostr(LayerOffset[i].y));
+      layerNode.SetAttribute('x',widestring(inttostr(LayerOffset[i].x)));
+      layerNode.SetAttribute('y',widestring(inttostr(LayerOffset[i].y)));
       strval := '';
       case BlendOperation[i] of
         boLighten: strval := 'svg:lighten';
@@ -427,13 +427,13 @@ begin
         boSvgSoftLight: strval := 'svg:soft-light';
         else strval := 'svg:src-over';
       end;
-      layerNode.SetAttribute('composite-op',strval);
+      layerNode.SetAttribute('composite-op',widestring(strval));
       if BlendOperation[i] <> boTransparent then //in 'transparent' case, linear blending depends on general setting
       begin
         if BlendOperation[i] in[boAdditive,boDarkOverlay,boDifference,boSubtractInverse,
              boSubtract,boExclusion,boNegation] then
           strval := 'yes' else strval := 'no';
-        layerNode.SetAttribute('gamma-correction',strval);
+        layerNode.SetAttribute('gamma-correction',widestring(strval));
       end;
     end;
   end;

--- a/bgrabitmap/bgrapalette.pas
+++ b/bgrabitmap/bgrapalette.pas
@@ -196,8 +196,10 @@ type
     procedure SetReductionColorCount(AValue: Integer); virtual; abstract;
   public
     constructor Create(APalette: TBGRACustomPalette; ASeparateAlphaChannel: boolean); virtual; abstract; overload;
+    constructor Create(AColors: array of TBGRAPixel; ASeparateAlphaChannel: boolean); overload;
     constructor Create(ABitmap: TBGRACustomBitmap; AAlpha: TAlphaChannelPaletteOption); virtual; abstract; overload;
     constructor Create(APalette: TBGRACustomPalette; ASeparateAlphaChannel: boolean; AReductionColorCount: integer); virtual; abstract; overload;
+    constructor Create(AColors: array of TBGRAPixel; ASeparateAlphaChannel: boolean; AReductionColorCount: integer); overload;
     constructor Create(ABitmap: TBGRACustomBitmap; AAlpha: TAlphaChannelPaletteOption; AReductionColorCount: integer); virtual; abstract; overload;
     procedure ApplyDitheringInplace(AAlgorithm: TDitheringAlgorithm; ABitmap: TBGRACustomBitmap; ABounds: TRect); virtual; abstract; overload;
     procedure ApplyDitheringInplace(AAlgorithm: TDitheringAlgorithm; ABitmap: TBGRACustomBitmap); overload;
@@ -602,6 +604,30 @@ end;
 function TBGRACustomColorQuantizer.GetDominantColor: TBGRAPixel;
 begin
   result := ReducedPalette.DominantColor;
+end;
+
+constructor TBGRACustomColorQuantizer.Create(AColors: array of TBGRAPixel;
+  ASeparateAlphaChannel: boolean);
+var palette: TBGRAPalette;
+  i: Integer;
+begin
+  palette := TBGRAPalette.Create;
+  for i := 0 to high(AColors) do
+    palette.AddColor(AColors[i]);
+  Create(palette, ASeparateAlphaChannel);
+  palette.Free;
+end;
+
+constructor TBGRACustomColorQuantizer.Create(AColors: array of TBGRAPixel;
+  ASeparateAlphaChannel: boolean; AReductionColorCount: integer);
+var palette: TBGRAPalette;
+  i: Integer;
+begin
+  palette := TBGRAPalette.Create;
+  for i := 0 to high(AColors) do
+    palette.AddColor(AColors[i]);
+  Create(palette, ASeparateAlphaChannel, AReductionColorCount);
+  palette.Free;
 end;
 
 procedure TBGRACustomColorQuantizer.ApplyDitheringInplace(

--- a/bgrabitmap/bgrapath.pas
+++ b/bgrabitmap/bgrapath.pas
@@ -2300,6 +2300,7 @@ end;
 procedure TBGRAPath.NeedSpace(count: integer);
 begin
   OnModify;
+  count += 4; //avoid memory error
   if FDataPos + count > FDataCapacity then
   begin
     FDataCapacity := (FDataCapacity shl 1)+8;

--- a/bgrabitmap/bgrareadico.pas
+++ b/bgrabitmap/bgrareadico.pas
@@ -9,7 +9,7 @@ uses
   Classes, SysUtils, FPimage{$IFDEF BGRABITMAP_USE_LCL}, Graphics{$ENDIF};
 
 type
-  TCustomIconClass = class of TCustomIcon;
+  {$IFDEF BGRABITMAP_USE_LCL}TCustomIconClass = class of TCustomIcon;{$ENDIF}
   TByteSet = set of byte;
 
   { TBGRAReaderIcoOrCur }
@@ -40,7 +40,7 @@ type
 
 implementation
 
-uses BGRABitmapTypes;
+uses BGRABitmapTypes{$IFNDEF BGRABITMAP_USE_LCL}, BGRAIconCursor{$ENDIF};
 
 { TBGRAReaderCur }
 
@@ -100,15 +100,30 @@ begin
       raise exception.Create('No adequate icon found') else
     begin
       ico.Current := bestIdx;
-      (Img as TBGRACustomBitmap).Assign(ico);
+      Img.Assign(ico);
     end;
   finally
     ico.free;
   end;
 end;
 {$ELSE}
+var icoCur: TBGRAIconCursor;
+    compWidth,compHeight: integer;
+    bmp: TBGRACustomBitmap;
 begin
-  raise exception.create('Not implemented');
+  if WantedWidth > 0 then compWidth:= WantedWidth else compWidth:= 65536;
+  if WantedHeight > 0 then compHeight:= WantedHeight else compHeight:= 65536;
+  icoCur := TBGRAIconCursor.Create(Str);
+  try
+    bmp := icoCur.GetBestFitBitmap(compWidth,compHeight);
+    try
+      Img.Assign(bmp);
+    finally
+      bmp.Free;
+    end;
+  finally
+    icoCur.Free;
+  end;
 end;
 {$ENDIF}
 

--- a/bgrabitmap/bgrareadico.pas
+++ b/bgrabitmap/bgrareadico.pas
@@ -88,7 +88,7 @@ begin
     begin
       ico.GetDescription(i,format,height,width);
       if (bestIdx = -1) or (abs(height-compHeight)+abs(width-compWidth) < abs(bestHeight-compHeight)+abs(bestWidth-compWidth)) or
-      ((height = bestHeight) or (width = bestWidth) and (format > maxFormat)) then
+      ((height = bestHeight) and (width = bestWidth) and (format > maxFormat)) then
       begin
         bestIdx := i;
         bestHeight := height;

--- a/bgrabitmap/bgrasvgshapes.pas
+++ b/bgrabitmap/bgrasvgshapes.pas
@@ -569,6 +569,7 @@ begin
     result[i].x := parser.ParseFloat;
     result[i].y := parser.ParseFloat;
   end;
+  parser.Free;
 end;
 
 procedure TSVGPolypoints.SetPoints(AValue: string);

--- a/bgrabitmap/bgrathumbnail.pas
+++ b/bgrabitmap/bgrathumbnail.pas
@@ -8,7 +8,7 @@ interface
 uses
   Classes, SysUtils, BGRABitmap, BGRABitmapTypes, FPimage;
 
-function GetBitmapThumbnail(ABitmap: TBGRABitmap; AWidth,AHeight: integer; ABackColor: TBGRAPixel; ACheckers: boolean; ADest: TBGRABitmap= nil; AVerticalShrink : single = 1): TBGRABitmap;
+function GetBitmapThumbnail(ABitmap: TBGRABitmap; AWidth,AHeight: integer; ABackColor: TBGRAPixel; ACheckers: boolean; ADest: TBGRABitmap= nil; AVerticalShrink : single = 1; AHotSpotX: integer = -1; AHotSpotY: integer = -1): TBGRABitmap;
 function GetFileThumbnail(AFilenameUTF8: string; AWidth,AHeight: integer; ABackColor: TBGRAPixel; ACheckers: boolean; ADest: TBGRABitmap= nil): TBGRABitmap;
 function GetStreamThumbnail(AStream: TStream; AWidth,AHeight: integer; ABackColor: TBGRAPixel; ACheckers: boolean; ASuggestedExtensionUTF8: string = ''; ADest: TBGRABitmap= nil): TBGRABitmap; overload;
 function GetStreamThumbnail(AStream: TStream; AReader: TFPCustomImageReader; AWidth,AHeight: integer; ABackColor: TBGRAPixel; ACheckers: boolean; ADest: TBGRABitmap= nil): TBGRABitmap; overload;
@@ -45,8 +45,8 @@ begin
   bmp.DrawCheckers(ARect, BGRA(255,255,255), BGRA(220,220,220));
 end;
 
-function GetBitmapThumbnail(ABitmap: TBGRABitmap; AWidth, AHeight: integer; ABackColor: TBGRAPixel; ACheckers: boolean; ADest: TBGRABitmap; AVerticalShrink: single
-  ): TBGRABitmap;
+function GetBitmapThumbnail(ABitmap: TBGRABitmap; AWidth, AHeight: integer; ABackColor: TBGRAPixel; ACheckers: boolean;
+  ADest: TBGRABitmap; AVerticalShrink: single; AHotSpotX: integer; AHotSpotY: integer): TBGRABitmap;
 var
   factorX, factorY, factor: single;
   xIcon,yIcon,wIcon,hIcon: Integer;
@@ -73,6 +73,11 @@ begin
       if (ABackColor.alpha <> 0) or ACheckers then
         result.StretchPutImage(Rect(xIcon,yIcon,xIcon+wIcon,yIcon+hIcon),ABitmap,dmDrawWithTransparency) else
         result.StretchPutImage(Rect(xIcon,yIcon,xIcon+wIcon,yIcon+hIcon),ABitmap,dmSet);
+      if (AHotSpotX <> -1) and (wIcon > 0) and (hIcon > 0) then
+      begin
+        result.HorizLine(xIcon,yIcon+AHotSpotY*hIcon div ABitmap.Height,xIcon+wIcon-1,BGRA(255,0,0,128),dmDrawWithTransparency);
+        result.VertLine(xIcon+AHotSpotX*wIcon div ABitmap.Width,yIcon,yIcon+hIcon-1,BGRA(255,0,0,128),dmDrawWithTransparency);
+      end;
     end;
   except
   end;
@@ -380,9 +385,7 @@ begin
   icoBmp := TBGRABitmap.Create;
   try
     icoBmp.LoadFromStream(AStream, reader);
-    icoBmp.HorizLine(0,icoBmp.HotSpot.Y,icoBmp.Width-1, BGRA(255,0,0,64),dmDrawWithTransparency);
-    icoBmp.VertLine(icoBmp.HotSpot.X,0,icoBmp.Height-1, BGRA(255,0,0,64),dmDrawWithTransparency);
-    result := GetBitmapThumbnail(icoBmp, AWidth, AHeight, ABackColor, ACheckers, ADest);
+    result := GetBitmapThumbnail(icoBmp, AWidth, AHeight, ABackColor, ACheckers, ADest, 1, icoBmp.HotSpot.x, icoBmp.HotSpot.y);
   except
   end;
   icoBmp.Free;

--- a/bgrabitmap/bgrathumbnail.pas
+++ b/bgrabitmap/bgrathumbnail.pas
@@ -33,7 +33,11 @@ function GetXwdThumbnail(AStream: TStream; AWidth, AHeight: integer; ABackColor:
 function GetXPixMapThumbnail(AStream: TStream; AWidth, AHeight: integer; ABackColor: TBGRAPixel; ACheckers: boolean; ADest: TBGRABitmap= nil): TBGRABitmap;
 function GetBmpMioMapThumbnail(AStream: TStream; AWidth, AHeight: integer; ABackColor: TBGRAPixel; ACheckers: boolean; ADest: TBGRABitmap= nil): TBGRABitmap;
 
-procedure DrawThumbnailCheckers(bmp: TBGRABitmap; ARect: TRect; ADarkCheckers: boolean = false);
+procedure DrawThumbnailCheckers(bmp: TBGRABitmap; ARect: TRect; AIconCheckers: boolean = false);
+
+var
+  ImageCheckersColor1,ImageCheckersColor2  : TBGRAPixel;
+  IconCheckersColor1,IconCheckersColor2  : TBGRAPixel;
 
 implementation
 
@@ -41,12 +45,12 @@ uses Types, base64, BGRAUTF8,
      DOM, XMLRead, BGRAReadJPEG, BGRAReadPng, BGRAReadGif, BGRAReadBMP,
      BGRAReadPSD, BGRAReadIco, UnzipperExt, BGRAReadLzp;
 
-procedure DrawThumbnailCheckers(bmp: TBGRABitmap; ARect: TRect; ADarkCheckers: boolean);
+procedure DrawThumbnailCheckers(bmp: TBGRABitmap; ARect: TRect; AIconCheckers: boolean);
 begin
-  if ADarkCheckers then
-    bmp.DrawCheckers(ARect, BGRA(140,180,180), BGRA(80,140,140))
+  if AIconCheckers then
+    bmp.DrawCheckers(ARect, IconCheckersColor1, IconCheckersColor2)
   else
-    bmp.DrawCheckers(ARect, BGRA(255,255,255), BGRA(220,220,220));
+    bmp.DrawCheckers(ARect, ImageCheckersColor1, ImageCheckersColor2);
 end;
 
 function InternalGetBitmapThumbnail(ABitmap: TBGRABitmap; AWidth, AHeight: integer; ABackColor: TBGRAPixel; ACheckers: boolean;
@@ -492,5 +496,13 @@ begin
   result := GetStreamThumbnail(AStream,reader,AWidth,AHeight,ABackColor,ACheckers,ADest);
   reader.Free;
 end;
+
+initialization
+
+  IconCheckersColor1 := BGRA(140,180,180);
+  IconCheckersColor2 := BGRA(80,140,140);
+
+  ImageCheckersColor1 := BGRA(255,255,255);
+  ImageCheckersColor2 := BGRA(220,220,220);
 
 end.

--- a/bgrabitmap/bgrawinresource.pas
+++ b/bgrabitmap/bgrawinresource.pas
@@ -1039,14 +1039,17 @@ begin
   'ico': begin
            result := TGroupIconEntry.Create(self, entryName, resourceInfo);
            TGroupIconEntry(result).CopyFrom(AContent);
+           AContent.Free;
          end;
   'cur': begin
            result := TGroupCursorEntry.Create(self, entryName, resourceInfo);
            TGroupCursorEntry(result).CopyFrom(AContent);
+           AContent.Free;
          end;
   'bmp': begin
            result := TBitmapResourceEntry.Create(self, entryName, resourceInfo, AContent);
            TBitmapResourceEntry(result).CopyFrom(AContent);
+           AContent.Free;
          end;
   'dat': result := TUnformattedResourceEntry.Create(self, NameOrId(RT_RCDATA), entryName, resourceInfo, AContent);
   'html','htm': result := TUnformattedResourceEntry.Create(self, NameOrId(RT_HTML), entryName, resourceInfo, AContent);

--- a/bgrabitmap/bgrawinresource.pas
+++ b/bgrabitmap/bgrawinresource.pas
@@ -1,0 +1,1165 @@
+unit BGRAWinResource;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, BGRAMultiFileType, BGRABitmapTypes;
+
+const
+  RT_CURSOR = 1;
+  RT_BITMAP = 2;
+  RT_ICON = 3;
+
+  RT_MENU = 4;
+  RT_DIALOG = 5;
+  RT_STRING = 6;
+  RT_FONTDIR = 7;
+  RT_FONT = 8;
+  RT_ACCELERATOR = 9;
+  RT_RCDATA = 10;
+  RT_MESSAGETABLE = 11;
+
+  RT_GROUP = 11;
+  RT_GROUP_CURSOR = RT_GROUP + RT_CURSOR;
+  RT_GROUP_ICON = RT_GROUP + RT_ICON;
+
+  RT_VERSION = 16;
+  RT_ANICURSOR = 21;
+  RT_ANIICON = 22;
+  RT_HTML = 23;
+  RT_MANIFEST = 24;
+
+type
+  TNameOrId = record
+    Id: integer;
+    Name: utf8string;
+  end;
+
+  { TResourceInfo }
+
+  TResourceInfo = object
+    DataVersion: DWord;
+    MemoryFlags: Word;
+    LanguageId: Word;
+    Version: DWord;
+    Characteristics: DWord;
+    procedure SwapIfNecessary;
+  end;
+
+  TWinResourceContainer = class;
+
+  { TCustomResourceEntry }
+
+  TCustomResourceEntry = class(TMultiFileEntry)
+  private
+    class function GetNextEntry(AContainer: TMultiFileContainer; AStream: TStream): TCustomResourceEntry;
+    procedure Serialize(ADestination: TStream);
+  protected
+    FTypeNameOrId: TNameOrId;
+    FEntryNameOrId: TNameOrId;
+    FResourceInfo: TResourceInfo;
+    FReferenceCount: integer;
+    function GetName: utf8string; override;
+    procedure SetName(AValue: utf8string); override;
+    function GetId: integer;
+    procedure SetId(AValue: integer);
+    function GetTypeId: integer;
+    function GetTypeName: utf8string;
+    procedure IncrementReferences; virtual;
+    procedure DecrementReferences; virtual;
+    procedure SerializeHeader(ADestination: TStream); virtual;
+    procedure SerializeData(ADestination: TStream); virtual; abstract;
+    function GetDataSize: integer; virtual; abstract;
+    function GetLanguageId: integer;
+    procedure SetLanguageId(AValue: integer);
+  public
+    constructor Create(AContainer: TMultiFileContainer; ATypeNameOrId: TNameOrId; AEntryNameOrId: TNameOrId; const AResourceInfo: TResourceInfo);
+    property Id: integer read GetId write SetId;
+    property TypeName: utf8string read GetTypeName;
+    property TypeId: integer read GetTypeId;
+    property LanguageId: integer read GetLanguageId write SetLanguageId;
+  end;
+
+  { TUnformattedResourceEntry }
+
+  TUnformattedResourceEntry = class(TCustomResourceEntry)
+  protected
+    FDataStream: TStream;
+    function GetFileSize: int64; override;
+    function GetDataSize: integer; override;
+    procedure SerializeData(ADestination: TStream); override;
+    function GetExtension: utf8string; override;
+  public
+    constructor Create(AContainer: TMultiFileContainer; ATypeNameOrId: TNameOrId; AEntryNameOrId: TNameOrId; const AResourceInfo: TResourceInfo; ADataStream: TStream);
+    destructor Destroy; override;
+    function CopyTo(ADestination: TStream): integer; override;
+  end;
+
+  { TBitmapResourceEntry }
+
+  TBitmapResourceEntry = class(TUnformattedResourceEntry)
+  protected
+    function GetFileSize: int64; override;
+    function GetExtension: utf8string; override;
+  public
+    constructor Create(AContainer: TMultiFileContainer; AEntryNameOrId: TNameOrId; const AResourceInfo: TResourceInfo; ADataStream: TStream);
+    function CopyTo(ADestination: TStream): integer; override;
+    procedure CopyFrom(ASource: TStream);
+  end;
+
+  { TGroupIconHeader }
+
+  TGroupIconHeader = object
+    Reserved, ResourceType, ImageCount: Word;
+    procedure SwapIfNecessary;
+  end;
+  TGroupIconDirEntry = packed record
+    Width, Height, Colors, Reserved: byte;
+    //stored in little endian
+    case byte of
+    0: (Variable: DWord; ImageSize: DWord; ImageId: Word);
+    1: (Planes, BitsPerPixel: Word);
+    2: (HotSpotX, HotSpotY: Word);
+  end;
+  TIconFileDirEntry = packed record
+    Width, Height, Colors, Reserved: byte;
+    //stored in little endian
+    case byte of
+    0: (Variable: DWord; ImageSize: DWord; ImageOffset: DWord);
+    1: (Planes, BitsPerPixel: Word);
+    2: (HotSpotX, HotSpotY: Word);
+  end;
+
+  { TGroupIconOrCursorEntry }
+
+  TGroupIconOrCursorEntry = class(TCustomResourceEntry)
+  private
+    function GetNbIcons: integer;
+  protected
+    FGroupIconHeader: TGroupIconHeader;
+    FDirectory: packed array of TGroupIconDirEntry;
+    function GetFileSize: int64; override;
+    function GetDataSize: integer; override;
+    procedure SerializeData(ADestination: TStream); override;
+    procedure IncrementReferences; override;
+    procedure DecrementReferences; override;
+    function ExpectedResourceType: word; virtual; abstract;
+  public
+    constructor Create(AContainer: TMultiFileContainer; ATypeNameOrId: TNameOrId; AEntryNameOrId: TNameOrId; const AResourceInfo: TResourceInfo; ADataStream: TStream);
+    constructor Create(AContainer: TMultiFileContainer; ATypeNameOrId: TNameOrId; AEntryNameOrId: TNameOrId; const AResourceInfo: TResourceInfo);
+    procedure Clear;
+    function CopyTo(ADestination: TStream): integer; override;
+    procedure CopyFrom(ASource: TStream);
+    property NbIcons: integer read GetNbIcons;
+  end;
+
+  { TGroupIconEntry }
+
+  TGroupIconEntry = class(TGroupIconOrCursorEntry)
+  protected
+    function GetExtension: utf8string; override;
+    function ExpectedResourceType: word; override;
+  public
+    constructor Create(AContainer: TMultiFileContainer; AEntryNameOrId: TNameOrId; const AResourceInfo: TResourceInfo; ADataStream: TStream);
+    constructor Create(AContainer: TMultiFileContainer; AEntryNameOrId: TNameOrId; const AResourceInfo: TResourceInfo);
+  end;
+
+  { TGroupCursorEntry }
+
+  TGroupCursorEntry = class(TGroupIconOrCursorEntry)
+  protected
+    function GetExtension: utf8string; override;
+    function ExpectedResourceType: word; override;
+  public
+    constructor Create(AContainer: TMultiFileContainer; AEntryNameOrId: TNameOrId; const AResourceInfo: TResourceInfo; ADataStream: TStream);
+    constructor Create(AContainer: TMultiFileContainer; AEntryNameOrId: TNameOrId; const AResourceInfo: TResourceInfo);
+  end;
+
+  { TWinResourceContainer }
+
+  TWinResourceContainer = class(TMultiFileContainer)
+  private
+    function InternalFind(const AEntry: TNameOrId; const AType: TNameOrId; ALanguageId: integer = 0): TCustomResourceEntry;
+    procedure AddHidden(AEntry: TCustomResourceEntry);
+    function GetMaxId(AType: TNameOrId): integer;
+    procedure IncrementReferenceOf(ANameId, ATypeId: integer);
+    procedure DecrementReferenceOf(ANameId, ATypeId: integer);
+  protected
+    FHiddenEntries: TMultiFileEntryList;
+    procedure Init; override;
+    procedure ClearHiddenEntries;
+    procedure RemoveHidden(AEntry: TCustomResourceEntry);
+    function CreateEntry(AName: utf8string; AExtension: utf8string; AContent: TStream; ALanguageId: integer): TMultiFileEntry; overload;
+    function CreateEntry(AName: utf8string; AExtension: utf8string; AContent: TStream): TMultiFileEntry; override;
+  public
+    procedure Clear; override;
+    destructor Destroy; override;
+    procedure Delete(AIndex: integer); override;
+    procedure LoadFromStream(AStream: TStream); override;
+    function IndexOf(AName: utf8string; AExtenstion: utf8string; ACaseSensitive: boolean = True): integer; override;
+    function IndexOf(AName: utf8string; AExtenstion: utf8string; ALanguageId: integer; ACaseSensitive: boolean = True): integer; overload;
+    procedure SaveToStream(ADestination: TStream); override;
+  end;
+
+implementation
+
+uses Math, BMPcomn, BGRAUTF8;
+
+operator =(const ANameOrId1, ANameOrId2: TNameOrId): boolean;
+begin
+  if (ANameOrId1.Id < 0) then
+    result := (ANameOrId2.Id < 0) and (ANameOrId2.Name = ANameOrId1.Name)
+  else
+    result := ANameOrId2.Id = ANameOrId1.Id;
+end;
+
+function NameOrId(AName: string): TNameOrId;
+begin
+  result.Id := -1;
+  result.Name := AName;
+end;
+
+function NameOrId(AId: integer): TNameOrId;
+begin
+  result.Id := AId;
+  result.Name := IntToStr(AId);
+end;
+
+{ TGroupCursorEntry }
+
+function TGroupCursorEntry.GetExtension: utf8string;
+begin
+  Result:= 'cur';
+end;
+
+function TGroupCursorEntry.ExpectedResourceType: word;
+begin
+  result := 2;
+end;
+
+constructor TGroupCursorEntry.Create(AContainer: TMultiFileContainer;
+  AEntryNameOrId: TNameOrId; const AResourceInfo: TResourceInfo;
+  ADataStream: TStream);
+begin
+  inherited Create(AContainer,NameOrId(RT_GROUP_CURSOR),AEntryNameOrId,AResourceInfo,ADataStream);
+end;
+
+constructor TGroupCursorEntry.Create(AContainer: TMultiFileContainer;
+  AEntryNameOrId: TNameOrId; const AResourceInfo: TResourceInfo);
+begin
+  inherited Create(AContainer,NameOrId(RT_GROUP_CURSOR),AEntryNameOrId,AResourceInfo);
+end;
+
+{ TGroupIconEntry }
+
+function TGroupIconEntry.GetExtension: utf8string;
+begin
+  Result:= 'ico';
+end;
+
+function TGroupIconEntry.ExpectedResourceType: word;
+begin
+  result := 1;
+end;
+
+constructor TGroupIconEntry.Create(AContainer: TMultiFileContainer;
+  AEntryNameOrId: TNameOrId; const AResourceInfo: TResourceInfo;
+  ADataStream: TStream);
+begin
+  inherited Create(AContainer,NameOrId(RT_GROUP_ICON),AEntryNameOrId,AResourceInfo,ADataStream);
+end;
+
+constructor TGroupIconEntry.Create(AContainer: TMultiFileContainer;
+  AEntryNameOrId: TNameOrId; const AResourceInfo: TResourceInfo);
+begin
+  inherited Create(AContainer,NameOrId(RT_GROUP_ICON),AEntryNameOrId,AResourceInfo);
+end;
+
+{ TGroupIconHeader }
+
+procedure TGroupIconHeader.SwapIfNecessary;
+begin
+  Reserved := LEtoN(Reserved);
+  ResourceType := LEtoN(ResourceType);
+  ImageCount := LEtoN(ImageCount);
+end;
+
+{ TGroupIconOrCursorEntry }
+
+function TGroupIconOrCursorEntry.GetNbIcons: integer;
+begin
+  result := FGroupIconHeader.ImageCount;
+end;
+
+function TGroupIconOrCursorEntry.GetFileSize: int64;
+var
+  i: Integer;
+begin
+  Result:= sizeof(FGroupIconHeader) + sizeof(TIconFileDirEntry)*NbIcons;
+  for i := 0 to NbIcons-1 do
+    Result += LEtoN(FDirectory[i].ImageSize);
+end;
+
+function TGroupIconOrCursorEntry.GetDataSize: integer;
+begin
+  result := sizeof(FGroupIconHeader) + sizeof(TGroupIconDirEntry)*NbIcons;
+end;
+
+procedure TGroupIconOrCursorEntry.SerializeData(ADestination: TStream);
+begin
+  FGroupIconHeader.SwapIfNecessary;
+  try
+    ADestination.WriteBuffer(FGroupIconHeader, sizeof(FGroupIconHeader));
+  finally
+    FGroupIconHeader.SwapIfNecessary;
+  end;
+  ADestination.WriteBuffer(FDirectory[0], sizeof(TGroupIconDirEntry)*NbIcons);
+end;
+
+procedure TGroupIconOrCursorEntry.IncrementReferences;
+var
+  i: Integer;
+begin
+  for i := 0 to NbIcons-1 do
+    TWinResourceContainer(Container).IncrementReferenceOf(LEtoN(FDirectory[i].ImageId), TypeId - RT_GROUP);
+end;
+
+procedure TGroupIconOrCursorEntry.DecrementReferences;
+var
+  i: Integer;
+begin
+  for i := 0 to NbIcons-1 do
+    TWinResourceContainer(Container).DecrementReferenceOf(LEtoN(FDirectory[i].ImageId), TypeId - RT_GROUP);
+end;
+
+constructor TGroupIconOrCursorEntry.Create(AContainer: TMultiFileContainer;
+  ATypeNameOrId: TNameOrId; AEntryNameOrId: TNameOrId; const AResourceInfo: TResourceInfo;
+  ADataStream: TStream);
+begin
+  inherited Create(AContainer,ATypeNameOrId,AEntryNameOrId,AResourceInfo);
+
+  ADataStream.ReadBuffer(FGroupIconHeader, sizeof(FGroupIconHeader));
+  FGroupIconHeader.SwapIfNecessary;
+  if FGroupIconHeader.ResourceType <> ExpectedResourceType then
+    raise exception.Create('Unexpected group type');
+
+  if ADataStream.Position + NbIcons*sizeof(TGroupIconDirEntry) > ADataStream.Size then
+    raise exception.Create('Directory dimension mismatch');
+  setlength(FDirectory, NbIcons);
+  ADataStream.ReadBuffer(FDirectory[0], NbIcons*sizeof(TGroupIconDirEntry));
+end;
+
+constructor TGroupIconOrCursorEntry.Create(AContainer: TMultiFileContainer;
+  ATypeNameOrId: TNameOrId; AEntryNameOrId: TNameOrId;
+  const AResourceInfo: TResourceInfo);
+begin
+  inherited Create(AContainer,ATypeNameOrId,AEntryNameOrId,AResourceInfo);
+
+  FGroupIconHeader.Reserved := 0;
+  FGroupIconHeader.ResourceType := ExpectedResourceType;
+  FGroupIconHeader.ImageCount := 0;
+end;
+
+procedure TGroupIconOrCursorEntry.Clear;
+begin
+  DecrementReferences;
+  FDirectory := nil;
+  FGroupIconHeader.ImageCount := 0;
+end;
+
+function TGroupIconOrCursorEntry.CopyTo(ADestination: TStream): integer;
+var
+  fileDir: packed array of TIconFileDirEntry;
+  offset, written, i: integer;
+  iconEntry: TCustomResourceEntry;
+  iconEntrySize: DWord;
+  iconData: TMemoryStream;
+  copyCount: Int64;
+  subType: TNameOrId;
+
+  procedure FillZero(ACount: integer);
+  var
+    Zero: packed array[0..255] of byte;
+  begin
+    if ACount <= 0 then exit;
+    FillChar({%H-}Zero, Sizeof(Zero), 0);
+    while ACount > 0 do
+    begin
+      ADestination.WriteBuffer(Zero, Min(ACount, sizeof(Zero)));
+      Dec(ACount, Min(ACount, sizeof(Zero)));
+    end;
+  end;
+
+begin
+  result:= 0;
+  FGroupIconHeader.SwapIfNecessary;
+  try
+    ADestination.WriteBuffer(FGroupIconHeader, sizeof(FGroupIconHeader));
+  finally
+    FGroupIconHeader.SwapIfNecessary;
+  end;
+  Inc(result, sizeof(FGroupIconHeader));
+
+  offset := result+sizeof(TIconFileDirEntry)*NbIcons;
+  setlength(fileDir, NbIcons);
+  for i := 0 to NbIcons-1 do
+  begin
+    move(FDirectory[i], fileDir[i], 12);
+    fileDir[i].ImageOffset := NtoLE(offset);
+    inc(offset, fileDir[i].ImageSize);
+  end;
+
+  ADestination.WriteBuffer(fileDir[0], sizeof(TIconFileDirEntry)*NbIcons);
+  inc(result, sizeof(TIconFileDirEntry)*NbIcons);
+
+  subType := NameOrId(TypeId - RT_GROUP);
+  for i := 0 to NbIcons-1 do
+  begin
+    iconEntry := (Container as TWinResourceContainer).InternalFind(NameOrId(LEtoN(FDirectory[i].ImageId)),subType); //no language for icons
+    iconEntrySize := LEtoN(FDirectory[i].ImageSize);
+    if iconEntry = nil then
+      FillZero(iconEntrySize) else
+    begin
+      iconData := TMemoryStream.Create;
+      iconEntry.CopyTo(IconData);
+      iconData.Position:= 0;
+      copyCount := Min(IconData.Size, iconEntrySize);
+      if copyCount > 0 then written := ADestination.CopyFrom(IconData, copyCount)
+      else written := 0;
+      FillZero(iconEntrySize-written);
+      IconData.Free;
+    end;
+    result += iconEntrySize;
+  end;
+end;
+
+procedure TGroupIconOrCursorEntry.CopyFrom(ASource: TStream);
+var
+  tempGroup: TGroupIconHeader;
+  fileDir: packed array of TIconFileDirEntry;
+  iconStream: array of TMemoryStream;
+  startPos: int64;
+  maxId, i: integer;
+  iconEntry: TUnformattedResourceEntry;
+  resourceInfo: TResourceInfo;
+  subType: TNameOrId;
+begin
+  startPos := ASource.Position;
+  ASource.ReadBuffer({%H-}tempGroup, sizeof(tempGroup));
+  tempGroup.SwapIfNecessary;
+  if tempGroup.ResourceType <> ExpectedResourceType then
+    raise exception.Create('Unexpected resource type');
+
+  if ASource.Position + sizeof(TIconFileDirEntry)*tempGroup.ImageCount > ASource.Size then
+    raise exception.Create('Directory dimension mismatch');
+
+  setlength(fileDir, tempGroup.ImageCount);
+  ASource.ReadBuffer(fileDir[0], sizeof(TIconFileDirEntry)*tempGroup.ImageCount);
+
+  try
+    setlength(iconStream, tempGroup.ImageCount);
+    for i := 0 to tempGroup.ImageCount-1 do
+    begin
+      ASource.Position:= startPos + LEtoN(fileDir[i].ImageOffset);
+      iconStream[i] := TMemoryStream.Create;
+      iconStream[i].CopyFrom(ASource, LEtoN(fileDir[i].ImageSize));
+    end;
+
+    subType := NameOrId(self.TypeId - RT_GROUP);
+    maxId := TWinResourceContainer(Container).GetMaxId(subType);
+
+    Clear;
+    FGroupIconHeader.ImageCount := tempGroup.ImageCount;
+    setlength(FDirectory, tempGroup.ImageCount);
+    fillchar({%H-}resourceInfo,sizeof(resourceInfo),0);
+    for i := 0 to tempGroup.ImageCount-1 do
+    begin
+      move(fileDir[i], FDirectory[i], 12);
+      inc(maxId);
+      FDirectory[i].ImageId := maxId;
+      iconEntry := TUnformattedResourceEntry.Create(Container, subType, NameOrId(maxId), resourceInfo, iconStream[i]);
+      iconStream[i] := nil;
+      TWinResourceContainer(Container).AddHidden(iconEntry);
+    end;
+
+  finally
+    for i := 0 to high(iconStream) do
+      iconStream[i].Free;
+    iconStream := nil;
+  end;
+end;
+
+{ TBitmapResourceEntry }
+
+function TBitmapResourceEntry.GetFileSize: int64;
+begin
+  result := sizeof(TBitMapFileHeader)+FDataStream.Size;
+end;
+
+function TBitmapResourceEntry.GetExtension: utf8string;
+begin
+  Result:= 'bmp';
+end;
+
+constructor TBitmapResourceEntry.Create(AContainer: TMultiFileContainer;
+  AEntryNameOrId: TNameOrId; const AResourceInfo: TResourceInfo;
+  ADataStream: TStream);
+begin
+  inherited Create(AContainer, NameOrId(RT_BITMAP), AEntryNameOrId, AResourceInfo, ADataStream);
+end;
+
+function TBitmapResourceEntry.CopyTo(ADestination: TStream): integer;
+var header: PBitMapInfoHeader;
+  fileHeader: TBitMapFileHeader;
+  headerSize: integer;
+  extraSize: integer;
+
+begin
+  result := 0;
+  FDataStream.Position := 0;
+  headerSize := LEtoN(FDataStream.ReadDWord);
+  if (headerSize < 16) or (headerSize > FDataStream.Size) then
+    raise exception.Create('Invalid header size');
+  getmem(header, headerSize);
+  try
+    fillchar(header^, headerSize,0);
+    header^.Size := NtoLE(headerSize);
+    FDataStream.ReadBuffer((PByte(header)+4)^, headerSize-4);
+    if LEtoN(header^.Compression) = BI_BITFIELDS then
+      extraSize := 4*3
+    else if LEtoN(header^.BitCount) in [1,4,8] then
+    begin
+      if header^.ClrUsed > 0 then
+        extraSize := 4*header^.ClrUsed
+      else
+        extraSize := 4*(1 shl header^.BitCount);
+    end else
+      extraSize := 0;
+    fileHeader.bfType:= Word('BM');
+    fileHeader.bfSize := NtoLE(Integer(sizeof(TBitMapFileHeader) + FDataStream.Size));
+    fileHeader.bfReserved:= 0;
+    fileHeader.bfOffset := NtoLE(Integer(sizeof(TBitMapFileHeader) + headerSize + extraSize));
+    ADestination.WriteBuffer(fileHeader, sizeof(fileHeader));
+    result += sizeof(fileHeader);
+    ADestination.WriteBuffer(header^, headerSize);
+    result += headerSize;
+    if FDataStream.Size - headerSize > 0 then
+      result += ADestination.CopyFrom(FDataStream, FDataStream.Size - headerSize);
+  finally
+    freemem(header);
+  end;
+end;
+
+procedure TBitmapResourceEntry.CopyFrom(ASource: TStream);
+var
+  fileHeader: TBitMapFileHeader;
+  dataSize: integer;
+begin
+  ASource.ReadBuffer({%H-}fileHeader, sizeof(fileHeader));
+  if fileHeader.bfType <> Word('BM') then
+    raise exception.Create('Invalid file header');
+  dataSize := LEtoN(fileHeader.bfSize) - sizeof(fileHeader);
+  if ASource.Position + dataSize > ASource.Size then
+    raise exception.Create('Invalid file size');
+
+  FDataStream.Free;
+  FDataStream := TMemoryStream.Create;
+  FDataStream.CopyFrom(ASource, dataSize);
+end;
+
+{ TUnformattedResourceEntry }
+
+function TUnformattedResourceEntry.GetFileSize: int64;
+begin
+  Result:= FDataStream.Size;
+end;
+
+function TUnformattedResourceEntry.GetDataSize: integer;
+begin
+  result := FDataStream.Size;
+end;
+
+procedure TUnformattedResourceEntry.SerializeData(ADestination: TStream);
+begin
+  if FDataStream.Size > 0 then
+  begin
+    FDataStream.Position := 0;
+    ADestination.CopyFrom(FDataStream, FDataStream.Size);
+  end;
+end;
+
+function TUnformattedResourceEntry.GetExtension: utf8string;
+var format: TBGRAImageFormat;
+begin
+  case TypeId of
+  RT_MANIFEST: result := 'manifest';
+  RT_HTML: result := 'html';
+  RT_RCDATA:
+  begin
+    FDataStream.Position:= 0;
+    format := DetectFileFormat(FDataStream);
+    if format = ifUnknown then
+      result := 'dat'
+    else
+      result := SuggestImageExtension(format);
+  end;
+  RT_ANICURSOR: result := 'ani';
+  else
+    if TypeName = 'ANICURSOR' then
+      result := 'ani'
+    else
+      result := '';
+  end;
+end;
+
+constructor TUnformattedResourceEntry.Create(AContainer: TMultiFileContainer;
+  ATypeNameOrId: TNameOrId; AEntryNameOrId: TNameOrId;
+  const AResourceInfo: TResourceInfo; ADataStream: TStream);
+begin
+  inherited Create(AContainer,ATypeNameOrId,AEntryNameOrId,AResourceInfo);
+  FDataStream := ADataStream;
+end;
+
+destructor TUnformattedResourceEntry.Destroy;
+begin
+  FreeAndNil(FDataStream);
+  inherited Destroy;
+end;
+
+function TUnformattedResourceEntry.CopyTo(ADestination: TStream): integer;
+begin
+  if FDataStream.Size > 0 then
+  begin
+    FDataStream.Position := 0;
+    result := ADestination.CopyFrom(FDataStream, FDataStream.Size)
+  end
+  else
+    result := 0;
+end;
+
+{ TResourceInfo }
+
+procedure TResourceInfo.SwapIfNecessary;
+begin
+  DataVersion := LEtoN(DataVersion);
+  MemoryFlags := LEtoN(MemoryFlags);
+  LanguageId := LEtoN(LanguageId);
+  Version := LEtoN(Version);
+  Characteristics := LEtoN(Characteristics);
+end;
+
+{ TCustomResourceEntry }
+
+function TCustomResourceEntry.GetId: integer;
+begin
+  result := FEntryNameOrId.Id;
+end;
+
+function TCustomResourceEntry.GetTypeId: integer;
+begin
+  result := FTypeNameOrId.Id;
+end;
+
+function GetDWord(var ASource: PByte; var ARemainingBytes: Integer): DWord;
+begin
+  if ARemainingBytes >= 4 then
+  begin
+    result := LEtoN(PDWord(ASource)^);
+    inc(ASource, 4);
+    dec(ARemainingBytes, 4);
+  end else
+  begin
+    result := 0;
+    inc(ASource, ARemainingBytes);
+    ARemainingBytes:= 0;
+  end;
+end;
+
+function GetWord(var ASource: PByte; var ARemainingBytes: Integer): Word;
+begin
+  if ARemainingBytes >= 2 then
+  begin
+    result := LEtoN(PWord(ASource)^);
+    inc(ASource, 2);
+    dec(ARemainingBytes, 2);
+  end else
+  begin
+    result := 0;
+    inc(ASource, ARemainingBytes);
+    ARemainingBytes:= 0;
+  end;
+end;
+
+function GetNameOrId(var ASource: PByte; var ARemainingBytes: Integer): TNameOrId;
+var curChar: Word;
+  pstart: PByte;
+begin
+  pstart := ASource;
+  curChar := GetWord(ASource,ARemainingBytes);
+  if curChar = $ffff then
+  begin
+    result.Id := GetWord(ASource,ARemainingBytes);
+    result.Name := IntToStr(result.Id);
+  end else
+  begin
+    while curChar <> 0 do
+      curChar := GetWord(ASource,ARemainingBytes);
+    result.Id := -1;
+    result.Name := UTF8Encode(WideCharLenToString(PWideChar(pstart), (ASource-pstart) div 2 -1));
+  end;
+end;
+
+function TCustomResourceEntry.GetLanguageId: integer;
+begin
+  result := FResourceInfo.LanguageId;
+end;
+
+class function TCustomResourceEntry.GetNextEntry(AContainer: TMultiFileContainer; AStream: TStream): TCustomResourceEntry;
+var
+  entrySize, headerSize, remaining, padding: Integer;
+  headerData: Pointer;
+  pHeaderData: PByte;
+  typeNameOrId: TNameOrId;
+  entryNameOrId: TNameOrId;
+  info: TResourceInfo;
+  dataStream: TMemoryStream;
+  dummy: DWord;
+begin
+  result := nil;
+  if AStream.Position + 16 < AStream.Size then
+  begin
+    entrySize := LEtoN(AStream.ReadDWord);
+    headerSize := LEtoN(AStream.ReadDWord);
+    if headerSize < 16 then
+      raise exception.Create('Header too small');
+    remaining := ((headerSize-8) + 3) and not 3;
+    if AStream.Position + remaining + entrySize > AStream.Size then
+      raise exception.Create('Data would be outside of stream');
+
+    GetMem(headerData, remaining);
+    try
+      AStream.ReadBuffer(headerData^, remaining);
+      pHeaderData := PByte(headerData);
+      typeNameOrId := GetNameOrId(pHeaderData, remaining);
+      entryNameOrId := GetNameOrId(pHeaderData, remaining);
+      padding := (4 - ((pHeaderData-PByte(headerData)) and 3)) and 3;
+      inc(pHeaderData, padding);
+      dec(remaining, padding);
+
+      FillChar({%H-}info, SizeOf(info), 0);
+      Move(pHeaderData^, info, Min(Sizeof(info), remaining));
+      info.SwapIfNecessary;
+
+      dataStream := TMemoryStream.Create;
+      if entrySize > 0 then dataStream.CopyFrom(AStream, entrySize);
+      padding := ((entrySize+3) and not 3) - entrySize;
+      if padding > 0 then AStream.Read({%H-}dummy, padding);
+    finally
+      FreeMem(headerData);
+    end;
+
+    dataStream.Position := 0;
+    case typeNameOrId.Id of
+    RT_BITMAP: result := TBitmapResourceEntry.Create(AContainer,entryNameOrId,info,dataStream);
+    RT_GROUP_ICON: result := TGroupIconEntry.Create(AContainer,entryNameOrId,info,dataStream);
+    RT_GROUP_CURSOR: result := TGroupCursorEntry.Create(AContainer,entryNameOrId,info,dataStream);
+    else
+      result := TUnformattedResourceEntry.Create(AContainer,typeNameOrId,entryNameOrId,info,dataStream);
+    end;
+  end;
+end;
+
+procedure WriteNameOrId(ADestination: TStream; ANameOrId: TNameOrId);
+var buffer: PUnicodeChar;
+  maxLen,actualLen: integer;
+begin
+  if ANameOrId.Id < 0 then
+  begin
+    maxLen := length(ANameOrId.Name)*2 + 1;
+    getmem(buffer, maxLen*sizeof(UnicodeChar));
+    try
+      fillchar(buffer^, maxLen*sizeof(UnicodeChar), 0);
+      actualLen := Utf8ToUnicode(buffer, maxLen, @ANameOrId.Name[1], length(ANameOrId.Name));
+      ADestination.WriteBuffer(buffer^, actualLen*sizeof(UnicodeChar));
+    finally
+      freemem(buffer);
+    end;
+  end else
+  begin
+    ADestination.WriteWord($ffff);
+    ADestination.WriteWord(NtoLE(Word(ANameOrId.Id)));
+  end;
+end;
+
+procedure TCustomResourceEntry.Serialize(ADestination: TStream);
+var zero: DWord;
+  padding: integer;
+begin
+  SerializeHeader(ADestination);
+  SerializeData(ADestination);
+  padding := (4-(GetDataSize and 3)) and 3;
+  if padding > 0 then
+  begin
+    zero := 0;
+    ADestination.WriteBuffer(zero, padding);
+  end;
+end;
+
+procedure TCustomResourceEntry.SetLanguageId(AValue: integer);
+begin
+  if (AValue >= 0) and (AValue <= 65535) then
+  begin
+    if AValue = LanguageId then exit;
+    if FTypeNameOrId.Id >= 0 then
+    begin
+      if TWinResourceContainer(Container).InternalFind(FEntryNameOrId, FTypeNameOrId, AValue) <> nil then
+        raise exception.Create('Language id already used for this resource');
+    end else
+      raise exception.Create('Language id cannot be specified for custom types');
+    FEntryNameOrId.Id := AValue;
+    FEntryNameOrId.Name := IntToStr(AValue);
+  end
+  else
+    raise ERangeError.Create('Id out of bounds');
+end;
+
+procedure TCustomResourceEntry.SerializeHeader(ADestination: TStream);
+var
+  entryHeader: record
+    EntrySize: integer;
+    HeaderSize: integer;
+  end;
+  headerStream: TMemoryStream;
+begin
+  entryHeader.EntrySize := LEtoN(GetDataSize);
+  headerStream := TMemoryStream.Create;
+  WriteNameOrId(headerStream,FTypeNameOrId);
+  WriteNameOrId(headerStream,FEntryNameOrId);
+  if headerStream.Position and 3 = 2 then headerStream.WriteWord(0);
+  FResourceInfo.SwapIfNecessary;
+  try
+    headerStream.WriteBuffer(FResourceInfo, sizeof(FResourceInfo));
+  finally
+    FResourceInfo.SwapIfNecessary;
+  end;
+  entryHeader.HeaderSize := LEtoN(integer(headerStream.Size+8));
+  headerStream.Position:= 0;
+  ADestination.WriteBuffer(entryHeader, sizeof(entryHeader));
+  ADestination.CopyFrom(headerStream, headerStream.Size);
+  if headerStream.Size and 3 = 2 then ADestination.WriteWord(0);
+  headerStream.Free;
+end;
+
+constructor TCustomResourceEntry.Create(AContainer: TMultiFileContainer;
+  ATypeNameOrId: TNameOrId; AEntryNameOrId: TNameOrId;
+  const AResourceInfo: TResourceInfo);
+begin
+  inherited Create(AContainer);
+  FTypeNameOrId := ATypeNameOrId;
+  FEntryNameOrId := AEntryNameOrId;
+  FResourceInfo := AResourceInfo;
+end;
+
+procedure TCustomResourceEntry.SetId(AValue: integer);
+begin
+  if (AValue >= 0) and (AValue <= 65535) then
+  begin
+    if AValue = FEntryNameOrId.Id then exit;
+    if TWinResourceContainer(Container).InternalFind(NameOrId(AValue), FTypeNameOrId, LanguageId) <> nil then
+      raise exception.Create('Id already used for this resource type');
+    FEntryNameOrId.Id := AValue;
+    FEntryNameOrId.Name := IntToStr(AValue);
+  end
+  else
+    raise ERangeError.Create('Id out of bounds');
+end;
+
+function TCustomResourceEntry.GetName: utf8string;
+begin
+  Result:= FEntryNameOrId.Name;
+end;
+
+procedure TCustomResourceEntry.SetName(AValue: utf8string);
+begin
+  if FEntryNameOrId = NameOrId(AValue) then exit;
+  if TWinResourceContainer(Container).InternalFind(NameOrId(AValue), FTypeNameOrId, LanguageId) <> nil then
+      raise exception.Create('Name already used for this resource type');
+  FEntryNameOrId.Name := AValue;
+  FEntryNameOrId.Id := -1;
+end;
+
+function TCustomResourceEntry.GetTypeName: utf8string;
+begin
+  result := FTypeNameOrId.Name;
+end;
+
+procedure TCustomResourceEntry.IncrementReferences;
+begin
+  //nothing
+end;
+
+procedure TCustomResourceEntry.DecrementReferences;
+begin
+  //nothing
+end;
+
+{ TWinResourceContainer }
+
+procedure TWinResourceContainer.LoadFromStream(AStream: TStream);
+var curEntry: TCustomResourceEntry;
+  i: Integer;
+begin
+  Clear;
+  repeat
+    curEntry := TCustomResourceEntry.GetNextEntry(self, AStream);
+    if curEntry <> nil then
+    begin
+      if curEntry.TypeId in [RT_ICON,RT_CURSOR] then
+        FHiddenEntries.Add(curEntry)
+      else
+        AddEntry(curEntry);
+    end;
+  until curEntry = nil;
+  for i := 0 to Count-1 do
+    TCustomResourceEntry(Entry[i]).IncrementReferences;
+end;
+
+function TWinResourceContainer.IndexOf(AName: utf8string; AExtenstion: utf8string; ACaseSensitive: boolean): integer;
+begin
+  result := IndexOf(AName, AExtenstion, 0, ACaseSensitive);
+end;
+
+function TWinResourceContainer.IndexOf(AName: utf8string; AExtenstion: utf8string;
+  ALanguageId: integer; ACaseSensitive: boolean): integer;
+var
+  i: Integer;
+  entryId, errPos: integer;
+begin
+  if AExtenstion = '' then
+  begin
+    result := -1;
+    exit;
+  end;
+  if ACaseSensitive then
+  begin
+    for i := 0 to Count-1 do
+      if (TCustomResourceEntry(Entry[i]).FEntryNameOrId.Id < 0) and
+         (TCustomResourceEntry(Entry[i]).FEntryNameOrId.Name = AName) and
+         (UTF8CompareText(Entry[i].Extension,AExtenstion) = 0) and
+         (TCustomResourceEntry(Entry[i]).LanguageId = ALanguageId) then
+      begin
+        result := i;
+        exit;
+      end;
+  end else
+    for i := 0 to Count-1 do
+      if (TCustomResourceEntry(Entry[i]).FEntryNameOrId.Id < 0) and
+         (UTF8CompareText(TCustomResourceEntry(Entry[i]).FEntryNameOrId.Name,AName) = 0) and
+         (UTF8CompareText(Entry[i].Extension,AExtenstion) = 0) and
+         (TCustomResourceEntry(Entry[i]).LanguageId = ALanguageId) then
+      begin
+        result := i;
+        exit;
+      end;
+  val(AName, entryId, errPos);
+  if (errPos = 0) and (entryId >= 0) then
+  begin
+    for i := 0 to Count-1 do
+      if (TCustomResourceEntry(Entry[i]).FEntryNameOrId.Id = entryId) and
+         (UTF8CompareText(Entry[i].Extension,AExtenstion) = 0) and
+         (TCustomResourceEntry(Entry[i]).LanguageId = ALanguageId) then
+      begin
+        result := i;
+        exit;
+      end;
+  end;
+  result := -1;
+end;
+
+procedure TWinResourceContainer.Init;
+begin
+  inherited Init;
+  FHiddenEntries := TMultiFileEntryList.Create;
+end;
+
+procedure TWinResourceContainer.ClearHiddenEntries;
+var i: integer;
+begin
+  if Assigned(FHiddenEntries) then
+  begin
+    for i := 0 to FHiddenEntries.Count-1 do
+      FHiddenEntries[i].Free;
+    FHiddenEntries.Clear;
+  end;
+end;
+
+procedure TWinResourceContainer.RemoveHidden(AEntry: TCustomResourceEntry);
+var
+  index: LongInt;
+begin
+  if Assigned(FHiddenEntries) then
+  begin
+    index := FHiddenEntries.IndexOf(AEntry);
+    if index <> -1 then
+    begin
+      AEntry.Free;
+      FHiddenEntries.Delete(index);
+    end;
+  end;
+end;
+
+function TWinResourceContainer.CreateEntry(AName: utf8string; AExtension: utf8string;
+  AContent: TStream; ALanguageId: integer): TMultiFileEntry;
+var
+  resourceInfo: TResourceInfo;
+  entryName: TNameOrId;
+  errPos: integer;
+begin
+  FillChar({%H-}resourceInfo, sizeof(resourceInfo), 0);
+  resourceInfo.LanguageId := ALanguageId;
+  val(AName, entryName.Id, errPos);
+  if (errPos = 0) and (entryName.Id >= 0) then
+    entryName.Name := IntToStr(entryName.Id)
+  else
+  begin
+    entryName.Id := -1;
+    entryName.Name := AName;
+  end;
+
+  case UTF8LowerCase(AExtension) of
+  'ico': begin
+           result := TGroupIconEntry.Create(self, entryName, resourceInfo);
+           TGroupIconEntry(result).CopyFrom(AContent);
+         end;
+  'cur': begin
+           result := TGroupCursorEntry.Create(self, entryName, resourceInfo);
+           TGroupCursorEntry(result).CopyFrom(AContent);
+         end;
+  'bmp': begin
+           result := TBitmapResourceEntry.Create(self, entryName, resourceInfo, AContent);
+           TBitmapResourceEntry(result).CopyFrom(AContent);
+         end;
+  'dat': result := TUnformattedResourceEntry.Create(self, NameOrId(RT_RCDATA), entryName, resourceInfo, AContent);
+  'html','htm': result := TUnformattedResourceEntry.Create(self, NameOrId(RT_HTML), entryName, resourceInfo, AContent);
+  'manifest': result := TUnformattedResourceEntry.Create(self, NameOrId(RT_MANIFEST), entryName, resourceInfo, AContent);
+  'ani': result := TUnformattedResourceEntry.Create(self, NameOrId(RT_ANICURSOR), entryName, resourceInfo, AContent);
+  else
+    case SuggestImageFormat('.'+AExtension) of
+    ifUnknown: raise exception.Create('Unhandled file extension');
+    else
+      result := TUnformattedResourceEntry.Create(self, NameOrId(RT_RCDATA), entryName, resourceInfo, AContent);
+    end;
+  end;
+end;
+
+function TWinResourceContainer.CreateEntry(AName: utf8string; AExtension: utf8string;
+  AContent: TStream): TMultiFileEntry;
+begin
+  result := CreateEntry(AName, AExtension, AContent, 0);
+end;
+
+procedure TWinResourceContainer.Clear;
+begin
+  ClearHiddenEntries;
+  inherited Clear;
+end;
+
+destructor TWinResourceContainer.Destroy;
+begin
+  ClearHiddenEntries;
+  FreeAndNil(FHiddenEntries);
+  inherited Destroy;
+end;
+
+procedure TWinResourceContainer.Delete(AIndex: integer);
+begin
+  if (AIndex >= 0) and (AIndex < Count) then
+    TCustomResourceEntry(Entry[AIndex]).DecrementReferences;
+  inherited Delete(AIndex);
+end;
+
+procedure TWinResourceContainer.SaveToStream(ADestination: TStream);
+var
+  i: Integer;
+begin
+  for i := 0 to Count-1 do
+    TCustomResourceEntry(Entry[i]).Serialize(ADestination);
+  for i := 0 to FHiddenEntries.Count-1 do
+    TCustomResourceEntry(FHiddenEntries.Items[i]).Serialize(ADestination);
+end;
+
+function TWinResourceContainer.InternalFind(const AEntry: TNameOrId;
+  const AType: TNameOrId; ALanguageId: integer): TCustomResourceEntry;
+var i: integer;
+begin
+  if Assigned(FHiddenEntries) and (ALanguageId = 0) and (AType.Id >= 0) then
+  begin
+    for i := 0 to FHiddenEntries.Count-1 do
+      if (TCustomResourceEntry(FHiddenEntries.Items[i]).FEntryNameOrId = AEntry) and
+         (TCustomResourceEntry(FHiddenEntries.Items[i]).FTypeNameOrId = AType) then
+      begin
+        result := TCustomResourceEntry(FHiddenEntries.Items[i]);
+        exit;
+      end;
+  end;
+  for i := 0 to Count-1 do
+    if (TCustomResourceEntry(Entry[i]).FEntryNameOrId = AEntry) and
+       (TCustomResourceEntry(Entry[i]).FTypeNameOrId = AType) and
+       (TCustomResourceEntry(Entry[i]).LanguageId = ALanguageId) then
+    begin
+      result := TCustomResourceEntry(Entry[i]);
+      exit;
+    end;
+  result := nil;
+end;
+
+procedure TWinResourceContainer.AddHidden(AEntry: TCustomResourceEntry);
+begin
+  FHiddenEntries.Add(AEntry);
+end;
+
+function TWinResourceContainer.GetMaxId(AType: TNameOrId): integer;
+var i: integer;
+begin
+  result := 0;
+  if Assigned(FHiddenEntries) and (AType.Id >= 0) then
+  begin
+    for i := 0 to FHiddenEntries.Count-1 do
+      if (TCustomResourceEntry(FHiddenEntries.Items[i]).FTypeNameOrId = AType) then
+      begin
+        if TCustomResourceEntry(FHiddenEntries.Items[i]).Id > result then result := TCustomResourceEntry(FHiddenEntries.Items[i]).Id;
+      end;
+  end;
+  for i := 0 to Count-1 do
+    if (TCustomResourceEntry(Entry[i]).FTypeNameOrId = AType) then
+    begin
+      if TCustomResourceEntry(Entry[i]).Id > result then result := TCustomResourceEntry(Entry[i]).Id;
+    end;
+end;
+
+procedure TWinResourceContainer.IncrementReferenceOf(ANameId, ATypeId: integer);
+var
+  item: TCustomResourceEntry;
+begin
+  item := InternalFind(NameOrId(ANameId), NameOrId(ATypeId));
+  if Assigned(item) then inc(item.FReferenceCount);
+end;
+
+procedure TWinResourceContainer.DecrementReferenceOf(ANameId, ATypeId: integer);
+var
+  item: TCustomResourceEntry;
+begin
+  item := InternalFind(NameOrId(ANameId), NameOrId(ATypeId));
+  if Assigned(item) then
+  begin
+    if item.FReferenceCount > 1 then
+      dec(item.FReferenceCount)
+    else
+      RemoveHidden(item);
+  end;
+end;
+
+end.
+


### PR DESCRIPTION
Support for ICO and CUR formats : 
- added BGRAIconCursor unit to read, modify and create files with different icon sizes
- handling XOR mask (loaded in the XorMask property of TBGRABitmap)
- improved thumbnails to display Xor mask and cursor hotspot

Compilation fix for Lazarus 1.7

OpenGL :
- fixes for GL shading language
- added framebuffers (TBGLFrameBuffer class and BGLCanvas.ActiveFrameBuffer property)
- added GetImage to retrieve bitmap from OpenGL surface
- added FilterBlurRadial and FilterBlurMotion to OpenGL textures

SVG : memory leak and crash fix