### PR TITLE
Dev bgrabitmap v10.6.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dev/colorspace/UnitMaker
 test/colorspace/ColorsDemo
 
 test/colorspace/HorseShoe
+.DS_Store

--- a/bgrabitmap/bgrabitmappack.lpk
+++ b/bgrabitmap/bgrabitmappack.lpk
@@ -29,7 +29,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="10" Minor="6" Release="2"/>
+    <Version Major="10" Minor="6" Release="3"/>
     <Files Count="134">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack4fpgui.lpk
+++ b/bgrabitmap/bgrabitmappack4fpgui.lpk
@@ -33,7 +33,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="10" Minor="6" Release="2"/>
+    <Version Major="10" Minor="6" Release="3"/>
     <Files Count="97">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack4nogui.lpk
+++ b/bgrabitmap/bgrabitmappack4nogui.lpk
@@ -35,7 +35,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="10" Minor="6" Release="2"/>
+    <Version Major="10" Minor="6" Release="3"/>
     <Files Count="101">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmaptypes.pas
+++ b/bgrabitmap/bgrabitmaptypes.pas
@@ -37,7 +37,7 @@ uses
 
 
 const
-  BGRABitmapVersion = 10060200;
+  BGRABitmapVersion = 10060300;
 
   function BGRABitmapVersionStr: string;
 

--- a/bgrabitmap/bgradefaultbitmap.pas
+++ b/bgrabitmap/bgradefaultbitmap.pas
@@ -300,7 +300,7 @@ type
       * If it is more out of the bounds, the result is ''BGRAPixelTransparent''.
       * ''AResampleFilter'' specifies how pixels must be interpolated. Accepted
         values are ''rfBox'', ''rfLinear'', ''rfHalfCosine'' and ''rfCosine'' }
-    function GetPixel(x, y: single; AResampleFilter: TResampleFilter = rfLinear; smoothBorder: boolean = true): TBGRAPixel; override;
+    function GetPixel(x, y: single; AResampleFilter: TResampleFilter = rfLinear; smoothBorder: boolean = true): TBGRAPixel; overload; override;
     {** Similar to previous ''GetPixel'' function, but the fractional part of
         the coordinate is supplied with a number from 0 to 255. The actual
         coordinate is (''x'' + ''fracX256''/256, ''y'' + ''fracY256''/256) }

--- a/bgrabitmap/bgralayeroriginal.pas
+++ b/bgrabitmap/bgralayeroriginal.pas
@@ -235,6 +235,7 @@ type
     procedure LoadImageFromStream(AStream: TStream);
     procedure SaveImageToStream(AStream: TStream);
     procedure AssignImage(AImage: TBGRACustomBitmap);
+    function GetImageCopy: TBGRABitmap;
     class function StorageClassName: RawByteString; override;
     property Width: integer read GetImageWidth;
     property Height: integer read GetImageHeight;
@@ -1941,6 +1942,12 @@ begin
   FImage := newImage;
   Inc(FContentVersion);
   EndUpdate;
+end;
+
+function TBGRALayerImageOriginal.GetImageCopy: TBGRABitmap;
+begin
+  if FImage = nil then result := nil
+  else result := FImage.Duplicate as TBGRABitmap;
 end;
 
 class function TBGRALayerImageOriginal.StorageClassName: RawByteString;

--- a/bgrabitmap/bgralayeroriginal.pas
+++ b/bgrabitmap/bgralayeroriginal.pas
@@ -83,6 +83,7 @@ type
     end;
     FPointSize: single;
     FPointMoving: integer;
+    FPointWasMoved: boolean;
     FPointCoordDelta: TPointF;
     FMovingRightButton: boolean;
     FPrevMousePos: TPointF;
@@ -868,6 +869,7 @@ begin
     end;
     if newCoord <> FPoints[FPointMoving].Coord then
     begin
+      FPointWasMoved:= true;
       if (FMovingRightButton xor FPoints[FPointMoving].RightButton) and
         Assigned(FPoints[FPointMoving].OnAlternateMove) then
         FPoints[FPointMoving].OnAlternateMove(self, FPoints[FPointMoving].Coord, newCoord, Shift)
@@ -910,6 +912,7 @@ begin
       if Assigned(FPoints[clickedPoint].OnMove) then
       begin
         FPointMoving:= clickedPoint;
+        FPointWasMoved:= false;
         FMovingRightButton:= RightButton;
         FPointCoordDelta := FPoints[FPointMoving].Coord - FPrevMousePos;
         for i := 0 to FStartMoveHandlers.Count-1 do
@@ -933,10 +936,17 @@ end;
 
 procedure TBGRAOriginalEditor.MouseUp(RightButton: boolean; Shift: TShiftState;
   ViewX, ViewY: single; out ACursor: TOriginalEditorCursor; out AHandled: boolean);
+var
+  i: Integer;
 begin
   AHandled:= false;
   if (RightButton = FMovingRightButton) and (FPointMoving <> -1) then
   begin
+    if not FPointWasMoved then
+    begin
+      for i := 0 to FClickPointHandlers.Count-1 do
+        FClickPointHandlers[i](self, FPointMoving, Shift);
+    end;
     FPointMoving:= -1;
     AHandled:= true;
   end;

--- a/bgrabitmap/bgralayers.pas
+++ b/bgrabitmap/bgralayers.pas
@@ -71,6 +71,7 @@ type
     function GetOriginalCount: integer; virtual;
     function GetOriginalByIndex({%H-}AIndex: integer): TBGRALayerCustomOriginal; virtual;
     function GetOriginalByIndexKnown({%H-}AIndex: integer): boolean; virtual;
+    function GetOriginalByIndexLoaded({%H-}AIndex: integer): boolean; virtual;
     function GetOriginalByIndexClass({%H-}AIndex: integer): TBGRALayerOriginalAny; virtual;
     function GetTransparent: Boolean; override;
     function GetEmpty: boolean; override;
@@ -198,6 +199,7 @@ type
     function GetOriginalCount: integer; override;
     function GetOriginalByIndex(AIndex: integer): TBGRALayerCustomOriginal; override;
     function GetOriginalByIndexKnown(AIndex: integer): boolean; override;
+    function GetOriginalByIndexLoaded(AIndex: integer): boolean; override;
     function GetOriginalByIndexClass(AIndex: integer): TBGRALayerOriginalAny; override;
     procedure SetBlendOperation(Layer: integer; op: TBlendOperation);
     procedure SetLayerVisible(layer: integer; AValue: boolean);
@@ -709,6 +711,14 @@ begin
   result:= Assigned(dir) and Assigned(c);
 end;
 
+function TBGRALayeredBitmap.GetOriginalByIndexLoaded(AIndex: integer): boolean;
+begin
+  if (AIndex < 0) or (AIndex >= OriginalCount) then
+    raise ERangeError.Create('Index out of bounds');
+
+  Result:= Assigned(FOriginals[AIndex].Instance);
+end;
+
 function TBGRALayeredBitmap.GetOriginalGuid(AIndex: integer): TGUID;
 begin
   if (AIndex < 0) or (AIndex >= OriginalCount) then
@@ -1111,9 +1121,9 @@ begin
      (ASource.LayerOriginalKnown[i] or (ASource is TBGRALayeredBitmap)) then
   begin
     idxOrig := ASource.IndexOfOriginal(ASource.LayerOriginalGuid[i]);
-    if not usedOriginals[idxOrig].used then
+    if (idxOrig <> -1) and not usedOriginals[idxOrig].used then
     begin
-      if ASource.LayerOriginalKnown[i] then
+      if ASource.GetOriginalByIndexLoaded(idxOrig) then
       begin
         orig := ASource.GetOriginalByIndex(idxOrig);
         idxNewOrig := AddOriginal(orig, false);
@@ -1507,7 +1517,7 @@ begin
   begin
     FindOriginal(FOriginals[AIndex].Guid, dir, c);
     if dir = nil then
-      raise exception.Create('Originals directory not found');
+      raise exception.Create('Original directory not found');
     dir.SaveToStream(AStream);
   end;
 end;
@@ -2359,6 +2369,11 @@ begin
 end;
 
 function TBGRACustomLayeredBitmap.GetOriginalByIndexKnown(AIndex: integer): boolean;
+begin
+  result := true;
+end;
+
+function TBGRACustomLayeredBitmap.GetOriginalByIndexLoaded(AIndex: integer): boolean;
 begin
   result := true;
 end;

--- a/bgrabitmap/bgralayers.pas
+++ b/bgrabitmap/bgralayers.pas
@@ -479,6 +479,7 @@ end;
 
 procedure TBGRALayeredBitmap.SetLayerUniqueId(layer: integer; AValue: integer);
 var i: integer;
+  layerDir: TMemDirectory;
 begin
   if (layer < 0) or (layer >= NbLayers) then
     raise Exception.Create('Index out of bounds')
@@ -487,6 +488,9 @@ begin
     for i := 0 to NbLayers-1 do
       if (i <> layer) and (FLayers[i].UniqueId = AValue) then
         raise Exception.Create('Another layer has the same identifier');
+    layerDir := GetLayerDirectory(layer,false);
+    if Assigned(layerDir) then
+      layerDir.ParentDirectory.Rename(inttostr(FLayers[layer].UniqueId),'',inttostr(AValue));
     FLayers[layer].UniqueId := AValue;
   end;
 end;

--- a/bgrabitmap/bgralayers.pas
+++ b/bgrabitmap/bgralayers.pas
@@ -510,6 +510,8 @@ end;
 
 procedure TBGRALayeredBitmap.SetLayerOriginalGuid(layer: integer;
   const AValue: TGuid);
+var
+  layerDir: TMemDirectory;
 begin
   if (layer < 0) or (layer >= NbLayers) then
     raise Exception.Create('Index out of bounds')
@@ -517,6 +519,9 @@ begin
   begin
     if FLayers[layer].OriginalGuid = AValue then exit;
     FLayers[layer].OriginalGuid := AValue;
+    layerDir := GetLayerDirectory(layer, false);
+    if Assigned(layerDir) then
+      layerDir.Delete(RenderSubDirectory,'');
 
     if (AValue <> GUID_NULL) and (IndexOfOriginal(AValue) <> -1) then
     begin

--- a/bgrabitmap/bgralayers.pas
+++ b/bgrabitmap/bgralayers.pas
@@ -2120,6 +2120,8 @@ end;
 
 procedure TBGRALayeredBitmap.SetLayerBitmap(layer: integer;
   ABitmap: TBGRABitmap; AOwned: boolean);
+var
+  layerDir: TMemDirectory;
 begin
   if (layer < 0) or (layer >= NbLayers) then
     raise Exception.Create('Index out of bounds')
@@ -2132,6 +2134,9 @@ begin
     FLayers[layer].Owner := AOwned;
     FLayers[layer].OriginalGuid := GUID_NULL;
     FLayers[layer].OriginalMatrix := AffineMatrixIdentity;
+    layerDir := GetLayerDirectory(layer, false);
+    if Assigned(layerDir) then
+      layerDir.Delete(RenderSubDirectory,'');
   end;
 end;
 

--- a/bgrabitmap/bgralayers.pas
+++ b/bgrabitmap/bgralayers.pas
@@ -1406,7 +1406,6 @@ begin
       raise exception.Create('GUID is already in use');
     end;
   end;
-  StoreOriginal(AOriginal);
   if FOriginals = nil then FOriginals := TBGRALayerOriginalList.Create;
   if AOwned then
   begin
@@ -1415,7 +1414,10 @@ begin
     AOriginal.OnEditingChange:= @OriginalEditingChange;
   end
   else
+  begin
+    StoreOriginal(AOriginal);
     result := FOriginals.Add(BGRALayerOriginalEntry(AOriginal.Guid));
+  end;
 end;
 
 function TBGRALayeredBitmap.AddOriginalFromStream(AStream: TStream;

--- a/bgrabitmap/bgralayers.pas
+++ b/bgrabitmap/bgralayers.pas
@@ -1720,7 +1720,6 @@ begin
   begin
     Unfreeze(layer);
     layerDir := GetLayerDirectory(layer, true);
-    if layerDir.IndexOf(RenderSubDirectory,'') = -1 then writeln('create render dir');
     renderDir := layerDir.Directory[layerDir.AddDirectory(RenderSubDirectory)];
     orig.RenderStorage := TBGRAMemOriginalStorage.Create(renderDir);
 

--- a/bgrabitmap/bgramultifiletype.pas
+++ b/bgrabitmap/bgramultifiletype.pas
@@ -224,12 +224,14 @@ begin
 end;
 
 function TMultiFileContainer.GetRawString(AIndex: integer): RawByteString;
-var s: TStringStream;
+var s: TMemoryStream;
 begin
-  s := TStringStream.Create('');
+  s := TMemoryStream.Create;
   try
     Entry[AIndex].CopyTo(s);
-    result := s.DataString;
+    setlength(result, s.Size);
+    if length(result)>0 then
+      move(s.Memory^, result[1], length(result));
   finally
     s.Free;
   end;

--- a/bgrabitmap/bgrasvgshapes.pas
+++ b/bgrabitmap/bgrasvgshapes.pas
@@ -962,8 +962,8 @@ begin
   begin
     p1.x:= Units.ConvertWidth(g.x1,AUnit,w).value;
     p1.y:= Units.ConvertHeight(g.y1,AUnit,h).value;
-    p2.x:= Units.ConvertWidth(g.x1,AUnit,w).value;
-    p2.y:= Units.ConvertHeight(g.y1,AUnit,h).value;
+    p2.x:= Units.ConvertWidth(g.x2,AUnit,w).value;
+    p2.y:= Units.ConvertHeight(g.y2,AUnit,h).value;
     m := ACanvas2d.matrix;
     ACanvas2d.transform(g.gradientMatrix[AUnit]);
     FCanvasGradient:= ACanvas2d.createLinearGradient(p1,p2);

--- a/commit.sh
+++ b/commit.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#git checkout HEAD~ -- <file to cancel>
+git add .
+git status
+echo "Type commit description (or press Enter to cancel):"
+read commitdesc
+if test -z "$commitdesc"
+then
+  git reset --
+else
+  git commit -m "$commitdesc"
+fi
+cd ..

--- a/dev/releaser/macbundle.pas
+++ b/dev/releaser/macbundle.pas
@@ -1,0 +1,200 @@
+unit MacBundle;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, ReleaserTypes, fgl, laz2_XMLRead, laz2_XMLWrite, Laz2_DOM;
+
+type
+
+  { TMacBundle }
+
+  TMacBundle = class(TReleaserObject)
+  private
+    FBundlepath: string;
+    FFilename: string;
+    FXml: TXmlDocument;
+    FDict: TStringList;
+    FChanged: boolean;
+    function GetName: string;
+    function GetPListFilename: string;
+    function ReadDict(ARoot: TDOMNode): TStringList;
+    procedure UpdateDict(ARoot: TDOMNode; ADict: TStringList);
+  public
+    constructor Create(AParameters: TStringList; ALogicDir: string); override;
+    destructor Destroy; override;
+    property Filename: string read FFilename;
+    function GetVersion: TVersion;
+    procedure GetVersions(AVersionList: TStringList); override;
+    procedure CheckVersion(AVersion: TVersion); override;
+    property Name: string read GetName;
+    procedure Save; override;
+    procedure UpdateVersion(AVersion: TVersion); override;
+  end;
+
+implementation
+
+{ TMacBundle }
+
+function TMacBundle.GetName: string;
+begin
+  result := '';
+  if Assigned(FDict) then
+    result := FDict.Values['CFBundleName'];
+  if result = '' then
+    result := ChangeFileExt(ExtractFileName(FBundlepath),'');
+end;
+
+function TMacBundle.GetPListFilename: string;
+begin
+  result := FBundlepath+PathDelim+'Contents'+PathDelim+'Info.plist';
+end;
+
+function TMacBundle.ReadDict(ARoot: TDOMNode): TStringList;
+var
+  dict, entry: TDOMNode;
+  key: string;
+begin
+  result := TStringList.Create;
+  if Assigned(ARoot) then
+  begin
+    dict := ARoot.FindNode('dict');
+    if Assigned(dict) then
+    begin
+      entry := dict.FirstChild;
+      while entry <> nil do
+      begin
+        if entry.NodeName = 'key' then
+        begin
+          key := entry.NodeValue;
+          entry := entry.NextSibling;
+          if (entry <> nil) and (entry.NodeName = 'string') then
+          begin
+            result.Values[key] := entry.NodeValue;
+            entry := entry.NextSibling;
+          end
+          else if (entry <> nil) and (entry.NodeName <> 'key') then
+            entry := entry.NextSibling;
+        end else
+          entry := entry.NextSibling;
+      end;
+    end;
+  end;
+end;
+
+procedure TMacBundle.UpdateDict(ARoot: TDOMNode; ADict: TStringList);
+var
+  dict, entry: TDOMNode;
+  key: string;
+begin
+  if Assigned(ARoot) then
+  begin
+    dict := ARoot.FindNode('dict');
+    if Assigned(dict) then
+    begin
+      entry := dict.FirstChild;
+      while entry <> nil do
+      begin
+        if entry.NodeName = 'key' then
+        begin
+          key := entry.NodeValue;
+          entry := entry.NextSibling;
+          if (entry <> nil) and (entry.NodeName = 'string') then
+          begin
+            entry.NodeValue := ADict.Values[key];
+            entry := entry.NextSibling;
+          end
+          else if (entry <> nil) and (entry.NodeName <> 'key') then
+            entry := entry.NextSibling;
+        end else
+          entry := entry.NextSibling;
+      end;
+    end;
+  end;
+end;
+
+constructor TMacBundle.Create(AParameters: TStringList; ALogicDir: string);
+var
+  stream: TFileStream;
+  plist: TDOMNode;
+begin
+  inherited Create(AParameters, ALogicDir);
+  ExpectParamCount(1);
+  FBundlepath:= ExpandFileName(ReplaceVariables(Param[0]));
+  stream := TFileStream.Create(GetPListFilename, fmOpenRead);
+  try
+    ReadXMLFile(FXml,stream);
+  finally
+    stream.Free;
+  end;
+  plist := FXml.FindNode('plist');
+  if plist = nil then raise exception.Create('plist node not found');
+  FDict := ReadDict(plist);
+  writeln('Bundle ',Name,' version ',VersionToStr(GetVersion));
+end;
+
+destructor TMacBundle.Destroy;
+begin
+  FXml.Free;
+  inherited Destroy;
+end;
+
+function TMacBundle.GetVersion: TVersion;
+begin
+  if Assigned(FDict) then
+    result := StrToVersion(FDict.Values['CFBundleVersion'])
+  else raise exception.Create('Version node not found');
+end;
+
+procedure TMacBundle.GetVersions(AVersionList: TStringList);
+var
+  ver: TVersion;
+  verStr: String;
+begin
+  ver := GetVersion;
+  verStr := VersionToStr(ver);
+  if AVersionList.IndexOf(verStr)=-1 then
+    AVersionList.Add(verStr);
+end;
+
+procedure TMacBundle.CheckVersion(AVersion: TVersion);
+begin
+  inherited CheckVersion(AVersion);
+  if AVersion<>GetVersion then raise exception.Create('Inconsistent version of bundle '+Name);
+end;
+
+procedure TMacBundle.Save;
+begin
+  if FChanged then
+  begin
+    writeln('Updating bundle ', Name,'...');
+    WriteXMLFile(FXml, FFilename);
+  end else
+    writeln('Bundle unchanged');
+end;
+
+procedure TMacBundle.UpdateVersion(AVersion: TVersion);
+var
+  versionStr: String;
+begin
+  if Assigned(FDict) then
+  begin
+    versionStr := VersionToStr(AVersion);
+    if FDict.Values['CFBundleVersion'] <> versionStr then
+    begin
+      FDict.Values['CFBundleVersion'] := versionStr;
+      FChanged := true;
+    end;
+    if FDict.Values['CFBundleShortVersionString'] <> versionStr then
+    begin
+      FDict.Values['CFBundleShortVersionString'] := versionStr;
+      FChanged := true;
+    end;
+    UpdateDict(FXml.FindNode('plist'), FDict);
+  end;
+end;
+
+end.
+

--- a/dev/releaser/releaser.lpi
+++ b/dev/releaser/releaser.lpi
@@ -29,7 +29,7 @@
         <PackageName Value="LazUtils"/>
       </Item1>
     </RequiredPackages>
-    <Units Count="10">
+    <Units Count="11">
       <Unit0>
         <Filename Value="releaser.lpr"/>
         <IsPartOfProject Value="True"/>
@@ -79,6 +79,11 @@
         <IsPartOfProject Value="True"/>
         <UnitName Value="CopyFile"/>
       </Unit9>
+      <Unit10>
+        <Filename Value="macbundle.pas"/>
+        <IsPartOfProject Value="True"/>
+        <UnitName Value="MacBundle"/>
+      </Unit10>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/dev/releaser/releaser.lpr
+++ b/dev/releaser/releaser.lpr
@@ -7,7 +7,7 @@ uses
   cthreads,
   {$ENDIF}{$ENDIF}
   Classes, SysUtils, CustApp, ReleaserTypes, ManagerFile, ArchiveUrl,
-  PackageFile, ProjectFile, ConstFile, TextLine, CopyFile
+  PackageFile, ProjectFile, ConstFile, TextLine, CopyFile, MacBundle
   { you can add units after this };
 
 type
@@ -140,6 +140,7 @@ begin
         'archive': factory := TArchiveUrl;
         'package': factory := TPackageFile;
         'project': factory := TProjectFile;
+        'bundle': factory := TMacBundle;
         'const': factory := TConstFile;
         'echo': for i := 0 to line.Count-1 do writeln(line[i]);
         'text': factory := TTextLine;

--- a/dev/releaser/releaser.lpr
+++ b/dev/releaser/releaser.lpr
@@ -205,7 +205,7 @@ begin
     on ex:exception do
     begin
       write('Error');
-      if lineNumber <> 0 then write(' on line',lineNumber);
+      if lineNumber <> 0 then write(' on line ',lineNumber);
       writeln(': ', ex.Message);
     end;
   end;

--- a/test/testsvg/svg/25.1 circle gradient.svg
+++ b/test/testsvg/svg/25.1 circle gradient.svg
@@ -1,6 +1,6 @@
 <svg height="200" width="200">
   <defs>
-    <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="0%">
+    <linearGradient id="grad1" x1="10%" y1="0%" x2="90%" y2="0%" gradientUnits="userSpaceOnUse">
       <stop offset="0%" style="stop-color:rgb(255,255,0);stop-opacity:1" />
       <stop offset="100%" style="stop-color:rgb(255,0,0);stop-opacity:1" />
     </linearGradient>

--- a/update_BGRABitmap.json
+++ b/update_BGRABitmap.json
@@ -10,12 +10,12 @@
       "ForceNotify" : false,
       "InternalVersion" : 1,
       "Name" : "bgrabitmappack.lpk",
-      "Version" : "10.6.2.0"
+      "Version" : "10.6.3.0"
     }
   ],
   "UpdatePackageData" : {
     "DisableInOPM" : false,
-    "DownloadZipURL" : "https://github.com/bgrabitmap/bgrabitmap/archive/v10.6.2.zip",
+    "DownloadZipURL" : "https://github.com/bgrabitmap/bgrabitmap/archive/v10.6.3.zip",
     "Name" : "bgrabitmap-master"
   }
 }


### PR DESCRIPTION
Layers
- optimize: avoid storing/loading originals if not necessary
- function to unload originals
- added TBGRALayerImageOriginal.GetImageCopy
- raise click point event if points is clicked but not moved
- AddPointAlternateMove: alternate handler if other mouse button was used
- RawString storage: avoid string conversion with newer version of FPC
- copy additional info of MemDirectory when assigning
- update layer MemDirectory when changing unique id

SVG
- fix gradient for userSpaceOnUse coordinates

Releaser
- add handler for MacOS bundle