### PR TITLE
Fixed bgrafpguibitmap.pas for Unix.

### DIFF
--- a/bgrabitmap/bgrafpguibitmap.pas
+++ b/bgrabitmap/bgrafpguibitmap.pas
@@ -45,8 +45,10 @@ type
       ALineOrder: TRawImageLineOrder; AWidth, AHeight: integer); override;
     procedure TakeScreenshot({%H-}ARect: TRect); override; //not available
     procedure TakeScreenshotOfPrimaryMonitor; override; //not available
+    {$IFDEF windows}
     procedure LoadFromDevice({%H-}DC: System.THandle); override; //not available
     procedure LoadFromDevice({%H-}DC: System.THandle; {%H-}ARect: TRect); override; //not available
+    {$endif} 
     property BitmapTransparent: boolean read GetBitmapTransparent write SetBitmapTransparent;
     property Canvas: TBGRACanvas read GetPseudoCanvas;
   end;
@@ -253,6 +255,7 @@ begin
   NotAvailable;
 end;
 
+{$IFDEF windows}
 procedure TBGRAfpGUIBitmap.LoadFromDevice(DC: System.THandle);
 begin
   NotAvailable;
@@ -262,6 +265,7 @@ procedure TBGRAfpGUIBitmap.LoadFromDevice(DC: System.THandle; ARect: TRect);
 begin
   NotAvailable;
 end;
+{$endif}
 
 end.
 


### PR DESCRIPTION
Hello.

Congratulation for that **great** work you have done for fpGUI.

It works perfectly. 
There are few change neeed to compile it under Linux (see pull request)

Here the error messages:

> bgrafpguibitmap.pas(51,14) Error: (3058) There is no method in an ancestor class to be overridden: "LoadFromDevice(LongInt;TRect);"
bgrafpguibitmap.pas(57,1) Fatal: (10026) There were 2 errors compiling module, stopping
Fatal: (1018) Compilation aborted

Fre;D
