### PR TITLE
Dev bgrabitmap v10.2

### DIFF
--- a/bgrabitmap/bgrabitmappack.lpk
+++ b/bgrabitmap/bgrabitmappack.lpk
@@ -29,7 +29,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="10" Minor="1"/>
+    <Version Major="10" Minor="2"/>
     <Files Count="134">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack4fpgui.lpk
+++ b/bgrabitmap/bgrabitmappack4fpgui.lpk
@@ -33,7 +33,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="10" Minor="1"/>
+    <Version Major="10" Minor="2"/>
     <Files Count="97">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack4nogui.lpk
+++ b/bgrabitmap/bgrabitmappack4nogui.lpk
@@ -35,7 +35,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="10" Minor="1"/>
+    <Version Major="10" Minor="2"/>
     <Files Count="101">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmaptypes.pas
+++ b/bgrabitmap/bgrabitmaptypes.pas
@@ -37,7 +37,7 @@ uses
 
 
 const
-  BGRABitmapVersion = 10010000;
+  BGRABitmapVersion = 10020000;
 
   function BGRABitmapVersionStr: string;
 

--- a/bgrabitmap/bgracanvas.pas
+++ b/bgrabitmap/bgracanvas.pas
@@ -426,14 +426,7 @@ end;
 procedure TBGRAPen.SetPenStyle(const AValue: TPenStyle);
 begin
   if AValue = psPattern then exit;
-  Case AValue of
-  psSolid: FCustomPenStyle := SolidPenStyle;
-  psDash: FCustomPenStyle := DashPenStyle;
-  psDot: FCustomPenStyle := DotPenStyle;
-  psDashDot: FCustomPenStyle := DashDotPenStyle;
-  psDashDotDot: FCustomPenStyle := DashDotDotPenStyle;
-  else FCustomPenStyle := ClearPenStyle;
-  end;
+  FCustomPenStyle := PenStyleToBGRA(AValue);
   FPenStyle := AValue;
 end;
 

--- a/bgrabitmap/bgracanvas2d.pas
+++ b/bgrabitmap/bgracanvas2d.pas
@@ -1331,14 +1331,8 @@ end;
 
 procedure TBGRACanvas2D.lineStyle(AStyle: TPenStyle);
 begin
-  case AStyle of
-    psSolid: lineStyle(SolidPenStyle);
-    psDash: lineStyle(DashPenStyle);
-    psDot: lineStyle(DotPenStyle);
-    psDashDot: lineStyle(DashDotPenStyle);
-    psDashDotDot: lineStyle(DashDotDotPenStyle);
-    psClear: lineStyle(ClearPenStyle);
-  end;
+  if AStyle = psPattern then exit;
+  lineStyle(PenStyleToBGRA(AStyle));
 end;
 
 function TBGRACanvas2D.QueryInterface({$IFDEF FPC_HAS_CONSTREF}constref{$ELSE}const{$ENDIF} IID: TGUID; out Obj): HResult; {$IF (not defined(WINDOWS)) AND (FPC_FULLVERSION>=20501)}cdecl{$ELSE}stdcall{$IFEND};

--- a/bgrabitmap/bgrafiltertype.pas
+++ b/bgrabitmap/bgrafiltertype.pas
@@ -166,7 +166,7 @@ begin
     end;
   end else
   begin
-    FSourceScanner.ScanMoveTo(X,Y);
+    FSourceScanner.ScanMoveTo(X+FScanOffset.X,Y+FScanOffset.Y);
     pexp := result;
     while Count > 0 do
     begin

--- a/bgrabitmap/bgragradientscanner.pas
+++ b/bgrabitmap/bgragradientscanner.pas
@@ -1467,6 +1467,7 @@ constructor TBGRAGradientScanner.Create(gradient: TBGRACustomGradient;
 begin
   FGradient := gradient;
   FGradientOwner := AGradientOwner;
+  InitGradient;
   Init(AGradientType,AOrigin,d1,AffineMatrixIdentity,Sinus);
 end;
 
@@ -1477,6 +1478,7 @@ begin
   if AGradientType in[gtLinear,gtReflected] then raise EInvalidArgument.Create('Two directions are not required for linear and reflected gradients');
   FGradient := gradient;
   FGradientOwner := AGradientOwner;
+  InitGradient;
   Init(AGradientType,AOrigin,d1,d2,AffineMatrixIdentity,Sinus);
 end;
 
@@ -1486,6 +1488,7 @@ constructor TBGRAGradientScanner.Create(gradient: TBGRACustomGradient;
 begin
   FGradient := gradient;
   FGradientOwner := AGradientOwner;
+  InitGradient;
   Init(AOrigin, ARadius, AFocal, AFocalRadius, AffineMatrixIdentity, AffineMatrixIdentity);
 end;
 

--- a/bgrabitmap/bgralayers.pas
+++ b/bgrabitmap/bgralayers.pas
@@ -1115,11 +1115,12 @@ begin
     if ASharedLayerIds and (ASource is TBGRALayeredBitmap) then
       LayerUniqueId[idx] := TBGRALayeredBitmap(ASource).LayerUniqueId[i];
     for idxOrig := 0 to high(usedOriginals) do
-      if usedOriginals[i].sourceGuid = ASource.LayerOriginalGuid[i] then
+      if usedOriginals[idxOrig].sourceGuid = ASource.LayerOriginalGuid[i] then
       begin
-        LayerOriginalGuid[idx] := usedOriginals[i].newGuid;
+        LayerOriginalGuid[idx] := usedOriginals[idxOrig].newGuid;
         LayerOriginalMatrix[idx] := ASource.LayerOriginalMatrix[i];
         LayerOriginalRenderStatus[idx] := ASource.LayerOriginalRenderStatus[i];
+        break;
       end;
   end;
 end;

--- a/bgrabitmap/bgramemdirectory.pas
+++ b/bgrabitmap/bgramemdirectory.pas
@@ -329,10 +329,10 @@ begin
   for i := 0 to Count-1 do
   if i <> idx then
   begin
-    if Entry[i].CompareNameAndExtension(ANewName,AExtension,ACaseSensitive) <> 0 then
+    if Entry[i].CompareNameAndExtension(ANewName,AExtension,ACaseSensitive) = 0 then
       raise exception.Create('Name with extension already in use');
   end;
-  Entry[i].Name := ANewName;
+  Entry[idx].Name := ANewName;
   exit(true);
 end;
 

--- a/bgrabitmap/bgrapen.pas
+++ b/bgrabitmap/bgrapen.pas
@@ -113,6 +113,7 @@ function IsClearPenStyle(ACustomPenStyle: TBGRAPenStyle): boolean;
 function DuplicatePenStyle(ACustomPenStyle: array of single): TBGRAPenStyle;
 function PenStyleEqual(AStyle1, AStyle2: TBGRAPenStyle): boolean;
 function BGRAToPenStyle(ACustomPenStyle: TBGRAPenStyle): TPenStyle;
+function PenStyleToBGRA(APenStyle: TPenStyle): TBGRAPenStyle;
 
 implementation
 
@@ -216,6 +217,18 @@ begin
   if PenStyleEqual(ACustomPenStyle, DashDotPenStyle) then exit(psDashDot);
   if PenStyleEqual(ACustomPenStyle, DashDotDotPenStyle) then exit(psDashDotDot);
   exit(psPattern);
+end;
+
+function PenStyleToBGRA(APenStyle: TPenStyle): TBGRAPenStyle;
+begin
+  Case APenStyle of
+  psSolid: result := SolidPenStyle;
+  psDash: result := DashPenStyle;
+  psDot: result := DotPenStyle;
+  psDashDot: result := DashDotPenStyle;
+  psDashDotDot: result := DashDotDotPenStyle;
+  else result := ClearPenStyle;
+  end;
 end;
 
 function PenStyleEqual(AStyle1, AStyle2: TBGRAPenStyle): boolean;
@@ -1205,15 +1218,8 @@ end;
 
 procedure TBGRAPenStroker.SetPenStyle(AValue: TPenStyle);
 begin
-  if FPenStyle=AValue then Exit;
-  Case AValue of
-  psSolid: FCustomPenStyle := SolidPenStyle;
-  psDash: FCustomPenStyle := DashPenStyle;
-  psDot: FCustomPenStyle := DotPenStyle;
-  psDashDot: FCustomPenStyle := DashDotPenStyle;
-  psDashDotDot: FCustomPenStyle := DashDotDotPenStyle;
-  else FCustomPenStyle := ClearPenStyle;
-  end;
+  if (FPenStyle=AValue) or (AValue=psPattern) then Exit;
+  FCustomPenStyle := PenStyleToBGRA(AValue);
   FPenStyle := AValue;
 end;
 

--- a/bgrabitmap/unibitmap.inc
+++ b/bgrabitmap/unibitmap.inc
@@ -1616,6 +1616,7 @@ procedure TCustomUniversalBitmap.ScanNextCustomChunk(var ACount: integer; out
 var
   quantity: Integer;
 begin
+  if (FScanWidth = 0) or (FScanHeight = 0) then raise exception.Create('Zero size scanner');
   APixels := FScanPtr;
   quantity := FScanWidth-FScanCurX;
   if ACount <= quantity then

--- a/bgrabitmap/universaldrawer.pas
+++ b/bgrabitmap/universaldrawer.pas
@@ -137,7 +137,7 @@ implementation
 
 uses BGRAPolygon, BGRAPolygonAliased, BGRAPath, BGRAFillInfo, BGRAUTF8,
   BGRAReadBMP, BGRAReadJpeg, BGRAWritePNG, BGRAWriteTiff,
-  BGRAFilterBlur;
+  BGRAFilterBlur, Math;
 
 { TUniversalDrawer }
 
@@ -424,8 +424,19 @@ var
   Y, X: integer;
   DX, DY, SX, SY, E: integer;
   drawPixelProc: TDrawPixelProc;
+  skip: Boolean;
+  r: TRect;
+  E64: Int64;
 begin
-  if ABrush.DoesNothing or (AAlpha= 0) then exit;
+  r := ADest.ClipRect;
+  skip := false;
+  if ABrush.DoesNothing or (AAlpha= 0) then skip := true;
+  if (x1 < r.Left) and (x2 < r.Left) then skip := true;
+  if (x1 >= r.Right) and (x2 >= r.Right) then skip := true;
+  if (y1 < r.Top) and (y2 < r.Top) then skip := true;
+  if (y1 >= r.Bottom) and (y2 >= r.Bottom) then skip := true;
+  if skip then exit;
+
   if (Y1 = Y2) then
   begin
     if (X1 = X2) then
@@ -477,7 +488,22 @@ begin
   if DX > DY then
   begin
     E := DY - DX shr 1;
-
+    if (X < r.Left) and (SX > 0) then
+    begin
+      E64 := E+int64(DY)*(r.Left-X)+DX;
+      E := (E64 mod DX)-DX;
+      Inc(Y, (E64 div DX)*SY);
+      X := r.Left;
+    end;
+    if (X >= r.Right) and (SX < 0) then
+    begin
+      E64 := E+int64(DY)*(X-(r.Right-1))+DX;
+      E := (E64 mod DX)-DX;
+      Inc(Y, (E64 div DX)*SY);
+      X := r.Right-1;
+    end;
+    if (X2 < r.Left) and (SX < 0) then X2 := r.Left;
+    if (X2 >= r.Right) and (SX > 0) then X2 := r.Right-1;
     while X <> X2 do
     begin
       drawPixelProc(X, Y, ABrush, AAlpha);
@@ -493,7 +519,22 @@ begin
   else
   begin
     E := DX - DY shr 1;
-
+    if (Y < r.Top) and (SY > 0) then
+    begin
+      E64 := E+int64(DX)*(r.Top-Y)+DY;
+      E := (E64 mod DY)-DY;
+      Inc(X, (E64 div DY)*SX);
+      Y := r.Top;
+    end;
+    if (Y >= r.Bottom) and (SY < 0) then
+    begin
+      E64 := E+int64(DX)*(Y-(r.Bottom-1))+DY;
+      E := (E64 mod DY)-DY;
+      Inc(X, (E64 div DY)*SX);
+      Y := r.Bottom-1;
+    end;
+    if (Y2 < r.Left) and (SY < 0) then Y2 := r.Left;
+    if (Y2 >= r.Right) and (SY > 0) then Y2 := r.Right-1;
     while Y <> Y2 do
     begin
       drawPixelProc(X, Y, ABrush, AAlpha);
@@ -515,81 +556,10 @@ class procedure TUniversalDrawer.DrawLineAntialias(ADest: TCustomUniversalBitmap
   x1, y1, x2, y2: integer; const ABrush: TUniversalBrush;
   DrawLastPixel: boolean; AAlpha: Word = 65535);
 var
-  Y, X:  integer;
-  DX, DY, SX, SY, E: integer;
-  curAlpha: Word;
+  dashPos: integer;
 begin
-  if ABrush.DoesNothing or (AAlpha= 0) then exit;
-  if (Y1 = Y2) and (X1 = X2) then
-  begin
-    if DrawLastPixel then
-      ADest.DrawPixel(X1, Y1, ABrush, AAlpha);
-    Exit;
-  end;
-
-  DX := X2 - X1;
-  DY := Y2 - Y1;
-
-  if DX < 0 then
-  begin
-    SX := -1;
-    DX := -DX;
-  end
-  else
-    SX := 1;
-
-  if DY < 0 then
-  begin
-    SY := -1;
-    DY := -DY;
-  end
-  else
-    SY := 1;
-
-  DX := DX shl 1;
-  DY := DY shl 1;
-
-  X := X1;
-  Y := Y1;
-
-  if DX > DY then
-  begin
-    E := 0;
-
-    while X <> X2 do
-    begin
-      curAlpha := AAlpha * E div DX;
-      ADest.DrawPixel(X, Y, ABrush, AAlpha - curAlpha);
-      ADest.DrawPixel(X, Y + SY, ABrush, curAlpha);
-      Inc(E, DY);
-      if E >= DX then
-      begin
-        Inc(Y, SY);
-        Dec(E, DX);
-      end;
-      Inc(X, SX);
-    end;
-  end
-  else
-  begin
-    E := 0;
-
-    while Y <> Y2 do
-    begin
-      curAlpha := AAlpha * E div DY;
-      ADest.DrawPixel(X, Y, ABrush, AAlpha - curAlpha);
-      ADest.DrawPixel(X + SX, Y, ABrush, curAlpha);
-      Inc(E, DX);
-      if E >= DY then
-      begin
-        Inc(X, SX);
-        Dec(E, DY);
-      end;
-      Inc(Y, SY);
-    end;
-  end;
-  if DrawLastPixel then
-    ADest.DrawPixel(X2, Y2, ABrush, AAlpha);
+  dashPos := 0;
+  DrawLineAntialias(ADest,x1,y1,x2,y2, ABrush,ABrush,$1000000,dashPos,DrawLastPixel,AAlpha);
 end;
 
 class procedure TUniversalDrawer.DrawLineAntialias(ADest: TCustomUniversalBitmap;
@@ -597,13 +567,29 @@ class procedure TUniversalDrawer.DrawLineAntialias(ADest: TCustomUniversalBitmap
   ADashLen: integer; var DashPos: integer; DrawLastPixel: boolean;
   AAlpha: Word = 65535);
 var
-  Y, X:  integer;
-  DX, DY, SX, SY, E: integer;
+  X, Y, DX, DY, SX, SY, E: integer;
   curAlpha: Word;
   curBrush: PUniversalBrush;
+  skip: Boolean;
+  r: TRect;
+  E64: Int64;
 begin
-  if (ABrush1.DoesNothing and ABrush2.DoesNothing) and (AAlpha= 0) then exit;
+  r := ADest.ClipRect;
+  skip := false;
+  if (ABrush1.DoesNothing and ABrush2.DoesNothing) or (AAlpha=0) then skip := true;
+  if (x1 < r.Left) and (x2 < r.Left) then skip := true;
+  if (x1 >= r.Right) and (x2 >= r.Right) then skip := true;
+  if (y1 < r.Top) and (y2 < r.Top) then skip := true;
+  if (y1 >= r.Bottom) and (y2 >= r.Bottom) then skip := true;
+
   if ADashLen<=0 then ADashLen := 1;
+  if skip then
+  begin
+    inc(DashPos, max(abs(x2-x1),abs(y2-y1)));
+    if DrawLastPixel then inc(DashPos);
+    DashPos := PositiveMod(DashPos,ADashLen+ADashLen);
+    exit;
+  end;
 
   DashPos := PositiveMod(DashPos,ADashLen+ADashLen);
   if DashPos < ADashLen then
@@ -613,39 +599,51 @@ begin
   if (Y1 = Y2) and (X1 = X2) then
   begin
     if DrawLastPixel then
+    begin
       ADest.DrawPixel(X1, Y1, curBrush^, AAlpha);
+      inc(DashPos);
+      if DashPos = ADashLen + ADashLen then DashPos := 0;
+    end;
     Exit;
   end;
 
   DX := X2 - X1;
   DY := Y2 - Y1;
-
   if DX < 0 then
   begin
     SX := -1;
     DX := -DX;
-  end
-  else
-    SX := 1;
+  end else SX := 1;
 
   if DY < 0 then
   begin
     SY := -1;
     DY := -DY;
-  end
-  else
-    SY := 1;
+  end else SY := 1;
 
   DX := DX shl 1;
   DY := DY shl 1;
-
   X := X1;
   Y := Y1;
-
   if DX > DY then
   begin
     E := 0;
-
+    if (X < r.Left) and (SX > 0) then
+    begin
+      E64 := E+int64(DY)*(r.Left-X);
+      E := E64 mod DX;
+      Inc(Y, (E64 div DX)*SY);
+      X := r.Left;
+    end;
+    if (X >= r.Right) and (SX < 0) then
+    begin
+      E64 := E+int64(DY)*(X-(r.Right-1));
+      E := E64 mod DX;
+      Inc(Y, (E64 div DX)*SY);
+      X := r.Right-1;
+    end;
+    if (X2 < r.Left) and (SX < 0) then X2 := r.Left;
+    if (X2 >= r.Right) and (SX > 0) then X2 := r.Right-1;
     while X <> X2 do
     begin
       curAlpha := AAlpha * E div DX;
@@ -673,7 +671,22 @@ begin
   else
   begin
     E := 0;
-
+    if (Y < r.Top) and (SY > 0) then
+    begin
+      E64 := E+int64(DX)*(r.Top-Y);
+      E := E64 mod DY;
+      Inc(X, (E64 div DY)*SX);
+      Y := r.Top;
+    end;
+    if (Y >= r.Bottom) and (SY < 0) then
+    begin
+      E64 := E+int64(DX)*(Y-(r.Bottom-1));
+      E := E64 mod DY;
+      Inc(X, (E64 div DY)*SX);
+      Y := r.Bottom-1;
+    end;
+    if (Y2 < r.Left) and (SY < 0) then Y2 := r.Left;
+    if (Y2 >= r.Right) and (SY > 0) then Y2 := r.Right-1;
     while Y <> Y2 do
     begin
       curAlpha := AAlpha * E div DY;

--- a/update_BGRABitmap.json
+++ b/update_BGRABitmap.json
@@ -10,12 +10,12 @@
       "ForceNotify" : false,
       "InternalVersion" : 1,
       "Name" : "bgrabitmappack.lpk",
-      "Version" : "10.1.0.0"
+      "Version" : "10.2.0.0"
     }
   ],
   "UpdatePackageData" : {
     "DisableInOPM" : false,
-    "DownloadZipURL" : "https://github.com/bgrabitmap/bgrabitmap/archive/v10.1.zip",
+    "DownloadZipURL" : "https://github.com/bgrabitmap/bgrabitmap/archive/v10.2.zip",
     "Name" : "bgrabitmap-master"
   }
 }


### PR DESCRIPTION
Various fixes:
- fix for lines with integer coordinates out of bounds
- fix TMemDirectory Rename and TLayeredBitmap Assign functions (LazPaint format related)
- raise exception when using empty scanner instead of infinite loop
- fix constant TBGRAGradientScanner when used with constant color
- fix scanner offset for dithering filter
- add PenStyleToBGRA function