### PR TITLE
Dev bgrabitmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.dbg
 *.exe
 *.lps
-backup/*
+backup
 lib
 debug
 *.res

--- a/bgrabitmap/bgrabitmappack.lpk
+++ b/bgrabitmap/bgrabitmappack.lpk
@@ -29,7 +29,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="9" Minor="7" Release="4"/>
+    <Version Major="9" Minor="8"/>
     <Files Count="113">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack.lpk
+++ b/bgrabitmap/bgrabitmappack.lpk
@@ -29,7 +29,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="9" Minor="7" Release="3"/>
+    <Version Major="9" Minor="7" Release="4"/>
     <Files Count="112">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack.lpk
+++ b/bgrabitmap/bgrabitmappack.lpk
@@ -30,7 +30,7 @@
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
     <Version Major="9" Minor="7" Release="4"/>
-    <Files Count="112">
+    <Files Count="113">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>
         <UnitName Value="BGRAAnimatedGif"/>
@@ -479,6 +479,10 @@
         <Filename Value="bgralazpaint.pas"/>
         <UnitName Value="BGRALazPaint"/>
       </Item112>
+      <Item113>
+        <Filename Value="bgramemdirectory.pas"/>
+        <UnitName Value="BGRAMemDirectory"/>
+      </Item113>
     </Files>
     <RequiredPkgs Count="2">
       <Item1>

--- a/bgrabitmap/bgrabitmappack.pas
+++ b/bgrabitmap/bgrabitmappack.pas
@@ -25,7 +25,7 @@ uses
   BGRAWriteBmpMioMap, BGRAOpenGLType, BGRASpriteGL, BGRAOpenGL, BGRACanvasGL, 
   BGRAFontGL, BGRAOpenGL3D, BGRAPhoxo, BGRAFilterScanner, BGRAFilterType, 
   BGRAFilterBlur, BGRAMultiFileType, BGRAWinResource, BGRALazResource, 
-  BGRAIconCursor, BGRABlurGL, BGRAReadTiff, BGRALazPaint;
+  BGRAIconCursor, BGRABlurGL, BGRAReadTiff, BGRALazPaint, BGRAMemDirectory;
 
 implementation
 

--- a/bgrabitmap/bgrabitmappack4fpgui.lpk
+++ b/bgrabitmap/bgrabitmappack4fpgui.lpk
@@ -33,7 +33,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="9" Minor="7" Release="3"/>
+    <Version Major="9" Minor="7" Release="4"/>
     <Files Count="96">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack4fpgui.lpk
+++ b/bgrabitmap/bgrabitmappack4fpgui.lpk
@@ -33,7 +33,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="9" Minor="7" Release="4"/>
+    <Version Major="9" Minor="8"/>
     <Files Count="96">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack4nogui.lpk
+++ b/bgrabitmap/bgrabitmappack4nogui.lpk
@@ -35,7 +35,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="9" Minor="7" Release="3"/>
+    <Version Major="9" Minor="7" Release="4"/>
     <Files Count="100">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack4nogui.lpk
+++ b/bgrabitmap/bgrabitmappack4nogui.lpk
@@ -35,7 +35,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="9" Minor="7" Release="4"/>
+    <Version Major="9" Minor="8"/>
     <Files Count="100">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmaptypes.pas
+++ b/bgrabitmap/bgrabitmaptypes.pas
@@ -299,13 +299,13 @@ type
         If align is taCenter, (''x'',''y'') is at the top and middle of the text.
         If align is taRightJustify, (''x'',''y'') is the top-right corner.
         The value of ''FontOrientation'' is taken into account, so that the text may be rotated }
-    procedure TextOut(ADest: TBGRACustomBitmap; x, y: single; sUTF8: string; c: TBGRAPixel; align: TAlignment); virtual; abstract;
-    procedure TextOut(ADest: TBGRACustomBitmap; x, y: single; sUTF8: string; c: TBGRAPixel; align: TAlignment; {%H-}ARightToLeft: boolean); virtual;
+    procedure TextOut(ADest: TBGRACustomBitmap; x, y: single; sUTF8: string; c: TBGRAPixel; align: TAlignment); virtual; abstract; overload;
+    procedure TextOut(ADest: TBGRACustomBitmap; x, y: single; sUTF8: string; c: TBGRAPixel; align: TAlignment; {%H-}ARightToLeft: boolean); virtual; overload;
 
     {** Same as above functions, except that the text is filled using texture.
         The value of ''FontOrientation'' is taken into account, so that the text may be rotated }
-    procedure TextOut(ADest: TBGRACustomBitmap; x, y: single; sUTF8: string; texture: IBGRAScanner; align: TAlignment); virtual; abstract;
-    procedure TextOut(ADest: TBGRACustomBitmap; x, y: single; sUTF8: string; texture: IBGRAScanner; align: TAlignment; {%H-}ARightToLeft: boolean); virtual;
+    procedure TextOut(ADest: TBGRACustomBitmap; x, y: single; sUTF8: string; texture: IBGRAScanner; align: TAlignment); virtual; abstract; overload;
+    procedure TextOut(ADest: TBGRACustomBitmap; x, y: single; sUTF8: string; texture: IBGRAScanner; align: TAlignment; {%H-}ARightToLeft: boolean); virtual; overload;
 
     {** Same as above, except that the orientation is specified, overriding the value of the property ''FontOrientation'' }
     procedure TextOutAngle(ADest: TBGRACustomBitmap; x, y: single; orientationTenthDegCCW: integer; sUTF8: string; c: TBGRAPixel; align: TAlignment); virtual; abstract;

--- a/bgrabitmap/bgrablend.pas
+++ b/bgrabitmap/bgrablend.pas
@@ -697,27 +697,18 @@ end;
 
 procedure DrawPixelInlineWithAlphaCheck(dest: PBGRAPixel; const c: TBGRAPixel);
 begin
-  if c.alpha = 0 then
-    exit;
-  if c.alpha = 255 then
-  begin
-    dest^ := c;
-    exit;
+  case c.alpha of
+  0: ;
+  255: dest^ := c;
+  else
+    DrawPixelInlineNoAlphaCheck(dest,c);
   end;
-  DrawPixelInlineNoAlphaCheck(dest,c);
 end;
 
 procedure DrawPixelInlineWithAlphaCheck(dest: PBGRAPixel; c: TBGRAPixel; appliedOpacity: byte);
 begin
   c.alpha := ApplyOpacity(c.alpha,appliedOpacity);
-  if c.alpha = 0 then
-    exit;
-  if c.alpha = 255 then
-  begin
-    dest^ := c;
-    exit;
-  end;
-  DrawPixelInlineNoAlphaCheck(dest,c);
+  DrawPixelInlineWithAlphaCheck(dest, c);
 end;
 
 procedure CopyPixelsWithOpacity(dest, src: PBGRAPixel; opacity: byte;
@@ -747,95 +738,132 @@ var
   calpha: byte;
 begin
   calpha := ec.alpha shr 8;
-  if calpha = 0 then
-    exit;
-  if calpha = 255 then
-  begin
-    dest^ := GammaCompression(ec);
-    exit;
+  case calpha of
+  0: ;
+  255: dest^ := GammaCompression(ec);
+  else
+    DrawExpandedPixelInlineNoAlphaCheck(dest,ec,calpha);
   end;
-  DrawExpandedPixelInlineNoAlphaCheck(dest,ec,calpha);
 end;
 
 procedure DrawPixelInlineExpandedOrNotWithAlphaCheck(dest: PBGRAPixel; const ec: TExpandedPixel; c: TBGRAPixel);
 begin
-  if c.alpha = 0 then
-    exit;
-  if c.alpha = 255 then
-  begin
-    dest^ := c;
-    exit;
+  case c.alpha of
+  0: ;
+  255: dest^ := c;
+  else
+    DrawExpandedPixelInlineNoAlphaCheck(dest,ec,c.alpha);
   end;
-  DrawExpandedPixelInlineNoAlphaCheck(dest,ec,c.alpha);
 end;
 
 procedure DrawPixelInlineNoAlphaCheck(dest: PBGRAPixel; const c: TBGRAPixel);
 var
-  a1f, a2f, a12, a12m: cardinal;
+  a1f, a2f, a12, a12m, alphaCorr: NativeUInt;
 begin
-  {$HINTS OFF}
-  a12  := 65025 - (not dest^.alpha) * (not c.alpha);
-  {$HINTS ON}
-  a12m := a12 shr 1;
+  case dest^.alpha of
+    0: dest^ := c;
+    255:
+      begin
+        alphaCorr := c.alpha;
+        if alphaCorr >= 128 then alphaCorr += 1;
+        dest^.red := GammaCompressionTab[(GammaExpansionTab[dest^.red] * NativeUInt(256-alphaCorr) + GammaExpansionTab[c.red]*alphaCorr) shr 8];
+        dest^.green := GammaCompressionTab[(GammaExpansionTab[dest^.green] * NativeUInt(256-alphaCorr) + GammaExpansionTab[c.green]*alphaCorr) shr 8];
+        dest^.blue := GammaCompressionTab[(GammaExpansionTab[dest^.blue] * NativeUInt(256-alphaCorr) + GammaExpansionTab[c.blue]*alphaCorr) shr 8];
+      end;
+    else
+    begin
+      {$HINTS OFF}
+      a12  := 65025 - (not dest^.alpha) * (not c.alpha);
+      {$HINTS ON}
+      a12m := a12 shr 1;
 
-  a1f := dest^.alpha * (not c.alpha);
-  a2f := (c.alpha shl 8) - c.alpha;
+      a1f := dest^.alpha * (not c.alpha);
+      a2f := (c.alpha shl 8) - c.alpha;
 
-  PDWord(dest)^ := ((GammaCompressionTab[(GammaExpansionTab[dest^.red] * a1f +
-                     GammaExpansionTab[c.red] * a2f + a12m) div a12]) shl TBGRAPixel_RedShift) or
-                   ((GammaCompressionTab[(GammaExpansionTab[dest^.green] * a1f +
-                     GammaExpansionTab[c.green] * a2f + a12m) div a12]) shl TBGRAPixel_GreenShift) or
-                   ((GammaCompressionTab[(GammaExpansionTab[dest^.blue] * a1f +
-                     GammaExpansionTab[c.blue] * a2f + a12m) div a12]) shl TBGRAPixel_BlueShift) or
-                   (((a12 + a12 shr 7) shr 8) shl TBGRAPixel_AlphaShift);
+      PDWord(dest)^ := ((GammaCompressionTab[(GammaExpansionTab[dest^.red] * a1f +
+                         GammaExpansionTab[c.red] * a2f + a12m) div a12]) shl TBGRAPixel_RedShift) or
+                       ((GammaCompressionTab[(GammaExpansionTab[dest^.green] * a1f +
+                         GammaExpansionTab[c.green] * a2f + a12m) div a12]) shl TBGRAPixel_GreenShift) or
+                       ((GammaCompressionTab[(GammaExpansionTab[dest^.blue] * a1f +
+                         GammaExpansionTab[c.blue] * a2f + a12m) div a12]) shl TBGRAPixel_BlueShift) or
+                       (((a12 + a12 shr 7) shr 8) shl TBGRAPixel_AlphaShift);
+    end;
+  end;
 end;
 
 procedure DrawExpandedPixelInlineNoAlphaCheck(dest: PBGRAPixel;
   const ec: TExpandedPixel; calpha: byte);
 var
-  a1f, a2f, a12, a12m: cardinal;
+  a1f, a2f, a12, a12m, alphaCorr: NativeUInt;
 begin
-  {$HINTS OFF}
-  a12  := 65025 - (not dest^.alpha) * (not calpha);
-  {$HINTS ON}
-  a12m := a12 shr 1;
+  case dest^.alpha of
+    0: dest^ := GammaCompression(ec);
+    255:
+      begin
+        alphaCorr := calpha;
+        if alphaCorr >= 128 then alphaCorr += 1;
+        dest^.red := GammaCompressionTab[(GammaExpansionTab[dest^.red] * NativeUInt(256-alphaCorr) + ec.red*alphaCorr) shr 8];
+        dest^.green := GammaCompressionTab[(GammaExpansionTab[dest^.green] * NativeUInt(256-alphaCorr) + ec.green*alphaCorr) shr 8];
+        dest^.blue := GammaCompressionTab[(GammaExpansionTab[dest^.blue] * NativeUInt(256-alphaCorr) + ec.blue*alphaCorr) shr 8];
+      end;
+    else
+    begin
+      {$HINTS OFF}
+      a12  := 65025 - (not dest^.alpha) * (not calpha);
+      {$HINTS ON}
+      a12m := a12 shr 1;
 
-  a1f := dest^.alpha * (not calpha);
-  a2f := (calpha shl 8) - calpha;
+      a1f := dest^.alpha * (not calpha);
+      a2f := (calpha shl 8) - calpha;
 
-  PDWord(dest)^ := ((GammaCompressionTab[(GammaExpansionTab[dest^.red] * a1f +
-                     ec.red * a2f + a12m) div a12]) shl TBGRAPixel_RedShift) or
-                   ((GammaCompressionTab[(GammaExpansionTab[dest^.green] * a1f +
-                     ec.green * a2f + a12m) div a12]) shl TBGRAPixel_GreenShift) or
-                   ((GammaCompressionTab[(GammaExpansionTab[dest^.blue] * a1f +
-                     ec.blue * a2f + a12m) div a12]) shl TBGRAPixel_BlueShift) or
-                   (((a12 + a12 shr 7) shr 8) shl TBGRAPixel_AlphaShift);
+      PDWord(dest)^ := ((GammaCompressionTab[(GammaExpansionTab[dest^.red] * a1f +
+                         ec.red * a2f + a12m) div a12]) shl TBGRAPixel_RedShift) or
+                       ((GammaCompressionTab[(GammaExpansionTab[dest^.green] * a1f +
+                         ec.green * a2f + a12m) div a12]) shl TBGRAPixel_GreenShift) or
+                       ((GammaCompressionTab[(GammaExpansionTab[dest^.blue] * a1f +
+                         ec.blue * a2f + a12m) div a12]) shl TBGRAPixel_BlueShift) or
+                       (((a12 + a12 shr 7) shr 8) shl TBGRAPixel_AlphaShift);
+    end;
+  end;
 end;
 
 procedure FastBlendPixelInline(dest: PBGRAPixel; const c: TBGRAPixel);
 var
-  a1f, a2f, a12, a12m: cardinal;
+  a1f, a2f, a12, a12m, alphaCorr: NativeUInt;
 begin
-  if c.alpha = 0 then
-    exit;
-  if c.alpha = 255 then
-  begin
-    dest^ := c;
-    exit;
+  case c.alpha of
+    0: ;
+    255: dest^ := c;
+    else
+    begin
+      case dest^.alpha of
+        0: dest^ := c;
+        255:
+        begin
+          alphaCorr := c.alpha;
+          if alphaCorr >= 128 then alphaCorr += 1;
+          dest^.red := (dest^.red * NativeUInt(256-alphaCorr) + c.red*(alphaCorr+1)) shr 8;
+          dest^.green := (dest^.green * NativeUInt(256-alphaCorr) + c.green*(alphaCorr+1)) shr 8;
+          dest^.blue := (dest^.blue * NativeUInt(256-alphaCorr) + c.blue*(alphaCorr+1)) shr 8;
+        end;
+        else
+        begin
+          {$HINTS OFF}
+          a12  := 65025 - (not dest^.alpha) * (not c.alpha);
+          {$HINTS ON}
+          a12m := a12 shr 1;
+
+          a1f := dest^.alpha * (not c.alpha);
+          a2f := (c.alpha shl 8) - c.alpha;
+
+          PDWord(dest)^ := (((dest^.red * a1f + c.red * a2f + a12m) div a12) shl TBGRAPixel_RedShift) or
+                           (((dest^.green * a1f + c.green * a2f + a12m) div a12) shl TBGRAPixel_GreenShift) or
+                           (((dest^.blue * a1f + c.blue * a2f + a12m) div a12) shl TBGRAPixel_BlueShift) or
+                           (((a12 + a12 shr 7) shr 8) shl TBGRAPixel_AlphaShift);
+        end;
+      end;
+    end;
   end;
-
-  {$HINTS OFF}
-  a12  := 65025 - (not dest^.alpha) * (not c.alpha);
-  {$HINTS ON}
-  a12m := a12 shr 1;
-
-  a1f := dest^.alpha * (not c.alpha);
-  a2f := (c.alpha shl 8) - c.alpha;
-
-  PDWord(dest)^ := (((dest^.red * a1f + c.red * a2f + a12m) div a12) shl TBGRAPixel_RedShift) or
-                   (((dest^.green * a1f + c.green * a2f + a12m) div a12) shl TBGRAPixel_GreenShift) or
-                   (((dest^.blue * a1f + c.blue * a2f + a12m) div a12) shl TBGRAPixel_BlueShift) or
-                   (((a12 + a12 shr 7) shr 8) shl TBGRAPixel_AlphaShift);
 end;
 
 procedure FastBlendPixelInline(dest: PBGRAPixel; c: TBGRAPixel;

--- a/bgrabitmap/bgrablend.pas
+++ b/bgrabitmap/bgrablend.pas
@@ -797,7 +797,12 @@ var
   a1f, a2f, a12, a12m, alphaCorr: NativeUInt;
 begin
   case dest^.alpha of
-    0: dest^ := GammaCompression(ec);
+    0: begin
+         dest^.red := GammaCompressionTab[ec.red];
+         dest^.green := GammaCompressionTab[ec.green];
+         dest^.blue := GammaCompressionTab[ec.blue];
+         dest^.alpha := calpha;
+      end;
     255:
       begin
         alphaCorr := calpha;

--- a/bgrabitmap/bgracanvas.pas
+++ b/bgrabitmap/bgracanvas.pas
@@ -187,7 +187,8 @@ type
     procedure PolyBezier(const Points: array of TPoint;
                          Filled: boolean = False;
                          Continuous: boolean = False);
-    procedure Draw(X,Y: Integer; SrcBitmap: TBGRACustomBitmap);
+    procedure Draw(X,Y: Integer; SrcBitmap: TBGRACustomBitmap); overload;
+    procedure Draw(X,Y: Integer; SrcBitmap: TBitmap); overload;
     procedure CopyRect(X,Y: Integer; SrcBitmap: TBGRACustomBitmap; SrcRect: TRect);
     procedure StretchDraw(DestRect: TRect; SrcBitmap: TBGRACustomBitmap; HorizFlip: Boolean = false; VertFlip: Boolean = false);
     procedure DrawFocusRect(bounds: TRect);
@@ -1426,6 +1427,11 @@ begin
 end;
 
 procedure TBGRACanvas.Draw(X, Y: Integer; SrcBitmap: TBGRACustomBitmap);
+begin
+  FBitmap.PutImage(X,Y,SrcBitmap,dmDrawWithTransparency);
+end;
+
+procedure TBGRACanvas.Draw(X, Y: Integer; SrcBitmap: TBitmap);
 begin
   FBitmap.PutImage(X,Y,SrcBitmap,dmDrawWithTransparency);
 end;

--- a/bgrabitmap/bgracanvasgl.pas
+++ b/bgrabitmap/bgracanvasgl.pas
@@ -1749,13 +1749,17 @@ end;
 procedure TBGLCustomCanvas.PutImageAffine(const Origin, HAxis, VAxis: TPointF;
   ATexture: IBGLTexture; AAlpha: byte);
 begin
+  {$PUSH}{$OPTIMIZATION OFF}
   ATexture.DrawAffine(Origin, HAxis, VAxis, AAlpha);
+  {$POP}
 end;
 
 procedure TBGLCustomCanvas.PutImageAffine(const Origin, HAxis, VAxis: TPointF;
   ATexture: IBGLTexture; AColor: TBGRAPixel);
 begin
+  {$PUSH}{$OPTIMIZATION OFF}
   ATexture.DrawAffine(Origin, HAxis, VAxis, AColor);
+  {$POP}
 end;
 
 procedure TBGLCustomCanvas.PutImageAffine(x, y: single; ATexture: IBGLTexture;

--- a/bgrabitmap/bgracustombitmap.inc
+++ b/bgrabitmap/bgracustombitmap.inc
@@ -720,7 +720,7 @@ type
      {Canvas drawing functions}
      procedure DataDrawTransparent(ACanvas: TCanvas; Rect: TRect;
        AData: Pointer; ALineOrder: TRawImageLineOrder; AWidth, AHeight: integer); virtual; abstract;
-     procedure DataDrawOpaque(ACanvas: TCanvas; Rect: TRect; AData: Pointer;
+     procedure DataDrawOpaque(ACanvas: TCanvas; ARect: TRect; AData: Pointer;
        ALineOrder: TRawImageLineOrder; AWidth, AHeight: integer); virtual; abstract;
      procedure GetImageFromCanvas(CanvasSource: TCanvas; x, y: integer); virtual; abstract;
      procedure Draw(ACanvas: TCanvas; x, y: integer; Opaque: boolean = True); virtual; abstract;

--- a/bgrabitmap/bgracustombitmap.inc
+++ b/bgrabitmap/bgracustombitmap.inc
@@ -734,7 +734,8 @@ type
      {BGRA bitmap functions}
      procedure CrossFade(ARect: TRect; Source1, Source2: IBGRAScanner; AFadePosition: byte; mode: TDrawMode = dmDrawWithTransparency); virtual; abstract;
      procedure CrossFade(ARect: TRect; Source1, Source2: IBGRAScanner; AFadeMask: IBGRAScanner; mode: TDrawMode = dmDrawWithTransparency); virtual; abstract;
-     procedure PutImage(x, y: integer; Source: TBGRACustomBitmap; mode: TDrawMode; AOpacity: byte = 255); virtual; abstract;
+     procedure PutImage(x, y: integer; Source: TBGRACustomBitmap; mode: TDrawMode; AOpacity: byte = 255); virtual; abstract; overload;
+     procedure PutImage(x, y: integer; Source: TBitmap; mode: TDrawMode; AOpacity: byte = 255); overload;
      procedure StretchPutImage(ARect: TRect; Source: TBGRACustomBitmap; mode: TDrawMode; AOpacity: byte = 255); virtual; abstract;
      procedure PutImageSubpixel(x, y: single; Source: TBGRACustomBitmap; AOpacity: byte = 255);
      procedure PutImagePart(x,y: integer; Source: TBGRACustomBitmap; SourceRect: TRect; mode: TDrawMode; AOpacity: byte = 255);
@@ -1923,6 +1924,15 @@ begin
       partial.Free;
     end;
   end;
+end;
+
+procedure TBGRACustomBitmap.PutImage(x, y: integer; Source: TBitmap;
+  mode: TDrawMode; AOpacity: byte);
+var bgra: TBGRACustomBitmap;
+begin
+  bgra := BGRABitmapFactory.create(Source);
+  PutImage(x,y, bgra, mode, AOpacity);
+  bgra.free;
 end;
 
 procedure TBGRACustomBitmap.PutImageSubpixel(x, y: single; Source: TBGRACustomBitmap; AOpacity: byte);

--- a/bgrabitmap/bgracustombitmap.inc
+++ b/bgrabitmap/bgracustombitmap.inc
@@ -1912,11 +1912,16 @@ procedure TBGRACustomBitmap.DrawPart(ARect: TRect; ACanvas: TCanvas; x,
 var
   partial: TBGRACustomBitmap;
 begin
-  partial := GetPart(ARect);
-  if partial <> nil then
+  if (ARect.Left = 0) and (ARect.Top = 0) and (ARect.Right = Width) and (ARect.Bottom = Height) then
+    Draw(ACanvas, x,y, Opaque)
+  else
   begin
-    partial.Draw(ACanvas, x, y, Opaque);
-    partial.Free;
+    partial := GetPart(ARect);
+    if partial <> nil then
+    begin
+      partial.Draw(ACanvas, x, y, Opaque);
+      partial.Free;
+    end;
   end;
 end;
 

--- a/bgrabitmap/bgradefaultbitmap.pas
+++ b/bgrabitmap/bgradefaultbitmap.pas
@@ -378,21 +378,21 @@ type
         is out of bounds, the image is repeated.
       * ''AResampleFilter'' specifies how pixels must be interpolated. Accepted
         values are ''rfBox'', ''rfLinear'', ''rfHalfCosine'' and ''rfCosine'' }
-    function GetPixelCycle(x, y: single; AResampleFilter: TResampleFilter = rfLinear): TBGRAPixel; override;
+    function GetPixelCycle(x, y: single; AResampleFilter: TResampleFilter = rfLinear): TBGRAPixel; override; overload;
     {** Similar to previous ''GetPixel'' function, but the fractional part of
         the coordinate is supplied with a number from 0 to 255. The actual
         coordinate is (''x'' + ''fracX256''/256, ''y'' + ''fracY256''/256) }
-    function GetPixelCycle256(x, y, fracX256,fracY256: int32or64; AResampleFilter: TResampleFilter = rfLinear): TBGRAPixel; override;
+    function GetPixelCycle256(x, y, fracX256,fracY256: int32or64; AResampleFilter: TResampleFilter = rfLinear): TBGRAPixel; override; overload;
     {** Computes the value of the pixel at a floating point coordiante
         by interpolating the values of the pixels around it. ''repeatX'' and
         ''repeatY'' specifies if the image is to be repeated or not.
       * ''AResampleFilter'' specifies how pixels must be interpolated. Accepted
         values are ''rfBox'', ''rfLinear'', ''rfHalfCosine'' and ''rfCosine'' }
-    function GetPixelCycle(x, y: single; AResampleFilter: TResampleFilter; repeatX: boolean; repeatY: boolean): TBGRAPixel; override;
+    function GetPixelCycle(x, y: single; AResampleFilter: TResampleFilter; repeatX: boolean; repeatY: boolean): TBGRAPixel; override; overload;
     {** Similar to previous ''GetPixel'' function, but the fractional part of
         the coordinate is supplied with a number from 0 to 255. The actual
         coordinate is (''x'' + ''fracX256''/256, ''y'' + ''fracY256''/256) }
-    function GetPixelCycle256(x, y, fracX256,fracY256: int32or64; AResampleFilter: TResampleFilter; repeatX: boolean; repeatY: boolean): TBGRAPixel; override;
+    function GetPixelCycle256(x, y, fracX256,fracY256: int32or64; AResampleFilter: TResampleFilter; repeatX: boolean; repeatY: boolean): TBGRAPixel; override; overload;
 
     {==== Drawing lines and polylines (integer coordinates) ====}
     {* These functions do not take into account current pen style/cap/join.

--- a/bgrabitmap/bgradefaultbitmap.pas
+++ b/bgrabitmap/bgradefaultbitmap.pas
@@ -948,7 +948,10 @@ end;
 procedure TBitmapTracker.Changed(Sender: TObject);
 begin
   if FUser <> nil then
+  begin
     FUser.FBitmapModified := True;
+    FUser.FAlphaCorrectionNeeded := true;
+  end;
   inherited Changed(Sender);
 end;
 
@@ -2038,7 +2041,12 @@ end;
 
 function TBGRADefaultBitmap.GetCanvas: TCanvas;
 begin
-  Result := Bitmap.Canvas;
+  if FDataModified or (FBitmap = nil) then
+  begin
+    RebuildBitmap;
+    FDataModified := False;
+  end;
+  Result := FBitmap.Canvas;
 end;
 
 function TBGRADefaultBitmap.GetCanvasFP: TFPImageCanvas;

--- a/bgrabitmap/bgradefaultbitmap.pas
+++ b/bgrabitmap/bgradefaultbitmap.pas
@@ -1091,12 +1091,16 @@ end;
 
 procedure TBGRADefaultBitmap.SetArrowEndSize(AValue: TPointF);
 begin
+  {$PUSH}{$OPTIMIZATION OFF}
   GetArrow.EndSize := AValue;
+  {$POP}
 end;
 
 procedure TBGRADefaultBitmap.SetArrowStartSize(AValue: TPointF);
 begin
+  {$PUSH}{$OPTIMIZATION OFF}
   GetArrow.StartSize := AValue;
+  {$POP}
 end;
 
 function TBGRADefaultBitmap.GetArrowEndOffset: single;

--- a/bgrabitmap/bgradefaultbitmap.pas
+++ b/bgrabitmap/bgradefaultbitmap.pas
@@ -795,7 +795,7 @@ type
     {BGRA bitmap functions}
     procedure CrossFade(ARect: TRect; Source1, Source2: IBGRAScanner; AFadePosition: byte; mode: TDrawMode = dmDrawWithTransparency); override;
     procedure CrossFade(ARect: TRect; Source1, Source2: IBGRAScanner; AFadeMask: IBGRAScanner; mode: TDrawMode = dmDrawWithTransparency); override;
-    procedure PutImage(x, y: integer; Source: TBGRACustomBitmap; mode: TDrawMode; AOpacity: byte = 255); override;
+    procedure PutImage(x, y: integer; Source: TBGRACustomBitmap; mode: TDrawMode; AOpacity: byte = 255); override; overload;
     procedure PutImageAffine(AMatrix: TAffineMatrix; Source: TBGRACustomBitmap; AOutputBounds: TRect; AResampleFilter: TResampleFilter; AMode: TDrawMode; AOpacity: Byte=255); override; overload;
     function GetImageAffineBounds(AMatrix: TAffineMatrix; ASourceBounds: TRect; AClipOutput: boolean = true): TRect; override; overload;
     function IsAffineRoughlyTranslation(AMatrix: TAffineMatrix; ASourceBounds: TRect): boolean; override;

--- a/bgrabitmap/bgragradientscanner.pas
+++ b/bgrabitmap/bgragradientscanner.pas
@@ -202,6 +202,7 @@ type
   private
     FOpacity: byte;
     FGrayscale: boolean;
+    FRandomBuffer, FRandomBufferCount: integer;
   public
     constructor Create(AGrayscale: Boolean; AOpacity: byte);
     function ScanAtInteger({%H-}X, {%H-}Y: integer): TBGRAPixel; override;
@@ -303,6 +304,7 @@ constructor TBGRARandomScanner.Create(AGrayscale: Boolean; AOpacity: byte);
 begin
   FGrayscale:= AGrayscale;
   FOpacity:= AOpacity;
+  FRandomBufferCount := 0;
 end;
 
 function TBGRARandomScanner.ScanAtInteger(X, Y: integer): TBGRAPixel;
@@ -311,15 +313,26 @@ begin
 end;
 
 function TBGRARandomScanner.ScanNextPixel: TBGRAPixel;
+var rgb: integer;
 begin
   if FGrayscale then
   begin
-    result.red := random(256);
+    if FRandomBufferCount = 0 then
+    begin
+      FRandomBuffer := random(256*256*256);
+      FRandomBufferCount := 3;
+    end;
+    result.red := FRandomBuffer and 255;
+    FRandomBuffer:= FRandomBuffer shr 8;
+    FRandomBufferCount -= 1;
     result.green := result.red;
     result.blue := result.red;
     result.alpha:= FOpacity;
   end else
-    Result:= BGRA(random(256),random(256),random(256),FOpacity);
+  begin
+    rgb := random(256*256*256);
+    Result:= BGRA(rgb and 255,(rgb shr 8) and 255,(rgb shr 16) and 255,FOpacity);
+  end;
 end;
 
 function TBGRARandomScanner.ScanAt(X, Y: Single): TBGRAPixel;

--- a/bgrabitmap/bgragradientscanner.pas
+++ b/bgrabitmap/bgragradientscanner.pas
@@ -106,7 +106,7 @@ type
     FOrigin,FDir1,FDir2: TPointF;
     FRelativeFocal: TPointF;
     FRadius, FFocalRadius: single;
-    FTransform: TAffineMatrix;
+    FTransform, FHiddenTransform: TAffineMatrix;
     FSinus: Boolean;
     FGradient: TBGRACustomGradient;
     FGradientOwner: boolean;
@@ -128,7 +128,7 @@ type
 
     procedure Init(AGradientType: TGradientType; AOrigin, d1: TPointF; ATransform: TAffineMatrix; Sinus: Boolean=False);
     procedure Init(AGradientType: TGradientType; AOrigin, d1, d2: TPointF; ATransform: TAffineMatrix; Sinus: Boolean=False);
-    procedure Init(AOrigin: TPointF; ARadius: single; AFocal: TPointF; AFocalRadius: single; ATransform: TAffineMatrix);
+    procedure Init(AOrigin: TPointF; ARadius: single; AFocal: TPointF; AFocalRadius: single; ATransform: TAffineMatrix; AHiddenTransform: TAffineMatrix);
 
     procedure InitGradientType;
     procedure InitTransform;
@@ -159,6 +159,7 @@ type
   public
     constructor Create(AGradientType: TGradientType; AOrigin, d1: TPointF);
     constructor Create(AGradientType: TGradientType; AOrigin, d1, d2: TPointF);
+    constructor Create(AOrigin, d1, d2, AFocal: TPointF; ARadiusRatio: single = 1; AFocalRadiusRatio: single = 0);
     constructor Create(AOrigin: TPointF; ARadius: single; AFocal: TPointF; AFocalRadius: single);
 
     constructor Create(c1, c2: TBGRAPixel; AGradientType: TGradientType; AOrigin, d1: TPointF;
@@ -186,6 +187,7 @@ type
     property Transform: TAffineMatrix read FTransform write SetTransform;
     property Gradient: TBGRACustomGradient read FGradient;
     property FlipGradient: boolean read FFlipGradient write SetFlipGradient;
+    property Sinus: boolean Read FSinus write FSinus;
   end;
 
   { TBGRAConstantScanner }
@@ -1036,13 +1038,34 @@ begin
   Init(AGradientType,AOrigin,d1,d2,AffineMatrixIdentity,False);
 end;
 
+constructor TBGRAGradientScanner.Create(AOrigin,
+  d1, d2, AFocal: TPointF; ARadiusRatio: single; AFocalRadiusRatio: single);
+var
+  m, mInv: TAffineMatrix;
+  focalInv: TPointF;
+begin
+  FGradient := nil;
+  SetGradient(BGRABlack,BGRAWhite,False);
+
+  m := AffineMatrix((d1-AOrigin).x, (d2-AOrigin).x, AOrigin.x,
+                    (d1-AOrigin).y, (d2-AOrigin).y, AOrigin.y);
+  if IsAffineMatrixInversible(m) then
+  begin
+    mInv := AffineMatrixInverse(m);
+    focalInv := mInv*AFocal;
+  end else
+    focalInv := PointF(0,0);
+
+  Init(PointF(0,0), ARadiusRatio, focalInv, AFocalRadiusRatio, AffineMatrixIdentity, m);
+end;
+
 constructor TBGRAGradientScanner.Create(AOrigin: TPointF; ARadius: single;
   AFocal: TPointF; AFocalRadius: single);
 begin
   FGradient := nil;
   SetGradient(BGRABlack,BGRAWhite,False);
 
-  Init(AOrigin, ARadius, AFocal, AFocalRadius, AffineMatrixIdentity);
+  Init(AOrigin, ARadius, AFocal, AFocalRadius, AffineMatrixIdentity, AffineMatrixIdentity);
 end;
 
 procedure TBGRAGradientScanner.SetFlipGradient(AValue: boolean);
@@ -1108,6 +1131,7 @@ begin
   FDir2 := d2;
   FSinus := Sinus;
   FTransform := ATransform;
+  FHiddenTransform := AffineMatrixIdentity;
 
   FRadius := 1;
   FRelativeFocal := PointF(0,0);
@@ -1118,7 +1142,7 @@ begin
 end;
 
 procedure TBGRAGradientScanner.Init(AOrigin: TPointF; ARadius: single;
-  AFocal: TPointF; AFocalRadius: single; ATransform: TAffineMatrix);
+  AFocal: TPointF; AFocalRadius: single; ATransform: TAffineMatrix; AHiddenTransform: TAffineMatrix);
 var maxRadius: single;
 begin
   FGradientType:= gtRadial;
@@ -1131,6 +1155,7 @@ begin
   FDir2 := AOrigin+PointF(0,maxRadius);
   FSinus := False;
   FTransform := ATransform;
+  FHiddenTransform := AHiddenTransform;
 
   FRadius := ARadius/maxRadius;
   FRelativeFocal := (AFocal - AOrigin)*(1/maxRadius);
@@ -1239,8 +1264,8 @@ begin
   else
     v := FDir2-FOrigin;
 
-  FMatrix := FTransform* AffineMatrix(u.x, v.x, FOrigin.x,
-                                      u.y, v.y, FOrigin.y);
+  FMatrix := FTransform * FHiddenTransform * AffineMatrix(u.x, v.x, FOrigin.x,
+                                                          u.y, v.y, FOrigin.y);
   if IsAffineMatrixInversible(FMatrix) then
   begin
     FMatrix := AffineMatrixInverse(FMatrix);
@@ -1432,7 +1457,7 @@ constructor TBGRAGradientScanner.Create(gradient: TBGRACustomGradient;
 begin
   FGradient := gradient;
   FGradientOwner := AGradientOwner;
-  Init(AOrigin, ARadius, AFocal, AFocalRadius, AffineMatrixIdentity);
+  Init(AOrigin, ARadius, AFocal, AFocalRadius, AffineMatrixIdentity, AffineMatrixIdentity);
 end;
 
 destructor TBGRAGradientScanner.Destroy;

--- a/bgrabitmap/bgragtkbitmap.pas
+++ b/bgrabitmap/bgragtkbitmap.pas
@@ -119,6 +119,8 @@ begin
     exit;
   end;
 
+  LoadFromBitmapIfNeeded;
+
   If not TBGRAPixel_RGBAOrder then SwapRedBlue;
   
   P := Rect.TopLeft;

--- a/bgrabitmap/bgragtkbitmap.pas
+++ b/bgrabitmap/bgragtkbitmap.pas
@@ -37,7 +37,8 @@ type
   private
     FPixBuf: Pointer;
     procedure DrawTransparent(ACanvas: TCanvas; Rect: TRect);
-    procedure DrawOpaque(ACanvas: TCanvas; Rect: TRect);
+    procedure DrawOpaque(ACanvas: TCanvas; ARect: TRect; ASourceRect: TRect);
+    procedure DrawOpaque(ACanvas: TCanvas; ARect: TRect);
   protected
     procedure ReallocData; override;
     procedure FreeData; override;
@@ -45,16 +46,19 @@ type
     procedure DataDrawTransparent(ACanvas: TCanvas; Rect: TRect;
       AData: Pointer; ALineOrder: TRawImageLineOrder; AWidth, AHeight: integer);
       override;
+    procedure DrawPart(ARect: TRect; ACanvas: TCanvas; x, y: integer; Opaque: boolean); override;
     procedure Draw(ACanvas: TCanvas; x, y: integer; Opaque: boolean = True); override;
     procedure Draw(ACanvas: TCanvas; Rect: TRect; Opaque: boolean = True); override;
-    procedure DataDrawOpaque(ACanvas: TCanvas; Rect: TRect; AData: Pointer;
-      ALineOrder: TRawImageLineOrder; AWidth, AHeight: integer); override;
+    procedure DataDrawOpaque(ACanvas: TCanvas; ARect: TRect; AData: Pointer;
+      ALineOrder: TRawImageLineOrder; AWidth, AHeight: integer); override; overload;
+    procedure DataDrawOpaque(ACanvas: TCanvas; ARect: TRect; ADataFirstRow: Pointer;
+      ARowStride: integer; AWidth, AHeight: integer); overload;
     procedure GetImageFromCanvas(CanvasSource: TCanvas; x, y: integer); override;
   end;
 
 implementation
 
-uses BGRABitmapTypes, BGRADefaultBitmap, LCLType,
+uses BGRABitmapTypes, BGRADefaultBitmap, BGRAFilterScanner, LCLType,
   LCLIntf, IntfGraphics,
   {$IFDEF LCLgtk2}
   gdk2, gtk2def, gdk2pixbuf, glib2,
@@ -129,9 +133,15 @@ begin
   If not TBGRAPixel_RGBAOrder then SwapRedBlue;
 end;
 
-procedure TBGRAGtkBitmap.DrawOpaque(ACanvas: TCanvas; Rect: TRect);
+procedure TBGRAGtkBitmap.DrawOpaque(ACanvas: TCanvas; ARect: TRect;
+  ASourceRect: TRect);
 begin
-  DataDrawOpaque(ACanvas,Rect,Data,LineOrder,Width,Height);
+  DataDrawOpaque(ACanvas,ARect,Data,LineOrder,Width,Height);
+end;
+
+procedure TBGRAGtkBitmap.DrawOpaque(ACanvas: TCanvas; ARect: TRect);
+begin
+  DrawOpaque(ACanvas, ARect, rect(0,0,Width,Height));
 end;
 
 procedure TBGRAGtkBitmap.DataDrawTransparent(ACanvas: TCanvas; Rect: TRect;
@@ -165,6 +175,23 @@ begin
   TempGtk.Free;
 end;
 
+procedure TBGRAGtkBitmap.DrawPart(ARect: TRect; ACanvas: TCanvas; x,
+  y: integer; Opaque: boolean);
+var
+  rowStride: Integer;
+begin
+  if Opaque then
+  begin
+    if LineOrder = riloTopToBottom then
+      rowStride := Width*sizeof(TBGRAPixel)
+    else
+      rowStride := -Width*sizeof(TBGRAPixel);
+    DataDrawOpaque(ACanvas, rect(x,y,x+ARect.Width,y+ARect.Height), Scanline[ARect.Top]+ARect.Left, rowStride, ARect.Width,ARect.Height);
+  end
+  else
+    inherited DrawPart(ARect, ACanvas, x, y, Opaque);
+end;
+
 procedure TBGRAGtkBitmap.Draw(ACanvas: TCanvas; x, y: integer; Opaque: boolean);
 begin
   if self = nil then
@@ -185,57 +212,104 @@ begin
     DrawTransparent(ACanvas, Rect);
 end;
 
-procedure TBGRAGtkBitmap.DataDrawOpaque(ACanvas: TCanvas; Rect: TRect;
+procedure TBGRAGtkBitmap.DataDrawOpaque(ACanvas: TCanvas; ARect: TRect;
   AData: Pointer; ALineOrder: TRawImageLineOrder; AWidth, AHeight: integer);
-var ptr: TBGRAPtrBitmap;
-    stretched: TBGRACustomBitmap;
-    temp: integer;
-    pos: TPoint;
-    dest: HDC;
+var
+  rowStride: Integer;
+  firstRow: Pointer;
 begin
-  if (AHeight = 0) or (AWidth = 0) or (Rect.Left = Rect.Right) or
-    (Rect.Top = Rect.Bottom) then
-    exit;
-
-  if Rect.Right < Rect.Left then
+  if ALineOrder = riloTopToBottom then
   begin
-    temp := Rect.Left;
-    Rect.Left := Rect.Right;
-    Rect.Right := temp;
+    rowStride := AWidth*sizeof(TBGRAPixel);
+    firstRow := AData;
+  end
+  else
+  begin
+    rowStride := -AWidth*sizeof(TBGRAPixel);
+    firstRow := PBGRAPixel(AData) + (AWidth*(AHeight-1));
   end;
 
-  if Rect.Bottom < Rect.Top then
+  DataDrawOpaque(ACanvas, ARect, firstRow, rowStride, AWidth, AHeight);
+end;
+
+procedure TBGRAGtkBitmap.DataDrawOpaque(ACanvas: TCanvas; ARect: TRect;
+  ADataFirstRow: Pointer; ARowStride: integer; AWidth, AHeight: integer);
+
+  procedure DataSwapRedBlue;
+  var
+    y: Integer;
+    p: PByte;
   begin
-    temp := Rect.Top;
-    Rect.Top := Rect.Bottom;
-    Rect.Bottom := temp;
+    p := PByte(ADataFirstRow);
+    for y := 0 to AHeight-1 do
+    begin
+      TBGRAFilterScannerSwapRedBlue.ComputeFilterAt(PBGRAPixel(p),PBGRAPixel(p),AWidth,False);
+      inc(p, ARowStride);
+    end;
   end;
 
-  if (AWidth <> Rect.Right-Rect.Left) or (AHeight <> Rect.Bottom-Rect.Top) then
+  procedure DrawStretched;
+  var
+    dataStart: Pointer;
+    ptr: TBGRAPtrBitmap;
+    stretched: TBGRACustomBitmap;
   begin
-    ptr := TBGRAPtrBitmap.Create(AWidth,AHeight,AData);
-    ptr.LineOrder := ALineOrder;
-    stretched := ptr.Resample(Rect.Right-Rect.Left,Rect.Bottom-Rect.Top);
+    if ARowStride < 0 then
+      dataStart := PByte(ADataFirstRow) + ARowStride*(Height-1)
+    else
+      dataStart := ADataFirstRow;
+
+    if ARowStride <> abs(AWidth*sizeof(TBGRAPixel)) then
+      raise exception.Create('DataDrawOpaque not supported when using custom row stride and resample');
+
+    ptr := TBGRAPtrBitmap.Create(AWidth,AHeight,dataStart);
+    if ARowStride < 0 then
+      ptr.LineOrder := riloBottomToTop
+    else
+      ptr.LineOrder := riloTopToBottom;
+    stretched := ptr.Resample(ARect.Right-ARect.Left,ARect.Bottom-ARect.Top);
     ptr.free;
-    DataDrawOpaque(ACanvas,Rect,AData,stretched.LineOrder,stretched.Width,stretched.Height);
+    DataDrawOpaque(ACanvas,ARect,dataStart,stretched.LineOrder,stretched.Width,stretched.Height);
     stretched.Free;
-    exit;
   end;
 
-  dest := ACanvas.Handle;
-  pos := rect.TopLeft;
-  LPtoDP(dest, pos, 1);
-  ptr := TBGRAPtrBitmap.Create(AWidth,AHeight,AData);
-  ptr.LineOrder := ALineOrder;
-  If ALineOrder = riloBottomToTop then ptr.VerticalFlip;
-  If not TBGRAPixel_RGBAOrder then ptr.SwapRedBlue;
-  gdk_draw_rgb_32_image(TGtkDeviceContext(dest).Drawable,
-    TGtkDeviceContext(Dest).GC, pos.x,pos.y,
-    AWidth,AHeight, GDK_RGB_DITHER_NORMAL,
-    AData, AWidth*sizeof(TBGRAPixel));
-  If not TBGRAPixel_RGBAOrder then ptr.SwapRedBlue;
-  If ALineOrder = riloBottomToTop then ptr.VerticalFlip;
-  ptr.Free;
+var
+  temp: integer;
+  pos: TPoint;
+  dest: HDC;
+
+begin
+  if (AHeight = 0) or (AWidth = 0) or (ARect.Left = ARect.Right) or
+    (ARect.Top = ARect.Bottom) then exit;
+
+  if ARect.Right < ARect.Left then
+  begin
+    temp := ARect.Left;
+    ARect.Left := ARect.Right;
+    ARect.Right := temp;
+  end;
+
+  if ARect.Bottom < ARect.Top then
+  begin
+    temp := ARect.Top;
+    ARect.Top := ARect.Bottom;
+    ARect.Bottom := temp;
+  end;
+
+  if (AWidth <> ARect.Right-ARect.Left) or (AHeight <> ARect.Bottom-ARect.Top) then
+    DrawStretched
+  else
+  begin
+    dest := ACanvas.Handle;
+    pos := ARect.TopLeft;
+    LPtoDP(dest, pos, 1);
+    if not TBGRAPixel_RGBAOrder then DataSwapRedBlue;
+    gdk_draw_rgb_32_image(TGtkDeviceContext(dest).Drawable,
+      TGtkDeviceContext(Dest).GC, pos.x,pos.y,
+      AWidth,AHeight, GDK_RGB_DITHER_NORMAL,
+      ADataFirstRow, ARowStride);
+    if not TBGRAPixel_RGBAOrder then DataSwapRedBlue;
+  end;
 end;
 
 procedure TBGRAGtkBitmap.GetImageFromCanvas(CanvasSource: TCanvas; x, y: integer);

--- a/bgrabitmap/bgragtkbitmap.pas
+++ b/bgrabitmap/bgragtkbitmap.pas
@@ -225,14 +225,17 @@ begin
   dest := ACanvas.Handle;
   pos := rect.TopLeft;
   LPtoDP(dest, pos, 1);
-  If ALineOrder = riloBottomToTop then VerticalFlip;
-  If not TBGRAPixel_RGBAOrder then SwapRedBlue;
+  ptr := TBGRAPtrBitmap.Create(AWidth,AHeight,AData);
+  ptr.LineOrder := ALineOrder;
+  If ALineOrder = riloBottomToTop then ptr.VerticalFlip;
+  If not TBGRAPixel_RGBAOrder then ptr.SwapRedBlue;
   gdk_draw_rgb_32_image(TGtkDeviceContext(dest).Drawable,
     TGtkDeviceContext(Dest).GC, pos.x,pos.y,
     AWidth,AHeight, GDK_RGB_DITHER_NORMAL,
     AData, AWidth*sizeof(TBGRAPixel));
-  If not TBGRAPixel_RGBAOrder then SwapRedBlue;
-  If ALineOrder = riloBottomToTop then VerticalFlip;
+  If not TBGRAPixel_RGBAOrder then ptr.SwapRedBlue;
+  If ALineOrder = riloBottomToTop then ptr.VerticalFlip;
+  ptr.Free;
 end;
 
 procedure TBGRAGtkBitmap.GetImageFromCanvas(CanvasSource: TCanvas; x, y: integer);

--- a/bgrabitmap/bgraiconcursor.pas
+++ b/bgrabitmap/bgraiconcursor.pas
@@ -24,7 +24,7 @@ type
     constructor Create(AContainer: TMultiFileContainer; AExtension: string; AInfo: TQuickImageInfo; AContent: TStream);
     class function TryCreate(AContainer: TMultiFileContainer; AContent: TStream): TBGRAIconCursorEntry;
     destructor Destroy; override;
-    function CopyTo(ADestination: TStream): integer; override;
+    function CopyTo(ADestination: TStream): int64; override;
     function GetBitmap: TBGRACustomBitmap;
     property Width: integer read FWidth;
     property Height: integer read FHeight;
@@ -287,7 +287,7 @@ begin
   inherited Destroy;
 end;
 
-function TBGRAIconCursorEntry.CopyTo(ADestination: TStream): integer;
+function TBGRAIconCursorEntry.CopyTo(ADestination: TStream): int64;
 begin
   if FContent.Size = 0 then
   begin

--- a/bgrabitmap/bgralayers.pas
+++ b/bgrabitmap/bgralayers.pas
@@ -293,7 +293,7 @@ type
     procedure LoadFromStream(AStream: TStream); virtual;
     procedure SaveToFile(AFilenameUTF8: string); virtual;
     procedure SaveToStream(AStream: TStream); virtual;
-    class function FriendlyClassName: RawByteString; virtual; abstract;
+    class function StorageClassName: RawByteString; virtual; abstract;
     property Guid: TGuid read GetGuid write SetGuid;
   end;
 
@@ -583,7 +583,7 @@ begin
   try
     memDir.LoadFromStream(AStream);
     storage := TBGRAMemOriginalStorage.Create(memDir);
-    if storage.RawString['class'] <> FriendlyClassName then
+    if storage.RawString['class'] <> StorageClassName then
       raise exception.Create('Invalid class');
     LoadFromStorage(storage);
     FreeAndNil(storage);
@@ -613,7 +613,7 @@ begin
   storage := nil;
   try
     storage := TBGRAMemOriginalStorage.Create(memDir);
-    storage.RawString['class'] := FriendlyClassName;
+    storage.RawString['class'] := StorageClassName;
     SaveToStorage(storage);
     FreeAndNil(storage);
     memDir.SaveToStream(AStream);
@@ -752,7 +752,7 @@ begin
     begin
       c := ADir.RawStringByFilename['class'];
       for i := 0 to high(LayerOriginalClasses) do
-        if LayerOriginalClasses[i].FriendlyClassName = c then
+        if LayerOriginalClasses[i].StorageClassName = c then
         begin
           AClass := LayerOriginalClasses[i];
           break;
@@ -771,7 +771,7 @@ begin
   storage := TBGRAMemOriginalStorage.Create(subdir);
   try
     AOriginal.SaveToStorage(storage);
-    storage.RawString['class'] := AOriginal.FriendlyClassName;
+    storage.RawString['class'] := AOriginal.StorageClassName;
   finally
     storage.Free;
   end;

--- a/bgrabitmap/bgralayers.pas
+++ b/bgrabitmap/bgralayers.pas
@@ -362,6 +362,7 @@ begin
     FLayers[layer].Original.Free;
     FLayers[layer].Original := AValue;
     FLayers[layer].OriginalChanged := true;
+    Unfreeze(layer);
   end;
 end;
 
@@ -375,7 +376,10 @@ begin
     if FLayers[layer].OriginalMatrix = AValue then exit;
     FLayers[layer].OriginalMatrix := AValue;
     if Assigned(FLayers[layer].Original) then
+    begin
       FLayers[layer].OriginalChanged := true;
+      Unfreeze(layer);
+    end;
   end;
 end;
 
@@ -400,6 +404,7 @@ begin
       LayerOriginal[layer] := original;
       FLayers[layer].OriginalGuid := AValue;
       FLayers[layer].OriginalChanged := true;
+      Unfreeze(layer);
     end;
   end;
 end;
@@ -1550,7 +1555,6 @@ begin
       end;
     end;
     if LayerVisible[i] then
-    with LayerOffset[i] do
     begin
       tempLayer := GetLayerBitmapDirectly(i);
       if tempLayer <> nil then
@@ -1561,11 +1565,12 @@ begin
         tempLayer := GetLayerBitmapCopy(i);
       end;
       if tempLayer <> nil then
+      with LayerOffset[i] do
       begin
         if (BlendOperation[i] = boTransparent) and not self.LinearBlend then //here it is specified not to use linear blending
-          Dest.PutImage(AX+x,AY+y,GetLayerBitmapDirectly(i),dmDrawWithTransparency, LayerOpacity[i])
+          Dest.PutImage(AX+x,AY+y,tempLayer,dmDrawWithTransparency, LayerOpacity[i])
         else
-          Dest.PutImage(AX+x,AY+y,GetLayerBitmapDirectly(i),dmLinearBlend, LayerOpacity[i]);
+          Dest.PutImage(AX+x,AY+y,tempLayer,dmLinearBlend, LayerOpacity[i]);
         if mustFreeCopy then tempLayer.Free;
       end;
     end;

--- a/bgrabitmap/bgralayers.pas
+++ b/bgrabitmap/bgralayers.pas
@@ -148,6 +148,7 @@ type
     function GetLayerOriginal(layer: integer): TBGRALayerCustomOriginal; override;
     function GetLayerOriginalMatrix(layer: integer): TAffineMatrix; override;
     function GetLayerOriginalGuid(layer: integer): TGuid; override;
+    function GetLayerOriginalChanged(layer: integer): boolean;
     procedure SetBlendOperation(Layer: integer; op: TBlendOperation);
     procedure SetLayerVisible(layer: integer; AValue: boolean);
     procedure SetLayerOpacity(layer: integer; AValue: byte);
@@ -158,6 +159,7 @@ type
     procedure SetLayerOriginal(layer: integer; AValue: TBGRALayerCustomOriginal);
     procedure SetLayerOriginalMatrix(layer: integer; AValue: TAffineMatrix);
     procedure SetLayerOriginalGuid(layer: integer; const AValue: TGuid);
+    procedure SetLayerOriginalChanged(layer: integer; AValue: boolean);
 
     procedure FindOriginal(AGuid: TGuid;
                 out ADir: TMemDirectory;
@@ -230,6 +232,7 @@ type
     property LayerOriginal[layer: integer]: TBGRALayerCustomOriginal read GetLayerOriginal write SetLayerOriginal;
     property LayerOriginalGuid[layer: integer]: TGuid read GetLayerOriginalGuid write SetLayerOriginalGuid;
     property LayerOriginalMatrix[layer: integer]: TAffineMatrix read GetLayerOriginalMatrix write SetLayerOriginalMatrix;
+    property LayerOriginalChanged[layer: integer]: boolean read GetLayerOriginalChanged write SetLayerOriginalChanged;
   end;
 
   TAffineMatrix = BGRABitmapTypes.TAffineMatrix;
@@ -506,6 +509,14 @@ begin
     result := FLayers[layer].OriginalGuid;
 end;
 
+function TBGRALayeredBitmap.GetLayerOriginalChanged(layer: integer): boolean;
+begin
+  if (layer < 0) or (layer >= NbLayers) then
+    raise Exception.Create('Index out of bounds')
+  else
+    result := FLayers[layer].OriginalChanged;
+end;
+
 procedure TBGRALayeredBitmap.SetLayerUniqueId(layer: integer; AValue: integer);
 var i: integer;
 begin
@@ -581,6 +592,19 @@ begin
       FLayers[layer].OriginalChanged := true;
       Unfreeze(layer);
     end;
+  end;
+end;
+
+procedure TBGRALayeredBitmap.SetLayerOriginalChanged(layer: integer;
+  AValue: boolean);
+begin
+  if (layer < 0) or (layer >= NbLayers) then
+    raise Exception.Create('Index out of bounds')
+  else
+  begin
+    FLayers[layer].OriginalChanged := AValue;
+    if AValue then
+      Unfreeze(layer);
   end;
 end;
 

--- a/bgrabitmap/bgralayers.pas
+++ b/bgrabitmap/bgralayers.pas
@@ -251,6 +251,9 @@ type
   { TBGRACustomOriginalStorage }
 
   TBGRACustomOriginalStorage = class
+  private
+    function GetBool(AName: utf8string): boolean;
+    procedure SetBool(AName: utf8string; AValue: boolean);
   protected
     FFormats: TFormatSettings;
     function GetInteger(AName: utf8string): integer;
@@ -270,6 +273,7 @@ type
     procedure WriteFile(AName: UTF8String; ASource: TStream; ACompress: boolean); virtual; abstract;
     property RawString[AName: utf8string]: RawByteString read GetRawString write SetRawString;
     property Int[AName: utf8string]: integer read GetInteger write SetInteger;
+    property Bool[AName: utf8string]: boolean read GetBool write SetBool;
     property Float[AName: utf8string]: single read GetSingle write SetSingle;
     property PointF[AName: utf8string]: TPointF read GetPointF write SetPointF;
     property Color[AName: UTF8String]: TBGRAPixel read GetColor write SetColor;
@@ -356,6 +360,7 @@ end;
 
 constructor TBGRAMemOriginalStorage.Create(AMemDir: TMemDirectory);
 begin
+  inherited Create;
   FMemDir := AMemDir;
 end;
 
@@ -400,6 +405,16 @@ begin
   RawString[AName] := LowerCase(BGRAToStr(AValue, CSSColors));
 end;
 
+function TBGRACustomOriginalStorage.GetBool(AName: utf8string): boolean;
+begin
+  result := StrToBool(RawString[AName]);
+end;
+
+procedure TBGRACustomOriginalStorage.SetBool(AName: utf8string; AValue: boolean);
+begin
+  RawString[AName] := BoolToStr(AValue,'true','false');
+end;
+
 function TBGRACustomOriginalStorage.GetInteger(AName: utf8string): integer;
 begin
   result := StrToIntDef(RawString[AName],0);
@@ -434,13 +449,13 @@ procedure TBGRACustomOriginalStorage.SetPointF(AName: utf8string;
   AValue: TPointF);
 begin
   if isEmptyPointF(AValue) then RemoveAttribute(AName)
-  else RawString[AName] := FloatToStr(AValue.x, FFormats)+','+FloatToStr(AValue.y, FFormats);
+  else RawString[AName] := FloatToStrF(AValue.x, ffGeneral,7,3, FFormats)+','+FloatToStrF(AValue.y, ffGeneral,7,3, FFormats);
 end;
 
 procedure TBGRACustomOriginalStorage.SetSingle(AName: utf8string; AValue: single);
 begin
   if AValue = EmptySingle then RemoveAttribute(AName)
-  else RawString[AName] := FloatToStr(AValue, FFormats);
+  else RawString[AName] := FloatToStrF(AValue, ffGeneral,7,3, FFormats);
 end;
 
 constructor TBGRACustomOriginalStorage.Create;

--- a/bgrabitmap/bgralazresource.pas
+++ b/bgrabitmap/bgralazresource.pas
@@ -24,7 +24,7 @@ type
   public
     constructor Create(AContainer: TMultiFileContainer; AName: utf8string; AValueType: utf8string; AContent: TStream);
     destructor Destroy; override;
-    function CopyTo(ADestination: TStream): integer; override;
+    function CopyTo(ADestination: TStream): int64; override;
   end;
 
   { TFormDataEntry }
@@ -38,7 +38,7 @@ type
   public
     constructor Create(AContainer: TMultiFileContainer; AName: utf8string; ABinaryContent: TStream);
     destructor Destroy; override;
-    function CopyTo(ADestination: TStream): integer; override;
+    function CopyTo(ADestination: TStream): int64; override;
   end;
 
   { TLazResourceContainer }
@@ -90,7 +90,7 @@ begin
   inherited Destroy;
 end;
 
-function TFormDataEntry.CopyTo(ADestination: TStream): integer;
+function TFormDataEntry.CopyTo(ADestination: TStream): int64;
 begin
   RequireTextContent;
   if FTextContent.Size = 0 then
@@ -148,7 +148,7 @@ begin
   FContent := AContent;
 end;
 
-function TLazResourceEntry.CopyTo(ADestination: TStream): integer;
+function TLazResourceEntry.CopyTo(ADestination: TStream): int64;
 begin
   if FContent.Size = 0 then
     result := 0

--- a/bgrabitmap/bgralclbitmap.pas
+++ b/bgrabitmap/bgralclbitmap.pas
@@ -746,7 +746,10 @@ end;
 procedure TBGRALCLBitmap.DoLoadFromBitmap;
 begin
   if FBitmap <> nil then
+  begin
     LoadFromRawImage(FBitmap.RawImage, FCanvasOpacity);
+    if FAlphaCorrectionNeeded then DoAlphaCorrection;
+  end;
 end;
 
 procedure TBGRALCLBitmap.RebuildBitmap;
@@ -777,6 +780,7 @@ begin
 
   FBitmap.Canvas.AntialiasingMode := amOff;
   FBitmapModified := False;
+  FAlphaCorrectionNeeded:= false;
 end;
 
 function TBGRALCLBitmap.CreatePtrBitmap(AWidth, AHeight: integer;

--- a/bgrabitmap/bgralclbitmap.pas
+++ b/bgrabitmap/bgralclbitmap.pas
@@ -25,7 +25,7 @@ type
     procedure Assign(Source: TPersistent); override;
     procedure DataDrawTransparent(ACanvas: TCanvas; Rect: TRect;
       AData: Pointer; ALineOrder: TRawImageLineOrder; AWidth, AHeight: integer); override;
-    procedure DataDrawOpaque(ACanvas: TCanvas; Rect: TRect; AData: Pointer;
+    procedure DataDrawOpaque(ACanvas: TCanvas; ARect: TRect; AData: Pointer;
       ALineOrder: TRawImageLineOrder; AWidth, AHeight: integer); override;
     procedure GetImageFromCanvas(CanvasSource: TCanvas; x, y: integer); override;
     procedure LoadFromDevice({%H-}DC: HDC); override;
@@ -862,10 +862,10 @@ begin
   DataDrawTransparentImplementation(ACanvas, Rect, AData, ALineOrder, AWidth, AHeight);
 end;
 
-procedure TBGRALCLBitmap.DataDrawOpaque(ACanvas: TCanvas; Rect: TRect;
+procedure TBGRALCLBitmap.DataDrawOpaque(ACanvas: TCanvas; ARect: TRect;
   AData: Pointer; ALineOrder: TRawImageLineOrder; AWidth, AHeight: integer);
 begin
-  DataDrawOpaqueImplementation(ACanvas, Rect, AData, ALineOrder, AWidth, AHeight);
+  DataDrawOpaqueImplementation(ACanvas, ARect, AData, ALineOrder, AWidth, AHeight);
 end;
 
 procedure TBGRALCLBitmap.GetImageFromCanvas(CanvasSource: TCanvas; x, y: integer

--- a/bgrabitmap/bgramultifiletype.pas
+++ b/bgrabitmap/bgramultifiletype.pas
@@ -331,13 +331,13 @@ end;
 function TMultiFileContainer.Add(AFilename: TEntryFilename; AContent: TStream;
   AOverwrite: boolean; AOwnStream: boolean): integer;
 begin
-  Add(AFilename.Name,AFilename.Extension, AContent, AOverwrite, AOwnStream);
+  result := Add(AFilename.Name,AFilename.Extension, AContent, AOverwrite, AOwnStream);
 end;
 
 function TMultiFileContainer.Add(AFilename: TEntryFilename;
   AContent: RawByteString; AOverwrite: boolean): integer;
 begin
-  Add(AFilename.Name,AFilename.Extension, AContent, AOverwrite);
+  result := Add(AFilename.Name,AFilename.Extension, AContent, AOverwrite);
 end;
 
 destructor TMultiFileContainer.Destroy;

--- a/bgrabitmap/bgramultifiletype.pas
+++ b/bgrabitmap/bgramultifiletype.pas
@@ -74,8 +74,10 @@ type
     constructor Create(AFilename: utf8string);
     constructor Create(AStream: TStream);
     constructor Create(AStream: TStream; AStartPos: Int64);
-    function Add(AName: utf8string; AExtension: utf8string; AContent: TStream; AOverwrite: boolean = false; AOwnStream: boolean = true): integer;
-    function Add(AName: utf8string; AExtension: utf8string; AContent: RawByteString; AOverwrite: boolean = false): integer;
+    function Add(AName: utf8string; AExtension: utf8string; AContent: TStream; AOverwrite: boolean = false; AOwnStream: boolean = true): integer; overload;
+    function Add(AName: utf8string; AExtension: utf8string; AContent: RawByteString; AOverwrite: boolean = false): integer; overload;
+    function Add(AFilename: TEntryFilename; AContent: TStream; AOverwrite: boolean = false; AOwnStream: boolean = true): integer; overload;
+    function Add(AFilename: TEntryFilename; AContent: RawByteString; AOverwrite: boolean = false): integer; overload;
     procedure Clear; virtual;
     destructor Destroy; override;
     procedure LoadFromFile(AFilename: utf8string);
@@ -324,6 +326,18 @@ begin
   stream := TMemoryStream.Create;
   stream.Write(AContent[1],length(AContent));
   result := Add(AName,AExtension,stream,AOverwrite);
+end;
+
+function TMultiFileContainer.Add(AFilename: TEntryFilename; AContent: TStream;
+  AOverwrite: boolean; AOwnStream: boolean): integer;
+begin
+  Add(AFilename.Name,AFilename.Extension, AContent, AOverwrite, AOwnStream);
+end;
+
+function TMultiFileContainer.Add(AFilename: TEntryFilename;
+  AContent: RawByteString; AOverwrite: boolean): integer;
+begin
+  Add(AFilename.Name,AFilename.Extension, AContent, AOverwrite);
 end;
 
 destructor TMultiFileContainer.Destroy;

--- a/bgrabitmap/bgramultifiletype.pas
+++ b/bgrabitmap/bgramultifiletype.pas
@@ -1,11 +1,35 @@
 unit BGRAMultiFileType;
 
 {$mode objfpc}{$H+}
+{$MODESWITCH ADVANCEDRECORDS}
 
 interface
 
 uses
   Classes, SysUtils, fgl;
+
+type
+
+  { TEntryFilename }
+
+  TEntryFilename = record
+  private
+    FExtension: utf8string;
+    FName: utf8string;
+    function GetFilename: utf8string;
+    function GetIsEmpty: boolean;
+    procedure SetExtension(AValue: utf8string);
+    procedure SetFilename(AValue: utf8string);
+    procedure SetName(AValue: utf8string);
+  public
+    function New(AName,AExtension: string): TEntryFilename;
+    function New(AFilename: string): TEntryFilename;
+    class operator =(const AValue1,AValue2: TEntryFilename): boolean;
+    property Filename: utf8string read GetFilename write SetFilename;
+    property Name: utf8string read FName write SetName;
+    property Extension: utf8string read FExtension write SetExtension;
+    property IsEmpty: boolean read GetIsEmpty;
+  end;
 
 type
   TMultiFileContainer = class;
@@ -21,7 +45,7 @@ type
     function GetExtension: utf8string; virtual;
   public
     constructor Create(AContainer: TMultiFileContainer);
-    function CopyTo({%H-}ADestination: TStream): integer; virtual;
+    function CopyTo({%H-}ADestination: TStream): int64; virtual;
     property Name: utf8string read GetName write SetName;
     property Extension: utf8string read GetExtension;
     property FileSize: int64 read GetFileSize;
@@ -41,13 +65,17 @@ type
     function GetCount: integer;
     function GetEntry(AIndex: integer): TMultiFileEntry;
     function CreateEntry(AName: utf8string; AExtension: utf8string; AContent: TStream): TMultiFileEntry; virtual; abstract;
+    function GetRawString(AIndex: integer): RawByteString;
+    function GetRawStringByFilename(AFilename: string): RawByteString;
+    procedure SetRawString(AIndex: integer; AValue: RawByteString);
+    procedure SetRawStringByFilename(AFilename: string; AValue: RawByteString);
   public
     constructor Create;
     constructor Create(AFilename: utf8string);
     constructor Create(AStream: TStream);
     constructor Create(AStream: TStream; AStartPos: Int64);
     function Add(AName: utf8string; AExtension: utf8string; AContent: TStream; AOverwrite: boolean = false; AOwnStream: boolean = true): integer;
-    function Add(AName: utf8string; AExtension: utf8string; AContent: utf8String; AOverwrite: boolean = false): integer;
+    function Add(AName: utf8string; AExtension: utf8string; AContent: RawByteString; AOverwrite: boolean = false): integer;
     procedure Clear; virtual;
     destructor Destroy; override;
     procedure LoadFromFile(AFilename: utf8string);
@@ -56,16 +84,90 @@ type
     procedure SaveToStream(ADestination: TStream); virtual; abstract;
     procedure Remove(AEntry: TMultiFileEntry); virtual;
     procedure Delete(AIndex: integer); virtual; overload;
-    function Delete(AName: utf8string; AExtension: utf8string;ACaseSensitive: boolean = True): boolean; overload;
-    function IndexOf(AEntry: TMultiFileEntry): integer;
-    function IndexOf(AName: utf8string; AExtenstion: utf8string; ACaseSensitive: boolean = True): integer; virtual;
+    function Delete(AName: utf8string; AExtension: utf8string; ACaseSensitive: boolean = True): boolean; overload;
+    function Delete(AFilename: TEntryFilename; ACaseSensitive: boolean = True): boolean; overload;
+    function IndexOf(AEntry: TMultiFileEntry): integer; overload;
+    function IndexOf(AName: utf8string; AExtenstion: utf8string; ACaseSensitive: boolean = True): integer; virtual; overload;
+    function IndexOf(AFilename: TEntryFilename; ACaseSensitive: boolean = True): integer;
     property Count: integer read GetCount;
     property Entry[AIndex: integer]: TMultiFileEntry read GetEntry;
+    property RawString[AIndex: integer]: RawByteString read GetRawString write SetRawString;
+    property RawStringByFilename[AFilename: string]: RawByteString read GetRawStringByFilename write SetRawStringByFilename;
   end;
 
 implementation
 
-uses BGRAUTF8;
+uses BGRAUTF8, strutils;
+
+{ TEntryFilename }
+
+function TEntryFilename.GetFilename: utf8string;
+begin
+  if Extension = '' then
+    result := Name
+  else
+    result := Name+'.'+Extension;
+end;
+
+function TEntryFilename.GetIsEmpty: boolean;
+begin
+  result := (FName='') and (FExtension = '');
+end;
+
+procedure TEntryFilename.SetExtension(AValue: utf8string);
+var
+  i: Integer;
+begin
+  if FExtension=AValue then Exit;
+  for i := 1 to length(AValue) do
+    if AValue[i] in ['.','/'] then
+      raise Exception.Create('Invalid extension');
+  FExtension:=AValue;
+end;
+
+procedure TEntryFilename.SetFilename(AValue: utf8string);
+var
+  idxDot: SizeInt;
+begin
+  idxDot := RPos('.',AValue);
+  if idxDot = 0 then
+  begin
+    Name := AValue;
+    Extension := '';
+  end
+  else
+  begin
+    Name := copy(AValue,1,idxDot-1);
+    Extension := copy(AValue,idxDot+1,length(AValue)-idxDot);
+  end;
+end;
+
+procedure TEntryFilename.SetName(AValue: utf8string);
+var
+  i: Integer;
+begin
+  if FName=AValue then Exit;
+  for i := 1 to length(AValue) do
+    if AValue[i] = '/' then
+      raise Exception.Create('Invalid name');
+  FName:=AValue;
+end;
+
+function TEntryFilename.New(AName, AExtension: string): TEntryFilename;
+begin
+  result.Name := AName;
+  result.Extension:= AExtension;
+end;
+
+function TEntryFilename.New(AFilename: string): TEntryFilename;
+begin
+  result.Filename:= AFilename;
+end;
+
+class operator TEntryFilename.=(const AValue1, AValue2: TEntryFilename): boolean;
+begin
+  result := (AValue1.Name = AValue2.Name) and (AValue1.Extension = AValue2.Extension);
+end;
 
 { TMultiFileEntry }
 
@@ -84,7 +186,7 @@ begin
   FContainer := AContainer;
 end;
 
-function TMultiFileEntry.CopyTo(ADestination: TStream): integer;
+function TMultiFileEntry.CopyTo(ADestination: TStream): int64;
 begin
   result := 0;
 end;
@@ -93,12 +195,55 @@ end;
 
 function TMultiFileContainer.GetCount: integer;
 begin
-  result := FEntries.Count;
+  if Assigned(FEntries) then
+    result := FEntries.Count
+  else
+    result := 0;
 end;
 
 function TMultiFileContainer.GetEntry(AIndex: integer): TMultiFileEntry;
 begin
   result := FEntries[AIndex];
+end;
+
+function TMultiFileContainer.GetRawString(AIndex: integer): RawByteString;
+var s: TStringStream;
+begin
+  s := TStringStream.Create('');
+  try
+    Entry[AIndex].CopyTo(s);
+    result := s.DataString;
+  finally
+    s.Free;
+  end;
+end;
+
+function TMultiFileContainer.GetRawStringByFilename(AFilename: string
+  ): RawByteString;
+var
+  idx: Integer;
+begin
+  idx := IndexOf(TEntryFilename.New(AFilename));
+  if idx = -1 then
+    result := ''
+  else
+    result := GetRawString(idx);
+end;
+
+procedure TMultiFileContainer.SetRawString(AIndex: integer;
+  AValue: RawByteString);
+begin
+  with Entry[AIndex] do
+    Add(Name, Extension, AValue, true);
+end;
+
+procedure TMultiFileContainer.SetRawStringByFilename(AFilename: string;
+  AValue: RawByteString);
+var
+  f: TEntryFilename;
+begin
+  f := TEntryFilename.New(AFilename);
+  Add(f.Name,f.Extension,AValue,true);
 end;
 
 procedure TMultiFileContainer.Init;
@@ -108,6 +253,8 @@ end;
 
 function TMultiFileContainer.AddEntry(AEntry: TMultiFileEntry; AIndex: integer): integer;
 begin
+  if not Assigned(FEntries) then
+    raise exception.Create('Entry list not created');
   if (AIndex >= 0) and (AIndex < FEntries.Count) then
   begin
     FEntries.Insert(AIndex, AEntry);
@@ -171,7 +318,7 @@ begin
 end;
 
 function TMultiFileContainer.Add(AName: utf8string; AExtension: utf8string;
-  AContent: utf8String; AOverwrite: boolean): integer;
+  AContent: RawByteString; AOverwrite: boolean): integer;
 var stream: TMemoryStream;
 begin
   stream := TMemoryStream.Create;
@@ -237,6 +384,12 @@ begin
   end;
 end;
 
+function TMultiFileContainer.Delete(AFilename: TEntryFilename;
+  ACaseSensitive: boolean): boolean;
+begin
+  result := Delete(AFilename.Name,AFilename.Extension,ACaseSensitive);
+end;
+
 function TMultiFileContainer.IndexOf(AEntry: TMultiFileEntry): integer;
 begin
   result := FEntries.IndexOf(AEntry);
@@ -262,6 +415,12 @@ begin
         exit;
       end;
   result := -1;
+end;
+
+function TMultiFileContainer.IndexOf(AFilename: TEntryFilename;
+  ACaseSensitive: boolean): integer;
+begin
+  result := IndexOf(AFilename.Name,AFilename.Extension,ACaseSensitive);
 end;
 
 procedure TMultiFileContainer.Clear;

--- a/bgrabitmap/bgraopengltype.pas
+++ b/bgrabitmap/bgraopengltype.pas
@@ -1071,13 +1071,17 @@ end;
 procedure TBGLCustomTexture.DrawAffine(const Origin, HAxis, VAxis: TPointF;
   AAlpha: byte);
 begin
+  {$PUSH}{$OPTIMIZATION OFF}
   DoDrawAffine(Origin,HAxis,VAxis, BGRA(255,255,255,AAlpha));
+  {$POP}
 end;
 
 procedure TBGLCustomTexture.DrawAffine(const Origin, HAxis, VAxis: TPointF;
   AColor: TBGRAPixel);
 begin
+  {$PUSH}{$OPTIMIZATION OFF}
   DoDrawAffine(Origin,HAxis,VAxis, AColor);
+  {$POP}
 end;
 
 procedure TBGLCustomTexture.DrawAffine(x, y: single;

--- a/bgrabitmap/bgrastreamlayers.pas
+++ b/bgrabitmap/bgrastreamlayers.pas
@@ -213,6 +213,7 @@ begin
       result.LayerOpacity[LayerIndex] := h.LayerOpacity shr 8;
       result.LayerOriginalGuid[LayerIndex] := h.OriginalGuid;
       result.LayerOriginalMatrix[LayerIndex] := h.OriginalMatrix;
+      result.LayerOriginalChanged[layerIndex] := false;
 
       if LayerEndPosition <> -1 then AStream.Position := LayerEndPosition;
     end;

--- a/bgrabitmap/bgrastreamlayers.pas
+++ b/bgrabitmap/bgrastreamlayers.pas
@@ -1,6 +1,7 @@
 unit BGRAStreamLayers;
 
 {$mode objfpc}{$H+}
+{$MODESWITCH ADVANCEDRECORDS}
 
 interface
 
@@ -18,7 +19,44 @@ procedure RegisterStreamLayers;
 implementation
 
 uses BGRABitmapTypes, BGRACompressableBitmap, zstream, BGRAReadLzp, BGRAWriteLzp,
-     BGRAUTF8;
+     BGRAUTF8, Math;
+
+type
+  PLayerHeader = ^TLayerHeader;
+
+  { TLayerHeader }
+
+  TLayerHeader = packed record
+    LayerOption, BlendOp,
+    LayerOfsX, LayerOfsY,
+    LayerUniqueId, LayerOpacity: Longint;
+    LayerBitmapSize: int64;
+    OriginalGuid: TGuid;
+    OriginalMatrix: TAffineMatrix;
+    procedure FixEndian;
+  end;
+
+{ TLayerHeader }
+
+procedure TLayerHeader.FixEndian;
+begin
+  LayerOption := NtoLE(LayerOption);
+  BlendOp := NtoLE(BlendOp);
+  LayerOfsX := NtoLE(LayerOfsX);
+  LayerOfsY := NtoLE(LayerOfsY);
+  LayerUniqueId := NtoLE(LayerUniqueId);
+  LayerOpacity := NtoLE(LayerOpacity);
+  LayerBitmapSize := NtoLE(LayerBitmapSize);
+  OriginalGuid.D1 := NtoBE(OriginalGuid.D1);
+  OriginalGuid.D2 := NtoBE(OriginalGuid.D2);
+  OriginalGuid.D3 := NtoBE(OriginalGuid.D3);
+  DWord(OriginalMatrix[1,1]) := NtoLE(DWord(OriginalMatrix[1,1]));
+  DWord(OriginalMatrix[2,1]) := NtoLE(DWord(OriginalMatrix[2,1]));
+  DWord(OriginalMatrix[1,2]) := NtoLE(DWord(OriginalMatrix[1,2]));
+  DWord(OriginalMatrix[2,2]) := NtoLE(DWord(OriginalMatrix[2,2]));
+  DWord(OriginalMatrix[1,3]) := NtoLE(DWord(OriginalMatrix[1,3]));
+  DWord(OriginalMatrix[2,3]) := NtoLE(DWord(OriginalMatrix[2,3]));
+end;
 
 procedure SaveLayeredBitmapToStream(AStream: TStream; ALayers: TBGRACustomLayeredBitmap);
 begin
@@ -40,7 +78,6 @@ const
   StreamHeader = 'TBGRALayeredBitmap'#26#0;
   StreamMaxLayerCount = 4096;
   StreamMaxHeaderSize = 256;
-
 
 function CheckStreamForLayers(AStream: TStream): boolean;
 var
@@ -68,21 +105,18 @@ function LoadLayersFromStream(AStream: TStream; out ASelectedLayerIndex: integer
 var
   OldPosition: Int64;
   HeaderFound: string;
-  NbLayers: LongInt;
+  NbLayers, canvasWidth, canvasHeight: LongInt;
   HeaderSize, LayerHeaderSize: LongInt;
-  LayerStackStartPosition, LayerHeaderPosition, LayerBitmapPosition, LayerEndPosition: Int64;
-  LayerOption,StackOption: LongInt;
+  LayerStackStartPosition, LayerHeaderPosition,
+  LayerBitmapPosition, LayerEndPosition, MemDirPos: Int64;
+  StackOption: LongInt;
   Layer: TBGRABitmap;
   i,LayerIndex: integer;
   LayerName: string;
-  LayerId: LongInt;
   Compression: TLzpCompression;
-  LayerVisible: boolean;
   LayerBlendOp: TBlendOperation;
-  LayerOffset: TPoint;
-  LayerOpacity: integer;
   LayerIdFound: boolean;
-  LayerBitmapSize: integer;
+  h: TLayerHeader;
 begin
   if Assigned(ADestination) then
   begin
@@ -115,47 +149,54 @@ begin
     StackOption := LEReadLongint(AStream);
     result.LinearBlend := (StackOption and 1) = 1;
     if (StackOption and 2) = 2 then Compression := lzpRLE else Compression:= lzpZStream;
+
+    if headerSize >= 20 then
+    begin
+      canvasWidth := LEReadLongint(AStream);
+      canvasHeight := LEReadLongint(AStream);
+      result.SetSize(canvasWidth,canvasHeight);
+    end;
+
+    if headerSize >= 28 then
+    begin
+      MemDirPos := LEReadInt64(AStream);
+    end else MemDirPos := 0;
     //end of header
+
+    if MemDirPos <> 0 then
+    begin
+      AStream.Position:= MemDirPos+OldPosition;
+      result.MemDirectory.LoadFromStream(AStream);
+    end;
 
     AStream.Position:= LayerStackStartPosition;
     for i := 0 to NbLayers-1 do
     begin
       LayerHeaderSize:= LEReadLongint(AStream);
+
       LayerHeaderPosition := AStream.Position;
       LayerBitmapPosition := LayerHeaderPosition + LayerHeaderSize;
       LayerEndPosition := -1;
 
-      LayerVisible := true;
-      LayerBlendOp := result.DefaultBlendingOperation;
-      LayerOffset := Point(0,0);
-      LayerId := 0;
-      LayerIdFound := false;
-      LayerOpacity := 255;
+      fillchar({%H-}h, sizeof(h), 0);
+      h.LayerOption := 1; //visible
+      h.BlendOp:= integer(result.DefaultBlendingOperation);
+      h.LayerOpacity := 65535; //opaque
+      h.LayerUniqueId:= maxLongint;
+      h.FixEndian;
 
-      if AStream.Position <= LayerBitmapPosition-4 then
-      begin
-        LayerOption := LEReadLongint(AStream);
-        LayerVisible := (LayerOption and 1) = 1;
-      end;
-      if AStream.Position <= LayerBitmapPosition-4 then
-        LayerBlendOp := TBlendOperation(LEReadLongint(AStream));
+      AStream.ReadBuffer(h, min(LayerHeaderSize, sizeof(h)));
+      h.FixEndian;
 
-      if AStream.Position <= LayerBitmapPosition-8 then
-      begin
-        LayerOffset := Point(LEReadLongint(AStream),LEReadLongint(AStream));
-        if AStream.Position <= LayerBitmapPosition-4 then
-        begin
-          LayerId := LEReadLongint(AStream);
-          LayerIdFound := true;
-        end;
-        if AStream.Position <= LayerBitmapPosition-4 then
-          LayerOpacity := LEReadLongint(AStream) shr 8;
-      end;
-      if AStream.Position <= LayerBitmapPosition-4 then
-      begin
-        LayerBitmapSize := LEReadLongint(AStream);
-        LayerEndPosition:= LayerBitmapPosition+LayerBitmapSize;
-      end;
+      if h.BlendOp > ord(high(TBlendOperation)) then
+        LayerBlendOp := result.DefaultBlendingOperation
+      else
+        LayerBlendOp:= TBlendOperation(h.BlendOp);
+
+      LayerIdFound := h.LayerUniqueId <> maxLongint;
+
+      if h.LayerBitmapSize > 0 then
+        LayerEndPosition:= LayerBitmapPosition+h.LayerBitmapSize;
 
       AStream.Position:= LayerBitmapPosition;
       Layer := LoadLayerBitmapFromStream(AStream, Compression);
@@ -164,12 +205,14 @@ begin
       Layer := nil;
 
       result.LayerName[LayerIndex] := LayerName;
-      result.LayerVisible[LayerIndex] := LayerVisible;
+      result.LayerVisible[LayerIndex] := (h.LayerOption and 1) = 1;
       result.BlendOperation[LayerIndex]:= LayerBlendOp;
-      result.LayerOffset[LayerIndex] := LayerOffset;
+      result.LayerOffset[LayerIndex] := Point(h.LayerOfsX,h.LayerOfsY);
       if ALoadLayerUniqueIds and LayerIdFound then
-        result.LayerUniqueId[LayerIndex] := LayerId;
-      result.LayerOpacity[LayerIndex] := LayerOpacity;
+        result.LayerUniqueId[LayerIndex] := h.LayerUniqueId;
+      result.LayerOpacity[LayerIndex] := h.LayerOpacity shr 8;
+      result.LayerOriginalGuid[LayerIndex] := h.OriginalGuid;
+      result.LayerOriginalMatrix[LayerIndex] := h.OriginalMatrix;
 
       if LayerEndPosition <> -1 then AStream.Position := LayerEndPosition;
     end;
@@ -185,48 +228,51 @@ end;
 
 procedure SaveLayersToStream(AStream: TStream; ALayers: TBGRACustomLayeredBitmap; ASelectedLayerIndex: integer; ACompression: TLzpCompression);
 var
-  LayerOption,StackOption: longint;
+  StackOption: longint;
   i: integer;
-  LayerHeaderSizePosition,LayerHeaderPosition: int64;
-  LayerBitmapPosition,LayerBitmapSizePosition,BitmapSize: int64;
-  LayerHeaderSize: integer;
+  DirectoryOffsetPos, EndPos: int64;
+  LayerHeaderPosition: int64;
+  LayerBitmapPosition,BitmapSize, startPos: int64;
   bitmap: TBGRABitmap;
+  h: TLayerHeader;
 begin
   if (ASelectedLayerIndex < -1) or (ASelectedLayerIndex >= ALayers.NbLayers) then
     raise exception.Create('Selected layer out of bounds');
+  startPos := AStream.Position;
   AStream.Write(StreamHeader[1], length(StreamHeader));
-  LEWriteLongint(AStream, 12); //header size
+  LEWriteLongint(AStream, 28); //header size
   LEWriteLongint(AStream, ALayers.NbLayers);
   LEWriteLongint(AStream, ASelectedLayerIndex);
   StackOption := 0;
   if ALayers.LinearBlend then StackOption := StackOption or 1;
   if ACompression = lzpRLE then StackOption:= StackOption or 2;
   LEWriteLongint(AStream, StackOption);
+  LEWriteLongint(AStream, ALayers.Width);
+  LEWriteLongint(AStream, ALayers.Height);
+  DirectoryOffsetPos := AStream.Position;
+  LEWriteInt64(AStream, 0);
   //end of header
 
   for i := 0 to ALayers.NbLayers-1 do
   begin
-    LayerHeaderSizePosition:= AStream.Position;
-    LEWriteLongint(AStream, 0); //header size not computed yet
+    LEWriteLongint(AStream, sizeof(h));
     LayerHeaderPosition := AStream.Position;
 
-    LayerOption := 0;
-    if ALayers.LayerVisible[i] then LayerOption:= LayerOption or 1;
-    LEWriteLongint(AStream, LayerOption);
-    LEWriteLongint(AStream, Longint(ALayers.BlendOperation[i]));
-    LEWriteLongint(AStream, ALayers.LayerOffset[i].x);
-    LEWriteLongint(AStream, ALayers.LayerOffset[i].y);
-    LEWriteLongint(AStream, ALayers.LayerUniqueId[i]);
-    LEWriteLongint(AStream, integer(ALayers.LayerOpacity[i])*$101);
-    LayerBitmapSizePosition:=AStream.Position;
-    LEWriteLongint(AStream, 0);
-    LayerBitmapPosition:=AStream.Position;
-    LayerHeaderSize := LayerBitmapPosition - LayerHeaderPosition;
-    AStream.Position:= LayerHeaderSizePosition;
-    LEWriteLongint(AStream, LayerHeaderSize);
+    h.LayerOption:= 0;
+    if ALayers.LayerVisible[i] then h.LayerOption:= h.LayerOption or 1;
+    h.BlendOp:= Longint(ALayers.BlendOperation[i]);
+    h.LayerOfsX:= ALayers.LayerOffset[i].x;
+    h.LayerOfsY:= ALayers.LayerOffset[i].y;
+    h.LayerUniqueId:= ALayers.LayerUniqueId[i];
+    h.LayerOpacity:= integer(ALayers.LayerOpacity[i])*$101;
+    h.LayerBitmapSize := 0;
+    h.OriginalGuid := ALayers.LayerOriginalGuid[i];
+    h.OriginalMatrix := ALayers.LayerOriginalMatrix[i];
+    h.FixEndian;
+    AStream.WriteBuffer(h, sizeof(h));
     //end of layer header
 
-    AStream.Position:= LayerBitmapPosition;
+    LayerBitmapPosition:=AStream.Position;
     bitmap := ALayers.GetLayerBitmapDirectly(i);
     if bitmap <> nil then
       SaveLayerBitmapToStream(AStream, bitmap, ALayers.LayerName[i], ACompression)
@@ -236,12 +282,23 @@ begin
       SaveLayerBitmapToStream(AStream, bitmap, ALayers.LayerName[i], ACompression);
       bitmap.free;
     end;
+
     BitmapSize := AStream.Position - LayerBitmapPosition;
-    if BitmapSize > maxLongint then
-      raise exception.Create('Image too big');
-    AStream.Position:= LayerBitmapSizePosition;
-    LEWriteLongint(AStream, BitmapSize);
+
+    //store back the bitmap size
+    AStream.Position:= LayerHeaderPosition + integer(PtrUInt(@PLayerHeader(nil)^.LayerBitmapSize));
+    LEWriteInt64(AStream, BitmapSize);
+
     AStream.Position:= LayerBitmapPosition+BitmapSize;
+  end;
+
+  EndPos:= AStream.Position;
+  if ALayers.HasMemFiles then
+  begin
+    AStream.Position := DirectoryOffsetPos;
+    LEWriteInt64(AStream,EndPos-startPos);
+    AStream.Position:= EndPos;
+    ALayers.MemDirectory.SaveToStream(AStream);
   end;
 end;
 

--- a/bgrabitmap/bgrastreamlayers.pas
+++ b/bgrabitmap/bgrastreamlayers.pas
@@ -348,5 +348,9 @@ begin
   LayeredBitmapCheckStreamProc := @CheckStreamForLayers;
 end;
 
+initialization
+
+  RegisterStreamLayers;
+
 end.
 

--- a/bgrabitmap/bgrasvg.pas
+++ b/bgrabitmap/bgrasvg.pas
@@ -775,8 +775,6 @@ begin
   ACanvas2d.save;
   ACanvas2d.translate(x,y);
   ACanvas2d.scale(destDpi.x/Units.DpiX,destDpi.y/Units.DpiY);
-  ACanvas2d.strokeResetTransform;
-  ACanvas2d.strokeScale(destDpi.x/Units.DpiX,destDpi.y/Units.DpiY);
   with GetViewBoxAlignment(AHorizAlign,AVertAlign) do ACanvas2d.translate(x,y);
   Draw(ACanvas2d, 0,0, cuPixel);
   ACanvas2d.restore;
@@ -789,6 +787,7 @@ begin
   acanvas2d.linearBlend := true;
   ACanvas2d.save;
   ACanvas2d.translate(x,y);
+  ACanvas2d.strokeMatrix := ACanvas2d.matrix;
   Content.Draw(ACanvas2d,AUnit);
   ACanvas2d.restore;
   ACanvas2d.linearBlend := prevLinearBlend;
@@ -804,8 +803,6 @@ begin
   ACanvas2d.save;
   ACanvas2d.translate(x,y);
   ACanvas2d.scale(destDpi.x/Units.DpiX,destDpi.y/Units.DpiY);
-  ACanvas2d.strokeResetTransform;
-  ACanvas2d.strokeScale(destDpi.x/Units.DpiX,destDpi.y/Units.DpiY);
   Draw(ACanvas2d, 0,0, cuPixel);
   ACanvas2d.restore;
 end;
@@ -827,15 +824,9 @@ begin
   begin
     ACanvas2d.translate(-min.x,-min.y);
     if size.x <> 0 then
-    begin
       ACanvas2d.scale(w/size.x,1);
-      ACanvas2d.strokeScale(w/size.x,1);
-    end;
     if size.y <> 0 then
-    begin
       ACanvas2d.scale(1,h/size.y);
-      ACanvas2d.strokeScale(1,h/size.y);
-    end;
   end;
   Draw(ACanvas2d, 0,0);
   ACanvas2d.restore;

--- a/bgrabitmap/bgrasvg.pas
+++ b/bgrabitmap/bgrasvg.pas
@@ -9,6 +9,21 @@ uses
   BGRACanvas2D, BGRASVGType;
 
 type
+  TCSSUnit = BGRAUnits.TCSSUnit;
+
+const
+  cuCustom = BGRAUnits.cuCustom;
+  cuPixel = BGRAUnits.cuPixel;
+  cuCentimeter = BGRAUnits.cuCentimeter;
+  cuMillimeter = BGRAUnits.cuMillimeter;
+  cuInch = BGRAUnits.cuInch;
+  cuPica = BGRAUnits.cuPica;
+  cuPoint = BGRAUnits.cuPoint;
+  cuFontEmHeight = BGRAUnits.cuFontEmHeight;
+  cuFontXHeight = BGRAUnits.cuFontXHeight;
+  cuPercent = BGRAUnits.cuPercent;
+
+type
   TSVGViewBox = record
     min, size: TPointF;
   end;

--- a/bgrabitmap/bgratext.pas
+++ b/bgrabitmap/bgratext.pas
@@ -707,12 +707,14 @@ begin
     begin
       grayscaleMask := TGrayscaleMask.Create(temp, cGreen);
       FreeAndNil(temp);
+      {$IFNDEF LINUX}
       pb := grayscaleMask.Data;
       for n := grayscaleMask.NbPixels - 1 downto 0 do
       begin
         pb^:= GammaExpansionTab[pb^] shr 8;
         Inc(pb);
       end;
+      {$ENDIF}
     end;
   end;
 end;

--- a/bgrabitmap/bgratext.pas
+++ b/bgrabitmap/bgratext.pas
@@ -514,7 +514,7 @@ begin
 end;
 {$ELSE}
 begin
-  result := AFontFullHeight;
+  result := AFontHeight;
 end;
 {$ENDIF}
 

--- a/bgrabitmap/bgratransform.pas
+++ b/bgrabitmap/bgratransform.pas
@@ -20,11 +20,13 @@ type
     function GetAsPolygon: ArrayOfTPointF;
     function GetBottomRight: TPointF;
     function GetIsEmpty: boolean;
+    function GetRectBounds: TRect;
   public
     TopLeft, TopRight,
     BottomLeft: TPointF;
     class function EmptyBox: TAffineBox;
     class function AffineBox(ATopLeft, ATopRight, ABottomLeft: TPointF): TAffineBox;
+    property RectBounds: TRect read GetRectBounds;
     property BottomRight: TPointF read GetBottomRight;
     property IsEmpty: boolean read GetIsEmpty;
     property AsPolygon: ArrayOfTPointF read GetAsPolygon;
@@ -199,6 +201,7 @@ operator =(M,N: TAffineMatrix): boolean;
 //matrix multiplication by a vector (apply transformation to that vector)
 operator *(M: TAffineMatrix; V: TPointF): TPointF;
 operator *(M: TAffineMatrix; A: array of TPointF): ArrayOfTPointF;
+operator *(M: TAffineMatrix; ab: TAffineBox): TAffineBox;
 
 //check if matrix is inversible
 function IsAffineMatrixInversible(M: TAffineMatrix): boolean;
@@ -428,6 +431,13 @@ begin
       result[i] := M*A[i];
 end;
 
+operator*(M: TAffineMatrix; ab: TAffineBox): TAffineBox;
+begin
+  result.TopLeft := M*ab.TopLeft;
+  result.TopRight := M*ab.TopRight;
+  result.BottomLeft := M*ab.BottomLeft;
+end;
+
 function IsAffineMatrixInversible(M: TAffineMatrix): boolean;
 begin
   result := M[1,1]*M[2,2]-M[1,2]*M[2,1] <> 0;
@@ -627,6 +637,27 @@ end;
 function TAffineBox.GetIsEmpty: boolean;
 begin
   result := isEmptyPointF(TopRight) or isEmptyPointF(BottomLeft) or isEmptyPointF(TopLeft);
+end;
+
+function TAffineBox.GetRectBounds: TRect;
+var
+  x1,y1,x2,y2: single;
+begin
+  x1 := TopLeft.x; x2 := x1;
+  y1 := TopLeft.y; y2 := y1;
+  if TopRight.x > x2 then x2 := TopRight.x;
+  if TopRight.x < x1 then x1 := TopRight.x;
+  if TopRight.y > y2 then y2 := TopRight.y;
+  if TopRight.y < y1 then y1 := TopRight.y;
+  if BottomLeft.x > x2 then x2 := BottomLeft.x;
+  if BottomLeft.x < x1 then x1 := BottomLeft.x;
+  if BottomLeft.y > y2 then y2 := BottomLeft.y;
+  if BottomLeft.y < y1 then y1 := BottomLeft.y;
+  if BottomRight.x > x2 then x2 := BottomRight.x;
+  if BottomRight.x < x1 then x1 := BottomRight.x;
+  if BottomRight.y > y2 then y2 := BottomRight.y;
+  if BottomRight.y < y1 then y1 := BottomRight.y;
+  result := Rect(floor(x1),floor(y1),ceil(x2),ceil(y2));
 end;
 
 class function TAffineBox.EmptyBox: TAffineBox;

--- a/bgrabitmap/bgrautf8.pas
+++ b/bgrabitmap/bgrautf8.pas
@@ -74,6 +74,8 @@ function GetFirstStrongBidiClass(const sUTF8: string): TUnicodeBidiClass;
 function GetLastStrongBidiClass(const sUTF8: string): TUnicodeBidiClass;
 
 //little endian stream functions
+function LEReadInt64(Stream: TStream): int64;
+procedure LEWriteInt64(Stream: TStream; AValue: int64);
 function LEReadLongint(Stream: TStream): longint;
 procedure LEWriteLongint(Stream: TStream; AValue: LongInt);
 function LEReadByte(Stream: TStream): byte;
@@ -707,6 +709,19 @@ begin
     if (CharIndex<>0) or (Len<0) then
       Result:=nil;
   end;
+end;
+
+function LEReadInt64(Stream: TStream): int64;
+begin
+  Result := 0;
+  stream.Read(Result, sizeof(Result));
+  Result := LEtoN(Result);
+end;
+
+procedure LEWriteInt64(Stream: TStream; AValue: int64);
+begin
+  AValue := NtoLE(AValue);
+  stream.Write(AValue, sizeof(AValue));
 end;
 
 function LEReadLongint(Stream: TStream): longint;

--- a/bgrabitmap/bgrautf8.pas
+++ b/bgrabitmap/bgrautf8.pas
@@ -72,6 +72,8 @@ function GetUnicodeBidiClass(P: PChar): TUnicodeBidiClass;
 function GetUnicodeBidiClass(u: cardinal): TUnicodeBidiClass;
 function GetFirstStrongBidiClass(const sUTF8: string): TUnicodeBidiClass;
 function GetLastStrongBidiClass(const sUTF8: string): TUnicodeBidiClass;
+function IsZeroWidthString(const sUTF8: string): boolean;
+function IsZeroWidthUnicode(u: cardinal): boolean;
 
 //little endian stream functions
 function LEReadInt64(Stream: TStream): int64;
@@ -693,6 +695,35 @@ begin
   end;
   exit(ubcUnknown);
 end;
+
+function IsZeroWidthString(const sUTF8: string): boolean;
+var
+  p,pEnd: PChar;
+  charLen: Integer;
+  u: Cardinal;
+begin
+  if sUTF8 = '' then exit(true);
+  p := @sUTF8[1];
+  pEnd := p + length(sUTF8);
+  while p < pEnd do
+  begin
+    charLen := UTF8CharacterLength(p);
+    if (charLen = 0) or (p+charLen > pEnd) then break;
+    u := UTF8CodepointToUnicode(p, charLen);
+    if not IsZeroWidthUnicode(u) then exit(false);
+    inc(p,charLen);
+  end;
+  exit(true);
+end;
+
+function IsZeroWidthUnicode(u: cardinal): boolean;
+begin
+  case u of
+  $200B,$200C,$200D,$FEFF,$200E,$200F: result := true;
+  else result := false;
+  end;
+end;
+
 
 function UTF8CharStart(UTF8Str: PChar; Len, CharIndex: PtrInt): PChar;
 var

--- a/bgrabitmap/bgravectorize.pas
+++ b/bgrabitmap/bgravectorize.pas
@@ -1383,7 +1383,7 @@ begin
       OldHeight := FFont.Height;
       FFont.Height := FontEmHeightSign * 100;
       lEmHeight := BGRATextSize(FFont, fqSystem, 'Hg', 1).cy;
-      FFont.Height := FontFullHeightSign * 100;
+      FFont.Height := FixLCLFontFullHeight(FFont.Name, FontFullHeightSign * 100);
       lFullHeight := BGRATextSize(FFont, fqSystem, 'Hg', 1).cy;
       if lEmHeight = 0 then
         FFontEmHeightRatio := 1
@@ -1424,7 +1424,8 @@ begin
     ClearGlyphs;
     FFont.Name := FName;
     FFont.Style := FStyle;
-    FFont.Height := FontFullHeightSign * FResolution;
+    FFont.Height := FixLCLFontFullHeight(FFont.Name, FontFullHeightSign * FResolution);
+    FFont.Quality := fqNonAntialiased;
     FFontEmHeightRatio := 1;
     FFontEmHeightRatioComputed := false;
     fillchar(FFontPixelMetric,sizeof(FFontPixelMetric),0);
@@ -1983,6 +1984,7 @@ end;
 function TBGRAVectorizedFont.GetGlyph(AIdentifier: string): TBGRAGlyph;
 var size: TSize;
   g: TBGRAPolygonalGlyph;
+  i: Integer;
 begin
   Result:=inherited GetGlyph(AIdentifier);
   if (result = nil) and (FResolution > 0) and (FFont <> nil) then
@@ -1992,7 +1994,6 @@ begin
     FBuffer.SetSize(size.cx+size.cy,size.cy);
     FBuffer.Fill(BGRAWhite);
     FBuffer.Canvas.Font := FFont;
-    FBuffer.Canvas.Font.Quality := fqNonAntialiased;
     FBuffer.Canvas.Font.Color := clBlack;
     FBuffer.Canvas.TextOut(size.cy div 2,0,AIdentifier);
     g.SetPoints(VectorizeMonochrome(FBuffer,1/FResolution,False));

--- a/bgrabitmap/bgrawinbitmap.pas
+++ b/bgrabitmap/bgrawinbitmap.pas
@@ -54,7 +54,7 @@ type
     procedure LoadFromBitmapIfNeeded; override;
     procedure Draw(ACanvas: TCanvas; x, y: integer; Opaque: boolean=True); override;
     procedure Draw(ACanvas: TCanvas; Rect: TRect; Opaque: boolean = True); override;
-    procedure DataDrawOpaque(ACanvas: TCanvas; Rect: TRect; AData: Pointer;
+    procedure DataDrawOpaque(ACanvas: TCanvas; ARect: TRect; AData: Pointer;
       ALineOrder: TRawImageLineOrder; AWidth, AHeight: integer); override;
     procedure GetImageFromCanvas(CanvasSource: TCanvas; x, y: integer); override;
   end;
@@ -182,7 +182,7 @@ begin
   if TBGRAPixel_RGBAOrder then SwapRedBlue;
 end;
 
-procedure TBGRAWinBitmap.DataDrawOpaque(ACanvas: TCanvas; Rect: TRect;
+procedure TBGRAWinBitmap.DataDrawOpaque(ACanvas: TCanvas; ARect: TRect;
   AData: Pointer; ALineOrder: TRawImageLineOrder; AWidth, AHeight: integer);
 var
   info:      TBITMAPINFO;
@@ -205,8 +205,8 @@ begin
   end;
 
   info := DIBitmapInfo(AWidth, AHeight);
-  StretchDIBits(ACanvas.Handle, Rect.Left, Rect.Top, Rect.Right -
-    Rect.Left, Rect.Bottom - Rect.Top,
+  StretchDIBits(ACanvas.Handle, ARect.Left, ARect.Top, ARect.Right -
+    ARect.Left, ARect.Bottom - ARect.Top,
     0, 0, AWidth, AHeight, AData, info, DIB_RGB_COLORS, SRCCOPY);
 
   if Temp <> nil then

--- a/bgrabitmap/bgrawinresource.pas
+++ b/bgrabitmap/bgrawinresource.pas
@@ -97,7 +97,7 @@ type
   public
     constructor Create(AContainer: TMultiFileContainer; ATypeNameOrId: TNameOrId; AEntryNameOrId: TNameOrId; const AResourceInfo: TResourceInfo; ADataStream: TStream);
     destructor Destroy; override;
-    function CopyTo(ADestination: TStream): integer; override;
+    function CopyTo(ADestination: TStream): int64; override;
   end;
 
   { TBitmapResourceEntry }
@@ -108,7 +108,7 @@ type
     function GetExtension: utf8string; override;
   public
     constructor Create(AContainer: TMultiFileContainer; AEntryNameOrId: TNameOrId; const AResourceInfo: TResourceInfo; ADataStream: TStream);
-    function CopyTo(ADestination: TStream): integer; override;
+    function CopyTo(ADestination: TStream): int64; override;
     procedure CopyFrom(ASource: TStream);
   end;
 
@@ -153,7 +153,7 @@ type
     constructor Create(AContainer: TMultiFileContainer; ATypeNameOrId: TNameOrId; AEntryNameOrId: TNameOrId; const AResourceInfo: TResourceInfo; ADataStream: TStream);
     constructor Create(AContainer: TMultiFileContainer; ATypeNameOrId: TNameOrId; AEntryNameOrId: TNameOrId; const AResourceInfo: TResourceInfo);
     procedure Clear;
-    function CopyTo(ADestination: TStream): integer; override;
+    function CopyTo(ADestination: TStream): int64; override;
     procedure CopyFrom(ASource: TStream);
     property NbIcons: integer read GetNbIcons;
   end;
@@ -373,7 +373,7 @@ begin
   FGroupIconHeader.ImageCount := 0;
 end;
 
-function TGroupIconOrCursorEntry.CopyTo(ADestination: TStream): integer;
+function TGroupIconOrCursorEntry.CopyTo(ADestination: TStream): int64;
 var
   fileDir: packed array of TIconFileDirEntry;
   offset, written, i: integer;
@@ -517,7 +517,7 @@ begin
   inherited Create(AContainer, NameOrId(RT_BITMAP), AEntryNameOrId, AResourceInfo, ADataStream);
 end;
 
-function TBitmapResourceEntry.CopyTo(ADestination: TStream): integer;
+function TBitmapResourceEntry.CopyTo(ADestination: TStream): int64;
 var fileHeader: TBitMapFileHeader;
 begin
   result := 0;
@@ -605,7 +605,7 @@ begin
   inherited Destroy;
 end;
 
-function TUnformattedResourceEntry.CopyTo(ADestination: TStream): integer;
+function TUnformattedResourceEntry.CopyTo(ADestination: TStream): int64;
 begin
   if FDataStream.Size > 0 then
   begin

--- a/bgrabitmap/geometrytypes.inc
+++ b/bgrabitmap/geometrytypes.inc
@@ -18,6 +18,7 @@ type
   end;
   {$endif}
 
+  {* An affine matrix contains three 2D vectors: the image of x, the image of y and the translation }
   TAffineMatrix = array[1..2,1..3] of single;
 
   {$if FPC_FULLVERSION>=030001}

--- a/test/testbgrafunc/umain.pas
+++ b/test/testbgrafunc/umain.pas
@@ -44,7 +44,7 @@ uses utest1, utest2, utest3, utest4, utest5, utest6, utest7,
      utest8, utest9, utest10, utest11, utest14, utest15, utest16, utest17,
      utest18, utest19, utest22, utest23, utest24, utest25, utest26,
      utest27, utest31, utest32, utest33, BGRAScene3D,
-     BGRABitmapTypes, LCLIntf;
+     BGRABitmapTypes, LCLIntf, BGRAText;
 
 const
     TestCount = 33;
@@ -138,7 +138,7 @@ begin
       ptText := Point(3,ClientHeight-25);
       with self.Canvas do
       begin
-        Font.Height := 25;
+        Font.Height := FixLCLFontFullHeight(Font.Name,25);
         Font.Style := [fsBold];
         Brush.Style := bsClear;
         Font.Color := clBlack;

--- a/update_BGRABitmap.json
+++ b/update_BGRABitmap.json
@@ -10,12 +10,12 @@
       "ForceNotify" : false,
       "InternalVersion" : 1,
       "Name" : "bgrabitmappack.lpk",
-      "Version" : "9.7.3.0"
+      "Version" : "9.7.4.0"
     }
   ],
   "UpdatePackageData" : {
     "DisableInOPM" : false,
-    "DownloadZipURL" : "https://github.com/bgrabitmap/bgrabitmap/archive/v9.7.3.zip",
+    "DownloadZipURL" : "https://github.com/bgrabitmap/bgrabitmap/archive/v9.7.4.zip",
     "Name" : "bgrabitmap-master"
   }
 }

--- a/update_BGRABitmap.json
+++ b/update_BGRABitmap.json
@@ -10,12 +10,12 @@
       "ForceNotify" : false,
       "InternalVersion" : 1,
       "Name" : "bgrabitmappack.lpk",
-      "Version" : "9.7.4.0"
+      "Version" : "9.8.0.0"
     }
   ],
   "UpdatePackageData" : {
     "DisableInOPM" : false,
-    "DownloadZipURL" : "https://github.com/bgrabitmap/bgrabitmap/archive/v9.7.4.zip",
+    "DownloadZipURL" : "https://github.com/bgrabitmap/bgrabitmap/archive/v9.8.zip",
     "Name" : "bgrabitmap-master"
   }
 }


### PR DESCRIPTION
Text/font:
- when splitting text, adding unicode orientation characters only when necessary and avoid infinite loop due to zero-width characters
- fixed font antialiasing gamma correction on linux

Bitmap/Canvas:
- added overload of PutImage to accept TBitmap parameter
- fixing alpha correction for Linux and MacOS (when drawing using LCL Canvas)
- optimized DrawPart (useful on Linux to update portion of virtual screen)

Miscellaneous:
- explicit overload for GetPixelCycle
- avoid some compiler bugs
- optimized blending functions (overall rendering speed on TBGRABitmap should be better)
- fixed SSE code for 64bit CPU
- fixed SVG rendering when Canvas2D has a transform
- other minor changes

Layers: started an class hierarchy for adding custom classes to the layer system (work in progress).