### PR TITLE
Dev bgrabitmap 11.2.3

### DIFF
--- a/bgrabitmap/bgrabitmappack.lpk
+++ b/bgrabitmap/bgrabitmappack.lpk
@@ -29,7 +29,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="11" Minor="2" Release="2"/>
+    <Version Major="11" Minor="2" Release="3"/>
     <Files Count="142">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack4fpgui.lpk
+++ b/bgrabitmap/bgrabitmappack4fpgui.lpk
@@ -33,7 +33,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="11" Minor="2" Release="2"/>
+    <Version Major="11" Minor="2" Release="3"/>
     <Files Count="105">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack4nogui.lpk
+++ b/bgrabitmap/bgrabitmappack4nogui.lpk
@@ -35,7 +35,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="11" Minor="2" Release="2"/>
+    <Version Major="11" Minor="2" Release="3"/>
     <Files Count="108">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmaptypes.pas
+++ b/bgrabitmap/bgrabitmaptypes.pas
@@ -684,7 +684,18 @@ begin //we can ignore UTF8 character length because #13 and #10 are always 1 byt
       end
         else
           delete(s,indexByte,1);
-    end;
+    end else
+    if (s[indexByte] = #$C2) and (length(s) >= indexByte+1) and (s[indexByte+1] = #$85) then
+    begin
+      result := true;
+      delete(s,indexByte,2);
+    end else
+    if (s[indexByte] = #$E2) and (length(s) >= indexByte+2) and (s[indexByte+1] = #$80) and
+       (s[indexByte+2] in[#$A8,#$A9]) then
+    begin
+      result := true;
+      delete(s,indexByte,3);
+    end
   end;
 end;
 

--- a/bgrabitmap/bgrabitmaptypes.pas
+++ b/bgrabitmap/bgrabitmaptypes.pas
@@ -18,7 +18,7 @@ unit BGRABitmapTypes;
 interface
 
 uses
-  BGRAClasses, BGRAGraphics,
+  BGRAClasses, BGRAGraphics, BGRAUnicode,
   FPImage{$IFDEF BGRABITMAP_USE_FPCANVAS}, FPImgCanv{$ENDIF}
   {$IFDEF BGRABITMAP_USE_LCL}, LCLType, GraphType, LResources{$ENDIF},
   BGRAMultiFileType;
@@ -133,8 +133,13 @@ type
   TBGRALoadingOptions = set of TBGRALoadingOption;
 
   TTextLayout = BGRAGraphics.TTextLayout;
-  TFontBidiMode = (fbmAuto, fbmLeftToRight, fbmRightToLeft);
+  TFontBidiMode = BGRAUnicode.TFontBidiMode;
   TBidiTextAlignment = (btaNatural, btaOpposite, btaLeftJustify, btaRightJustify, btaCenter);
+
+const
+  fbmAuto = BGRAUnicode.fbmAuto;
+  fbmLeftToRight = BGRAUnicode.fbmLeftToRight;
+  fbmRightToLeft = BGRAUnicode.fbmRightToLeft;
 
   function AlignmentToBidiTextAlignment(AAlign: TAlignment; ARightToLeft: boolean): TBidiTextAlignment; overload;
   function AlignmentToBidiTextAlignment(AAlign: TAlignment): TBidiTextAlignment; overload;
@@ -571,7 +576,7 @@ var
 
 implementation
 
-uses Math, SysUtils, BGRAUTF8, BGRAUnicode,
+uses Math, SysUtils, BGRAUTF8,
   FPReadXwd, FPReadXPM,
   FPWriteJPEG, FPWriteBMP, FPWritePCX,
   FPWriteTGA, FPWriteXPM, FPReadPNM, FPWritePNM;

--- a/bgrabitmap/bgrabitmaptypes.pas
+++ b/bgrabitmap/bgrabitmaptypes.pas
@@ -438,7 +438,7 @@ type
 {** Removes line ending and tab characters from a string (for a function
     like ''TextOut'' that does not handle this). this works with UTF8 strings
     as well }
-function CleanTextOutString(s: string): string;
+function CleanTextOutString(const s: string): string;
 {** Remove the line ending at the specified position or return False.
     This works with UTF8 strings however the index is the byte index }
 function RemoveLineEnding(var s: string; indexByte: integer): boolean;
@@ -648,7 +648,7 @@ begin
   end;
 end;
 
-function CleanTextOutString(s: string): string;
+function CleanTextOutString(const s: string): string;
 var idxIn, idxOut: integer;
 begin
   setlength(result, length(s));

--- a/bgrabitmap/bgrabitmaptypes.pas
+++ b/bgrabitmap/bgrabitmaptypes.pas
@@ -25,7 +25,7 @@ uses
 
 
 const
-  BGRABitmapVersion = 11020200;
+  BGRABitmapVersion = 11020300;
 
   function BGRABitmapVersionStr: string;
 

--- a/bgrabitmap/bgracanvas2d.pas
+++ b/bgrabitmap/bgracanvas2d.pas
@@ -727,6 +727,7 @@ begin
   result.fontEmHeight := fontEmHeight;
   result.fontStyle := fontStyle;
   result.textDirection:= textDirection;
+  result.textBaseline:= textBaseline;
 
   result.lineWidth := lineWidth;
   result.penStroker.LineCap := penStroker.LineCap;

--- a/bgrabitmap/bgracustombitmap.inc
+++ b/bgrabitmap/bgracustombitmap.inc
@@ -476,9 +476,9 @@ type
        mode: TFloodfillMode; Tolerance: byte = 0); overload; virtual;
      procedure FloodFill(X, Y: integer; const Brush: TUniversalBrush;
        Progressive: boolean; ToleranceW: Word = $00ff); overload; virtual;
-     procedure ParallelFloodFill(X, Y: integer; Dest: TBGRACustomBitmap; Color: TBGRAPixel;
+     procedure ParallelFloodFill(X, Y: integer; Dest: TCustomUniversalBitmap; Color: TBGRAPixel;
        mode: TFloodfillMode; Tolerance: byte = 0; DestOfsX: integer = 0; DestOfsY: integer = 0); overload; virtual; abstract;
-     procedure ParallelFloodFill(X, Y: integer; Dest: TBGRACustomBitmap; const Brush: TUniversalBrush;
+     procedure ParallelFloodFill(X, Y: integer; Dest: TCustomUniversalBitmap; const Brush: TUniversalBrush;
        Progressive: boolean; ToleranceW: Word = $00ff; DestOfsX: integer = 0; DestOfsY: integer = 0); overload; virtual; abstract;
      procedure GradientFill(x, y, x2, y2: integer; c1, c2: TBGRAPixel;
        gtype: TGradientType; o1, o2: TPointF; mode: TDrawMode;

--- a/bgrabitmap/bgracustombitmap.inc
+++ b/bgrabitmap/bgracustombitmap.inc
@@ -418,6 +418,8 @@ type
      procedure TextOut(x, y: single; const sUTF8: string; texture: IBGRAScanner; ARightToLeft: boolean); overload; virtual;
      procedure TextOut(x, y: single; const sUTF8: string; c: TBGRAPixel; align: TAlignment; ARightToLeft: boolean); overload; virtual; abstract;
      procedure TextOut(x, y: single; const sUTF8: string; texture: IBGRAScanner; align: TAlignment; ARightToLeft: boolean); overload; virtual; abstract;
+     procedure TextOut(x, y: single; const sUTF8: string; AColor: TBGRAPixel; AAlign: TAlignment; ALetterSpacing: single); overload; virtual; abstract;
+     procedure TextOut(x, y: single; const sUTF8: string; ATexture: IBGRAScanner; AAlign: TAlignment; ALetterSpacing: single); overload; virtual; abstract;
 
      { Overrides the font orientation with the parameter orientationTenthDegCCW }
      procedure TextOutAngle(x, y: single; orientationTenthDegCCW: integer; const sUTF8: string; c: TBGRAPixel); overload; virtual;

--- a/bgrabitmap/bgracustombitmap.inc
+++ b/bgrabitmap/bgracustombitmap.inc
@@ -389,49 +389,49 @@ type
      procedure FillRect(x, y, x2, y2: integer; texture: IBGRAScanner; mode: TDrawMode; ditheringAlgorithm: TDitheringAlgorithm); overload; virtual;
      procedure FillRect(x, y, x2, y2: integer; texture: IBGRAScanner; mode: TDrawMode; AScanOffset: TPoint; ditheringAlgorithm: TDitheringAlgorithm); overload; virtual; abstract;
 
-     procedure TextOutCurved(ACursor: TBGRACustomPathCursor; sUTF8: string; AColor: TBGRAPixel; AAlign: TAlignment; ALetterSpacing: single); overload; virtual; abstract;
-     procedure TextOutCurved(ACursor: TBGRACustomPathCursor; sUTF8: string; ATexture: IBGRAScanner; AAlign: TAlignment; ALetterSpacing: single); overload; virtual; abstract;
-     procedure TextOutCurved(APath: IBGRAPath; sUTF8: string; AColor: TBGRAPixel; AAlign: TAlignment; ALetterSpacing: single); overload; virtual;
-     procedure TextOutCurved(APath: IBGRAPath; sUTF8: string; ATexture: IBGRAScanner; AAlign: TAlignment; ALetterSpacing: single); overload; virtual;
-     procedure TextRect(ARect: TRect; x, y: integer; sUTF8: string; style: TTextStyle; c: TBGRAPixel); overload; virtual; abstract;
-     procedure TextRect(ARect: TRect; x, y: integer; sUTF8: string; style: TTextStyle; texture: IBGRAScanner); overload; virtual; abstract;
-     procedure TextMultiline(x,y: single; sUTF8: string; c: TBGRAPixel; AAlign: TBidiTextAlignment = btaLeftJustify; AVertAlign: TTextLayout = tlTop; AParagraphSpacing: single = 0); overload;
-     procedure TextMultiline(x,y: single; sUTF8: string; ATexture: IBGRAScanner; AAlign: TBidiTextAlignment = btaLeftJustify; AVertAlign: TTextLayout = tlTop; AParagraphSpacing: single = 0); overload;
-     procedure TextMultiline(ALeft,ATop,AWidth: single; sUTF8: string; c: TBGRAPixel; AAlign: TBidiTextAlignment = btaNatural; AVertAlign: TTextLayout = tlTop; AParagraphSpacing: single = 0); overload; virtual; abstract;
-     procedure TextMultiline(ALeft,ATop,AWidth: single; sUTF8: string; ATexture: IBGRAScanner; AAlign: TBidiTextAlignment = btaNatural; AVertAlign: TTextLayout = tlTop; AParagraphSpacing: single = 0); overload; virtual; abstract;
-     function TextSize(sUTF8: string): TSize; overload; virtual; abstract;
-     function TextAffineBox(sUTF8: string): TAffineBox; virtual; abstract;
-     function TextSize(sUTF8: string; AMaxWidth: integer): TSize; overload; virtual; abstract;
-     function TextSize(sUTF8: string; AMaxWidth: integer; ARightToLeft: boolean): TSize; overload; virtual; abstract;
-     function TextFitInfo(sUTF8: string; AMaxWidth: integer): integer; virtual; abstract;
-     function TextSizeMultiline(sUTF8: string; AMaxWidth: single = EmptySingle; AParagraphSpacing: single = 0): TSize; virtual; abstract;
+     procedure TextOutCurved(ACursor: TBGRACustomPathCursor; const sUTF8: string; AColor: TBGRAPixel; AAlign: TAlignment; ALetterSpacing: single); overload; virtual; abstract;
+     procedure TextOutCurved(ACursor: TBGRACustomPathCursor; const sUTF8: string; ATexture: IBGRAScanner; AAlign: TAlignment; ALetterSpacing: single); overload; virtual; abstract;
+     procedure TextOutCurved(APath: IBGRAPath; const sUTF8: string; AColor: TBGRAPixel; AAlign: TAlignment; ALetterSpacing: single); overload; virtual;
+     procedure TextOutCurved(APath: IBGRAPath; const sUTF8: string; ATexture: IBGRAScanner; AAlign: TAlignment; ALetterSpacing: single); overload; virtual;
+     procedure TextRect(ARect: TRect; x, y: integer; const sUTF8: string; style: TTextStyle; c: TBGRAPixel); overload; virtual; abstract;
+     procedure TextRect(ARect: TRect; x, y: integer; const sUTF8: string; style: TTextStyle; texture: IBGRAScanner); overload; virtual; abstract;
+     procedure TextMultiline(x,y: single; const sUTF8: string; c: TBGRAPixel; AAlign: TBidiTextAlignment = btaLeftJustify; AVertAlign: TTextLayout = tlTop; AParagraphSpacing: single = 0); overload;
+     procedure TextMultiline(x,y: single; const sUTF8: string; ATexture: IBGRAScanner; AAlign: TBidiTextAlignment = btaLeftJustify; AVertAlign: TTextLayout = tlTop; AParagraphSpacing: single = 0); overload;
+     procedure TextMultiline(ALeft,ATop,AWidth: single; const sUTF8: string; c: TBGRAPixel; AAlign: TBidiTextAlignment = btaNatural; AVertAlign: TTextLayout = tlTop; AParagraphSpacing: single = 0); overload; virtual; abstract;
+     procedure TextMultiline(ALeft,ATop,AWidth: single; const sUTF8: string; ATexture: IBGRAScanner; AAlign: TBidiTextAlignment = btaNatural; AVertAlign: TTextLayout = tlTop; AParagraphSpacing: single = 0); overload; virtual; abstract;
+     function TextSize(const sUTF8: string): TSize; overload; virtual; abstract;
+     function TextAffineBox(const sUTF8: string): TAffineBox; virtual; abstract;
+     function TextSize(const sUTF8: string; AMaxWidth: integer): TSize; overload; virtual; abstract;
+     function TextSize(const sUTF8: string; AMaxWidth: integer; ARightToLeft: boolean): TSize; overload; virtual; abstract;
+     function TextFitInfo(const sUTF8: string; AMaxWidth: integer): integer; virtual; abstract;
+     function TextSizeMultiline(const sUTF8: string; AMaxWidth: single = EmptySingle; AParagraphSpacing: single = 0): TSize; virtual; abstract;
 
      { Draw the UTF8 encoded string, (x,y) being the top-left corner by default. The color c or texture is used to fill the text.
        The value of FontOrientation is taken into account, so that the text may be rotated. }
-     procedure TextOut(x, y: single; sUTF8: string; c: TBGRAPixel; align: TAlignment); overload; virtual;
-     procedure TextOut(x, y: single; sUTF8: string; texture: IBGRAScanner; align: TAlignment); overload; virtual;
-     procedure TextOut(x, y: single; sUTF8: string; c: TBGRAPixel); overload; virtual;
-     procedure TextOut(x, y: single; sUTF8: string; c: TBGRAPixel; ARightToLeft: boolean); overload; virtual;
-     procedure TextOut(x, y: single; sUTF8: string; c: TColor); overload; virtual;
-     procedure TextOut(x, y: single; sUTF8: string; c: TColor; ARightToLeft: boolean); overload; virtual;
-     procedure TextOut(x, y: single; sUTF8: string; texture: IBGRAScanner); overload; virtual;
-     procedure TextOut(x, y: single; sUTF8: string; texture: IBGRAScanner; ARightToLeft: boolean); overload; virtual;
-     procedure TextOut(x, y: single; sUTF8: string; c: TBGRAPixel; align: TAlignment; ARightToLeft: boolean); overload; virtual; abstract;
-     procedure TextOut(x, y: single; sUTF8: string; texture: IBGRAScanner; align: TAlignment; ARightToLeft: boolean); overload; virtual; abstract;
+     procedure TextOut(x, y: single; const sUTF8: string; c: TBGRAPixel; align: TAlignment); overload; virtual;
+     procedure TextOut(x, y: single; const sUTF8: string; texture: IBGRAScanner; align: TAlignment); overload; virtual;
+     procedure TextOut(x, y: single; const sUTF8: string; c: TBGRAPixel); overload; virtual;
+     procedure TextOut(x, y: single; const sUTF8: string; c: TBGRAPixel; ARightToLeft: boolean); overload; virtual;
+     procedure TextOut(x, y: single; const sUTF8: string; c: TColor); overload; virtual;
+     procedure TextOut(x, y: single; const sUTF8: string; c: TColor; ARightToLeft: boolean); overload; virtual;
+     procedure TextOut(x, y: single; const sUTF8: string; texture: IBGRAScanner); overload; virtual;
+     procedure TextOut(x, y: single; const sUTF8: string; texture: IBGRAScanner; ARightToLeft: boolean); overload; virtual;
+     procedure TextOut(x, y: single; const sUTF8: string; c: TBGRAPixel; align: TAlignment; ARightToLeft: boolean); overload; virtual; abstract;
+     procedure TextOut(x, y: single; const sUTF8: string; texture: IBGRAScanner; align: TAlignment; ARightToLeft: boolean); overload; virtual; abstract;
 
      { Overrides the font orientation with the parameter orientationTenthDegCCW }
-     procedure TextOutAngle(x, y: single; orientationTenthDegCCW: integer; sUTF8: string; c: TBGRAPixel); overload; virtual;
-     procedure TextOutAngle(x, y: single; orientationTenthDegCCW: integer; sUTF8: string; c: TBGRAPixel; align: TAlignment); overload; virtual;
-     procedure TextOutAngle(x, y: single; orientationTenthDegCCW: integer; sUTF8: string; c: TBGRAPixel; align: TAlignment; ARightToLeft: boolean); overload; virtual; abstract;
-     procedure TextOutAngle(x, y: single; orientationTenthDegCCW: integer; sUTF8: string; texture: IBGRAScanner); overload; virtual;
-     procedure TextOutAngle(x, y: single; orientationTenthDegCCW: integer; sUTF8: string; texture: IBGRAScanner; align: TAlignment); overload; virtual;
-     procedure TextOutAngle(x, y: single; orientationTenthDegCCW: integer; sUTF8: string; texture: IBGRAScanner; align: TAlignment; ARightToLeft: boolean); overload; virtual; abstract;
+     procedure TextOutAngle(x, y: single; orientationTenthDegCCW: integer; const sUTF8: string; c: TBGRAPixel); overload; virtual;
+     procedure TextOutAngle(x, y: single; orientationTenthDegCCW: integer; const sUTF8: string; c: TBGRAPixel; align: TAlignment); overload; virtual;
+     procedure TextOutAngle(x, y: single; orientationTenthDegCCW: integer; const sUTF8: string; c: TBGRAPixel; align: TAlignment; ARightToLeft: boolean); overload; virtual; abstract;
+     procedure TextOutAngle(x, y: single; orientationTenthDegCCW: integer; const sUTF8: string; texture: IBGRAScanner); overload; virtual;
+     procedure TextOutAngle(x, y: single; orientationTenthDegCCW: integer; const sUTF8: string; texture: IBGRAScanner; align: TAlignment); overload; virtual;
+     procedure TextOutAngle(x, y: single; orientationTenthDegCCW: integer; const sUTF8: string; texture: IBGRAScanner; align: TAlignment; ARightToLeft: boolean); overload; virtual; abstract;
 
      { Draw the UTF8 encoded string in the rectangle ARect. Text is wrapped if necessary.
        The position depends on the specified horizontal alignment halign and vertical alignement valign.
        The color c or texture is used to fill the text. No rotation is applied. }
-     procedure TextRect(ARect: TRect; sUTF8: string; halign: TAlignment; valign: TTextLayout; c: TBGRAPixel); overload; virtual;
-     procedure TextRect(ARect: TRect; sUTF8: string; halign: TAlignment; valign: TTextLayout; texture: IBGRAScanner); overload; virtual;
+     procedure TextRect(ARect: TRect; const sUTF8: string; halign: TAlignment; valign: TTextLayout; c: TBGRAPixel); overload; virtual;
+     procedure TextRect(ARect: TRect; const sUTF8: string; halign: TAlignment; valign: TTextLayout; texture: IBGRAScanner); overload; virtual;
 
      //-------------------------- computing path ------------------------------------
 
@@ -1132,7 +1132,7 @@ begin
   FillRect(x,y,x2,y2,texture,mode,Point(0,0),ditheringAlgorithm);
 end;
 
-procedure TBGRACustomBitmap.TextOutCurved(APath: IBGRAPath; sUTF8: string;
+procedure TBGRACustomBitmap.TextOutCurved(APath: IBGRAPath; const sUTF8: string;
   AColor: TBGRAPixel; AAlign: TAlignment; ALetterSpacing: single);
 var cursor: TBGRACustomPathCursor;
 begin
@@ -1146,7 +1146,7 @@ begin
   cursor.free;
 end;
 
-procedure TBGRACustomBitmap.TextOutCurved(APath: IBGRAPath; sUTF8: string;
+procedure TBGRACustomBitmap.TextOutCurved(APath: IBGRAPath; const sUTF8: string;
   ATexture: IBGRAScanner; AAlign: TAlignment; ALetterSpacing: single);
 var cursor: TBGRACustomPathCursor;
 begin
@@ -1160,25 +1160,25 @@ begin
   cursor.free;
 end;
 
-procedure TBGRACustomBitmap.TextMultiline(x, y: single; sUTF8: string;
+procedure TBGRACustomBitmap.TextMultiline(x, y: single; const sUTF8: string;
   c: TBGRAPixel; AAlign: TBidiTextAlignment; AVertAlign: TTextLayout; AParagraphSpacing: single);
 begin
   TextMultiline(x, y, EmptySingle, sUTF8, c, AAlign, AVertAlign, AParagraphSpacing);
 end;
 
-procedure TBGRACustomBitmap.TextMultiline(x, y: single; sUTF8: string;
+procedure TBGRACustomBitmap.TextMultiline(x, y: single; const sUTF8: string;
   ATexture: IBGRAScanner; AAlign: TBidiTextAlignment; AVertAlign: TTextLayout; AParagraphSpacing: single);
 begin
   TextMultiline(x, y, EmptySingle, sUTF8, ATexture, AAlign, AVertAlign, AParagraphSpacing);
 end;
 
-procedure TBGRACustomBitmap.TextOut(x, y: single; sUTF8: string; c: TBGRAPixel;
+procedure TBGRACustomBitmap.TextOut(x, y: single; const sUTF8: string; c: TBGRAPixel;
   align: TAlignment);
 begin
   TextOut(x,y,sUTF8,c,align, GetFontRightToLeftFor(sUTF8));
 end;
 
-procedure TBGRACustomBitmap.TextOut(x, y: single; sUTF8: string;
+procedure TBGRACustomBitmap.TextOut(x, y: single; const sUTF8: string;
   texture: IBGRAScanner; align: TAlignment);
 begin
   TextOut(x,y,sUTF8,texture,align, GetFontRightToLeftFor(sUTF8));
@@ -1186,12 +1186,12 @@ end;
 
 { Draw the UTF8 encoded string, (x,y) being the top-left corner. The color c is used to fill the text.
   The value of FontOrientation is taken into account, so that the text may be rotated. }
-procedure TBGRACustomBitmap.TextOut(x, y: single; sUTF8: string; c: TBGRAPixel);
+procedure TBGRACustomBitmap.TextOut(x, y: single; const sUTF8: string; c: TBGRAPixel);
 begin
   TextOut(x, y, sUTF8, c, taLeftJustify);
 end;
 
-procedure TBGRACustomBitmap.TextOut(x, y: single; sUTF8: string; c: TBGRAPixel;
+procedure TBGRACustomBitmap.TextOut(x, y: single; const sUTF8: string; c: TBGRAPixel;
   ARightToLeft: boolean);
 begin
   TextOut(x, y, sUTF8, c, taLeftJustify, ARightToLeft);
@@ -1199,12 +1199,12 @@ end;
 
 { Draw the UTF8 encoded string, (x,y) being the top-left corner. The color c is used to fill the text.
   The value of FontOrientation is taken into account, so that the text may be rotated. }
-procedure TBGRACustomBitmap.TextOut(x, y: single; sUTF8: string; c: TColor);
+procedure TBGRACustomBitmap.TextOut(x, y: single; const sUTF8: string; c: TColor);
 begin
   TextOut(x, y, sUTF8, ColorToBGRA(c));
 end;
 
-procedure TBGRACustomBitmap.TextOut(x, y: single; sUTF8: string; c: TColor;
+procedure TBGRACustomBitmap.TextOut(x, y: single; const sUTF8: string; c: TColor;
   ARightToLeft: boolean);
 begin
   TextOut(x, y, sUTF8, ColorToBGRA(c), ARightToLeft);
@@ -1212,39 +1212,39 @@ end;
 
 { Draw the UTF8 encoded string, (x,y) being the top-left corner. The texture is used to fill the text.
   The value of FontOrientation is taken into account, so that the text may be rotated. }
-procedure TBGRACustomBitmap.TextOut(x, y: single; sUTF8: string;
+procedure TBGRACustomBitmap.TextOut(x, y: single; const sUTF8: string;
   texture: IBGRAScanner);
 begin
   TextOut(x, y, sUTF8, texture, taLeftJustify);
 end;
 
-procedure TBGRACustomBitmap.TextOut(x, y: single; sUTF8: string;
+procedure TBGRACustomBitmap.TextOut(x, y: single; const sUTF8: string;
   texture: IBGRAScanner; ARightToLeft: boolean);
 begin
   TextOut(x, y, sUTF8, texture, taLeftJustify, ARightToLeft);
 end;
 
 procedure TBGRACustomBitmap.TextOutAngle(x, y: single;
-  orientationTenthDegCCW: integer; sUTF8: string; c: TBGRAPixel);
+  orientationTenthDegCCW: integer; const sUTF8: string; c: TBGRAPixel);
 begin
   TextOutAngle(x,y, orientationTenthDegCCW, sUTF8,c,taLeftJustify);
 end;
 
 procedure TBGRACustomBitmap.TextOutAngle(x, y: single;
-  orientationTenthDegCCW: integer; sUTF8: string; c: TBGRAPixel;
+  orientationTenthDegCCW: integer; const sUTF8: string; c: TBGRAPixel;
   align: TAlignment);
 begin
   TextOutAngle(x,y, orientationTenthDegCCW, sUTF8,c,align, GetFontRightToLeftFor(sUTF8));
 end;
 
 procedure TBGRACustomBitmap.TextOutAngle(x, y: single;
-  orientationTenthDegCCW: integer; sUTF8: string; texture: IBGRAScanner);
+  orientationTenthDegCCW: integer; const sUTF8: string; texture: IBGRAScanner);
 begin
   TextOutAngle(x,y, orientationTenthDegCCW, sUTF8,texture,taLeftJustify);
 end;
 
 procedure TBGRACustomBitmap.TextOutAngle(x, y: single;
-  orientationTenthDegCCW: integer; sUTF8: string; texture: IBGRAScanner;
+  orientationTenthDegCCW: integer; const sUTF8: string; texture: IBGRAScanner;
   align: TAlignment);
 begin
   TextOutAngle(x,y, orientationTenthDegCCW, sUTF8,texture,align, GetFontRightToLeftFor(sUTF8));
@@ -1253,10 +1253,11 @@ end;
 { Draw the UTF8 encoded string in the rectangle ARect. Text is wrapped if necessary.
   The position depends on the specified horizontal alignment halign and vertical alignement valign.
   The color c is used to fill the text. No rotation is applied. }
-procedure TBGRACustomBitmap.TextRect(ARect: TRect; sUTF8: string;
+procedure TBGRACustomBitmap.TextRect(ARect: TRect; const sUTF8: string;
   halign: TAlignment; valign: TTextLayout; c: TBGRAPixel);
 var
   style: TTextStyle;
+  sUTF8bidi: String;
 begin
   {$hints off}
   FillChar(style,sizeof(style),0);
@@ -1267,17 +1268,20 @@ begin
   style.ShowPrefix := false;
   style.Clipping := false;
   style.RightToLeft := GetFontRightToLeftFor(sUTF8);
-  if FontBidiMode = fbmAuto then sUTF8 := AddParagraphBidiUTF8(sUTF8, style.RightToLeft);
-  TextRect(ARect,ARect.Left,ARect.Top,sUTF8,style,c);
+  if FontBidiMode = fbmAuto then
+    sUTF8bidi := AddParagraphBidiUTF8(sUTF8, style.RightToLeft)
+    else sUTF8bidi := sUTF8;
+  TextRect(ARect, ARect.Left, ARect.Top, sUTF8bidi, style, c);
 end;
 
 { Draw the UTF8 encoded string in the rectangle ARect. Text is wrapped if necessary.
   The position depends on the specified horizontal alignment halign and vertical alignement valign.
   The texture is used to fill the text. No rotation is applied. }
-procedure TBGRACustomBitmap.TextRect(ARect: TRect; sUTF8: string;
+procedure TBGRACustomBitmap.TextRect(ARect: TRect; const sUTF8: string;
   halign: TAlignment; valign: TTextLayout; texture: IBGRAScanner);
 var
   style: TTextStyle;
+  sUTF8bidi: String;
 begin
   {$hints off}
   FillChar(style,sizeof(style),0);
@@ -1288,8 +1292,10 @@ begin
   style.ShowPrefix := false;
   style.Clipping := false;
   style.RightToLeft := GetFontRightToLeftFor(sUTF8);
-  if FontBidiMode = fbmAuto then sUTF8 := AddParagraphBidiUTF8(sUTF8, style.RightToLeft);
-  TextRect(ARect,ARect.Left,ARect.Top,sUTF8,style,texture);
+  if FontBidiMode = fbmAuto then
+    sUTF8bidi := AddParagraphBidiUTF8(sUTF8, style.RightToLeft)
+    else sUTF8bidi := sUTF8;
+  TextRect(ARect,ARect.Left,ARect.Top,sUTF8bidi,style,texture);
 end;
 
 function TBGRACustomBitmap.ComputeEllipse(x, y, rx, ry: single): ArrayOfTPointF;

--- a/bgrabitmap/bgradefaultbitmap.pas
+++ b/bgrabitmap/bgradefaultbitmap.pas
@@ -463,41 +463,41 @@ type
       If align is taCenter, (x,y) is at the top and middle of the text.
       If align is taRightJustify, (x,y) is the top-right corner.
       The value of FontOrientation is taken into account, so that the text may be rotated. }
-    procedure TextOut(x, y: single; sUTF8: string; c: TBGRAPixel; align: TAlignment; ARightToLeft: boolean); overload; override;
+    procedure TextOut(x, y: single; const sUTF8: string; c: TBGRAPixel; align: TAlignment; ARightToLeft: boolean); overload; override;
 
     { Same as above functions, except that the text is filled using texture.
       The value of FontOrientation is taken into account, so that the text may be rotated. }
-    procedure TextOut(x, y: single; sUTF8: string; texture: IBGRAScanner; align: TAlignment; ARightToLeft: boolean); overload; override;
+    procedure TextOut(x, y: single; const sUTF8: string; texture: IBGRAScanner; align: TAlignment; ARightToLeft: boolean); overload; override;
 
     { Same as above, except that the orientation is specified, overriding the value of the property FontOrientation. }
-    procedure TextOutAngle(x, y: single; orientationTenthDegCCW: integer; sUTF8: string; c: TBGRAPixel; align: TAlignment; ARightToLeft: boolean); overload; override;
-    procedure TextOutAngle(x, y: single; orientationTenthDegCCW: integer; sUTF8: string; texture: IBGRAScanner; align: TAlignment; ARightToLeft: boolean); overload; override;
+    procedure TextOutAngle(x, y: single; orientationTenthDegCCW: integer; const sUTF8: string; c: TBGRAPixel; align: TAlignment; ARightToLeft: boolean); overload; override;
+    procedure TextOutAngle(x, y: single; orientationTenthDegCCW: integer; const sUTF8: string; texture: IBGRAScanner; align: TAlignment; ARightToLeft: boolean); overload; override;
 
-    procedure TextOutCurved(ACursor: TBGRACustomPathCursor; sUTF8: string; AColor: TBGRAPixel; AAlign: TAlignment; ALetterSpacing: single); overload; override;
-    procedure TextOutCurved(ACursor: TBGRACustomPathCursor; sUTF8: string; ATexture: IBGRAScanner; AAlign: TAlignment; ALetterSpacing: single); overload; override;
+    procedure TextOutCurved(ACursor: TBGRACustomPathCursor; const sUTF8: string; AColor: TBGRAPixel; AAlign: TAlignment; ALetterSpacing: single); overload; override;
+    procedure TextOutCurved(ACursor: TBGRACustomPathCursor; const sUTF8: string; ATexture: IBGRAScanner; AAlign: TAlignment; ALetterSpacing: single); overload; override;
 
-    procedure TextMultiline(ALeft,ATop,AWidth: single; sUTF8: string; c: TBGRAPixel; AAlign: TBidiTextAlignment = btaNatural; AVertAlign: TTextLayout = tlTop; AParagraphSpacing: single = 0); overload; override;
-    procedure TextMultiline(ALeft,ATop,AWidth: single; sUTF8: string; ATexture: IBGRAScanner; AAlign: TBidiTextAlignment = btaNatural; AVertAlign: TTextLayout = tlTop; AParagraphSpacing: single = 0); overload; override;
+    procedure TextMultiline(ALeft,ATop,AWidth: single; const sUTF8: string; c: TBGRAPixel; AAlign: TBidiTextAlignment = btaNatural; AVertAlign: TTextLayout = tlTop; AParagraphSpacing: single = 0); overload; override;
+    procedure TextMultiline(ALeft,ATop,AWidth: single; const sUTF8: string; ATexture: IBGRAScanner; AAlign: TBidiTextAlignment = btaNatural; AVertAlign: TTextLayout = tlTop; AParagraphSpacing: single = 0); overload; override;
 
     { Draw the UTF8 encoded string at the coordinate (x,y), clipped inside the rectangle ARect.
       Additional style information is provided by the style parameter.
       The color c or texture is used to fill the text. No rotation is applied. }
-    procedure TextRect(ARect: TRect; x, y: integer; sUTF8: string; style: TTextStyle; c: TBGRAPixel); overload; override;
-    procedure TextRect(ARect: TRect; x, y: integer; sUTF8: string; style: TTextStyle; texture: IBGRAScanner); overload; override;
+    procedure TextRect(ARect: TRect; x, y: integer; const sUTF8: string; style: TTextStyle; c: TBGRAPixel); overload; override;
+    procedure TextRect(ARect: TRect; x, y: integer; const sUTF8: string; style: TTextStyle; texture: IBGRAScanner); overload; override;
 
     { Returns the total size of the string provided using the current font.
       Orientation is not taken into account, so that the width is along the text. End of lines are stripped from the string. }
-    function TextSize(sUTF8: string): TSize; override;
-    function TextSizeMultiline(sUTF8: string; AMaxWidth: single = EmptySingle; AParagraphSpacing: single = 0): TSize; override;
+    function TextSize(const sUTF8: string): TSize; override;
+    function TextSizeMultiline(const sUTF8: string; AMaxWidth: single = EmptySingle; AParagraphSpacing: single = 0): TSize; override;
 
     { Returns the affine box of the string provided using the current font.
       Orientation is taken into account. End of lines are stripped from the string. }
-    function TextAffineBox(sUTF8: string): TAffineBox; override;
+    function TextAffineBox(const sUTF8: string): TAffineBox; override;
 
     { Returns the total size of a paragraph i.e. with word break }
-    function TextSize(sUTF8: string; AMaxWidth: integer): TSize; override;
-    function TextSize(sUTF8: string; AMaxWidth: integer; ARightToLeft: boolean): TSize; override;
-    function TextFitInfo(sUTF8: string; AMaxWidth: integer): integer; override;
+    function TextSize(const sUTF8: string; AMaxWidth: integer): TSize; override;
+    function TextSize(const sUTF8: string; AMaxWidth: integer; ARightToLeft: boolean): TSize; override;
+    function TextFitInfo(const sUTF8: string; AMaxWidth: integer): integer; override;
 
     {Spline}
     function ComputeClosedSpline(const APoints: array of TPointF; AStyle: TSplineStyle): ArrayOfTPointF; override;
@@ -2823,30 +2823,30 @@ end;
 {------------------------- Text functions ---------------------------------------}
 
 procedure TBGRADefaultBitmap.TextOutAngle(x, y: single; orientationTenthDegCCW: integer;
-  sUTF8: string; c: TBGRAPixel; align: TAlignment; ARightToLeft: boolean);
+  const sUTF8: string; c: TBGRAPixel; align: TAlignment; ARightToLeft: boolean);
 begin
   with (PointF(x,y)-GetFontAnchorRotatedOffset(orientationTenthDegCCW)) do
     FontRenderer.TextOutAngle(self,x,y,orientationTenthDegCCW,CleanTextOutString(sUTF8),c,align,ARightToLeft);
 end;
 
 procedure TBGRADefaultBitmap.TextOutAngle(x, y: single; orientationTenthDegCCW: integer;
-  sUTF8: string; texture: IBGRAScanner; align: TAlignment; ARightToLeft: boolean);
+  const sUTF8: string; texture: IBGRAScanner; align: TAlignment; ARightToLeft: boolean);
 begin
   with (PointF(x,y)-GetFontAnchorRotatedOffset(orientationTenthDegCCW)) do
     FontRenderer.TextOutAngle(self,x,y,orientationTenthDegCCW,CleanTextOutString(sUTF8),texture,align,ARightToLeft);
 end;
 
-procedure TBGRADefaultBitmap.TextOutCurved(ACursor: TBGRACustomPathCursor; sUTF8: string; AColor: TBGRAPixel; AAlign: TAlignment; ALetterSpacing: single);
+procedure TBGRADefaultBitmap.TextOutCurved(ACursor: TBGRACustomPathCursor; const sUTF8: string; AColor: TBGRAPixel; AAlign: TAlignment; ALetterSpacing: single);
 begin
   InternalTextOutCurved(ACursor, sUTF8, AColor, nil, AAlign, ALetterSpacing);
 end;
 
-procedure TBGRADefaultBitmap.TextOutCurved(ACursor: TBGRACustomPathCursor; sUTF8: string; ATexture: IBGRAScanner; AAlign: TAlignment; ALetterSpacing: single);
+procedure TBGRADefaultBitmap.TextOutCurved(ACursor: TBGRACustomPathCursor; const sUTF8: string; ATexture: IBGRAScanner; AAlign: TAlignment; ALetterSpacing: single);
 begin
   InternalTextOutCurved(ACursor, sUTF8, BGRAPixelTransparent, ATexture, AAlign, ALetterSpacing);
 end;
 
-procedure TBGRADefaultBitmap.TextMultiline(ALeft, ATop, AWidth: single; sUTF8: string;
+procedure TBGRADefaultBitmap.TextMultiline(ALeft, ATop, AWidth: single; const sUTF8: string;
   c: TBGRAPixel; AAlign: TBidiTextAlignment; AVertAlign: TTextLayout; AParagraphSpacing: single);
 var
   layout: TBidiTextLayout;
@@ -2870,7 +2870,7 @@ begin
 end;
 
 procedure TBGRADefaultBitmap.TextMultiline(ALeft, ATop, AWidth: single;
-  sUTF8: string; ATexture: IBGRAScanner; AAlign: TBidiTextAlignment;
+  const sUTF8: string; ATexture: IBGRAScanner; AAlign: TBidiTextAlignment;
   AVertAlign: TTextLayout; AParagraphSpacing: single);
 var
   layout: TBidiTextLayout;
@@ -2893,13 +2893,13 @@ begin
   layout.Free;
 end;
 
-procedure TBGRADefaultBitmap.TextOut(x, y: single; sUTF8: string;
+procedure TBGRADefaultBitmap.TextOut(x, y: single; const sUTF8: string;
   texture: IBGRAScanner; align: TAlignment; ARightToLeft: boolean);
 begin
   FontRenderer.TextOut(self,x,y,CleanTextOutString(sUTF8),texture,align, ARightToLeft);
 end;
 
-procedure TBGRADefaultBitmap.TextOut(x, y: single; sUTF8: string;
+procedure TBGRADefaultBitmap.TextOut(x, y: single; const sUTF8: string;
   c: TBGRAPixel; align: TAlignment; ARightToLeft: boolean);
 begin
   with (PointF(x,y)-GetFontAnchorRotatedOffset) do
@@ -2907,13 +2907,13 @@ begin
 end;
 
 procedure TBGRADefaultBitmap.TextRect(ARect: TRect; x, y: integer;
-  sUTF8: string; style: TTextStyle; c: TBGRAPixel);
+  const sUTF8: string; style: TTextStyle; c: TBGRAPixel);
 begin
   with (PointF(x,y)-GetFontAnchorRotatedOffset(0)) do
     FontRenderer.TextRect(self,ARect,system.round(x),system.round(y),sUTF8,style,c);
 end;
 
-procedure TBGRADefaultBitmap.TextRect(ARect: TRect; x, y: integer; sUTF8: string;
+procedure TBGRADefaultBitmap.TextRect(ARect: TRect; x, y: integer; const sUTF8: string;
   style: TTextStyle; texture: IBGRAScanner);
 begin
   with (PointF(x,y)-GetFontAnchorRotatedOffset(0)) do
@@ -2922,12 +2922,12 @@ end;
 
 { Returns the total size of the string provided using the current font.
   Orientation is not taken into account, so that the width is along the text.  }
-function TBGRADefaultBitmap.TextSize(sUTF8: string): TSize;
+function TBGRADefaultBitmap.TextSize(const sUTF8: string): TSize;
 begin
   result := FontRenderer.TextSize(CleanTextOutString(sUTF8));
 end;
 
-function TBGRADefaultBitmap.TextSizeMultiline(sUTF8: string; AMaxWidth: single;
+function TBGRADefaultBitmap.TextSizeMultiline(const sUTF8: string; AMaxWidth: single;
   AParagraphSpacing: single): TSize;
 var
   layout: TBidiTextLayout;
@@ -2942,7 +2942,7 @@ begin
   layout.Free;
 end;
 
-function TBGRADefaultBitmap.TextAffineBox(sUTF8: string): TAffineBox;
+function TBGRADefaultBitmap.TextAffineBox(const sUTF8: string): TAffineBox;
 var size: TSize;
   m: TAffineMatrix;
   dy: single;
@@ -2953,18 +2953,18 @@ begin
   result := TAffineBox.AffineBox(PointF(0,-dy), m*PointF(size.cx,-dy), m*PointF(0,size.cy-dy));
 end;
 
-function TBGRADefaultBitmap.TextSize(sUTF8: string; AMaxWidth: integer): TSize;
+function TBGRADefaultBitmap.TextSize(const sUTF8: string; AMaxWidth: integer): TSize;
 begin
   result := FontRenderer.TextSize(sUTF8, AMaxWidth, GetFontRightToLeftFor(sUTF8));
 end;
 
-function TBGRADefaultBitmap.TextSize(sUTF8: string; AMaxWidth: integer;
+function TBGRADefaultBitmap.TextSize(const sUTF8: string; AMaxWidth: integer;
   ARightToLeft: boolean): TSize;
 begin
   result := FontRenderer.TextSize(sUTF8, AMaxWidth, ARightToLeft);
 end;
 
-function TBGRADefaultBitmap.TextFitInfo(sUTF8: string; AMaxWidth: integer
+function TBGRADefaultBitmap.TextFitInfo(const sUTF8: string; AMaxWidth: integer
   ): integer;
 begin
   result := FontRenderer.TextFitInfo(sUTF8, AMaxWidth);

--- a/bgrabitmap/bgradefaultbitmap.pas
+++ b/bgrabitmap/bgradefaultbitmap.pas
@@ -1972,12 +1972,7 @@ begin
   if (ATexture = nil) and (AColor.alpha = 0) then exit;
   sUTF8 := CleanTextOutString(sUTF8);
   if sUTF8 = '' then exit;
-  case FontBidiMode of
-    fbmAuto: bidiArray := AnalyzeBidiUTF8(sUTF8);
-    fbmLeftToRight: bidiArray := AnalyzeBidiUTF8(sUTF8, false);
-    fbmRightToLeft: bidiArray := AnalyzeBidiUTF8(sUTF8, true);
-    else bidiArray := nil;
-  end;
+  bidiArray := AnalyzeBidiUTF8(sUTF8, FontBidiMode);
   if bidiArray = nil then exit;
   displayOrder := GetUTF8DisplayOrder(bidiArray);
 

--- a/bgrabitmap/bgralayeroriginal.pas
+++ b/bgrabitmap/bgralayeroriginal.pas
@@ -1581,7 +1581,9 @@ end;
 
 function TBGRACustomOriginalStorage.GetBool(AName: utf8string): boolean;
 begin
-  result := StrToBool(RawString[AName]);
+  if RawString[AName] = 'true' then
+    result := true
+    else result := false;
 end;
 
 function TBGRACustomOriginalStorage.GetSingleArray(AName: utf8string): ArrayOfSingle;

--- a/bgrabitmap/bgralayeroriginal.pas
+++ b/bgrabitmap/bgralayeroriginal.pas
@@ -618,7 +618,7 @@ begin
   if not isEmptyPointF(ACoord) then
   begin
     oldClip := ADest.ClipRect;
-    ADest.ClipRect := result;
+    ADest.IntersectClip(result);
     if AAlternateColor then c := BGRA(255,128,128,alpha)
       else if AHighlighted then c := BGRA(96,170,255,alpha)
       else c := BGRA(255,255,255,alpha);

--- a/bgrabitmap/bgralayeroriginal.pas
+++ b/bgrabitmap/bgralayeroriginal.pas
@@ -268,6 +268,7 @@ type
   protected
     FFormats: TFormatSettings;
     function GetBool(AName: utf8string): boolean;
+    function GetBoolDef(AName: utf8string; ADefault: boolean): boolean;
     function GetColorArray(AName: UTF8String): ArrayOfTBGRAPixel;
     function GetInteger(AName: utf8string): integer;
     function GetIntegerDef(AName: utf8string; ADefault: integer): integer;
@@ -314,6 +315,7 @@ type
     property Int[AName: utf8string]: integer read GetInteger write SetInteger;
     property IntDef[AName: utf8string; ADefault: integer]: integer read GetIntegerDef;
     property Bool[AName: utf8string]: boolean read GetBool write SetBool;
+    property BoolDef[AName: utf8string; ADefault: boolean]: boolean read GetBoolDef;
     property Float[AName: utf8string]: single read GetSingle write SetSingle;
     property FloatArray[AName: utf8string]: ArrayOfSingle read GetSingleArray write SetSingleArray;
     property FloatDef[AName: utf8string; ADefault: single]: single read GetSingleDef;
@@ -1579,11 +1581,17 @@ begin
   RectangleF[AName] := rF;
 end;
 
+function TBGRACustomOriginalStorage.GetBoolDef(AName: utf8string;
+  ADefault: boolean): boolean;
+begin
+  if RawString[AName] = 'true' then result := true
+  else if RawString[AName] = 'false' then result := false
+  else result := ADefault;
+end;
+
 function TBGRACustomOriginalStorage.GetBool(AName: utf8string): boolean;
 begin
-  if RawString[AName] = 'true' then
-    result := true
-    else result := false;
+  result := GetBoolDef(AName, false);
 end;
 
 function TBGRACustomOriginalStorage.GetSingleArray(AName: utf8string): ArrayOfSingle;

--- a/bgrabitmap/bgratext.pas
+++ b/bgrabitmap/bgratext.pas
@@ -1396,7 +1396,8 @@ begin
   else
     WordBreakHandler := @DefaultWorkBreakHandler;
 
-  if ContainsBidiIsolateOrFormattingUTF8(ATextUTF8) then
+  if ContainsBidiIsolateOrFormattingUTF8(ATextUTF8) or
+    (pos(UTF8_LINE_SEPARATOR, ATextUTF8) <> 0) then
   begin
     bidiLayout := TBidiTextLayout.Create(self, ATextUTF8, ARightToLeft);
     bidiLayout.WordBreakHandler:= WordBreakHandler;

--- a/bgrabitmap/bgratext.pas
+++ b/bgrabitmap/bgratext.pas
@@ -1673,6 +1673,16 @@ begin
   end;
   if InternalTextSize(ATextUTF8, false).cx <= AMaxWidth then
   begin
+    for p := 1 to length(ATextUTF8) do
+    begin
+      if RemoveLineEnding(ATextUTF8,p) then
+      begin
+        ARemainsUTF8:= copy(ATextUTF8,p,length(ATextUTF8)-p+1);
+        ATextUTF8 := copy(ATextUTF8,1,p-1);
+        ALineEndingBreak:= true;
+        exit;
+      end;
+    end;
     ARemainsUTF8 := '';
     exit;
   end;

--- a/bgrabitmap/bgrathumbnail.pas
+++ b/bgrabitmap/bgrathumbnail.pas
@@ -39,6 +39,7 @@ procedure DrawThumbnailCheckers(bmp: TBGRABitmap; ARect: TRect; AIconCheckers: b
 var
   ImageCheckersColor1,ImageCheckersColor2  : TBGRAPixel;
   IconCheckersColor1,IconCheckersColor2  : TBGRAPixel;
+  CheckersScale: single = 1;
 
 implementation
 
@@ -81,7 +82,7 @@ begin
       if hIcon = 0 then hIcon := 1;
       xIcon:= (result.Width-wIcon) div 2;
       yIcon:= (result.Height-hIcon) div 2;
-      if ACheckers then DrawThumbnailCheckers(result,Rect(xIcon,yIcon,xIcon+wIcon,yIcon+hIcon),ADarkCheckers);
+      if ACheckers then DrawThumbnailCheckers(result,Rect(xIcon,yIcon,xIcon+wIcon,yIcon+hIcon),ADarkCheckers,CheckersScale);
       if AShowHotSpot and (wIcon > 0) and (hIcon > 0) then
       begin
         hotspot := Point(xIcon+ABitmap.HotSpot.X*wIcon div ABitmap.Width,yIcon+ABitmap.HotSpot.Y*hIcon div ABitmap.Height);

--- a/bgrabitmap/bgrathumbnail.pas
+++ b/bgrabitmap/bgrathumbnail.pas
@@ -34,7 +34,8 @@ function GetXwdThumbnail(AStream: TStream; AWidth, AHeight: integer; ABackColor:
 function GetXPixMapThumbnail(AStream: TStream; AWidth, AHeight: integer; ABackColor: TBGRAPixel; ACheckers: boolean; ADest: TBGRABitmap= nil): TBGRABitmap;
 function GetBmpMioMapThumbnail(AStream: TStream; AWidth, AHeight: integer; ABackColor: TBGRAPixel; ACheckers: boolean; ADest: TBGRABitmap= nil): TBGRABitmap;
 
-procedure DrawThumbnailCheckers(bmp: TBGRABitmap; ARect: TRect; AIconCheckers: boolean = false; AScale: single = 1);
+procedure DrawThumbnailCheckers(bmp: TBGRABitmap; ARect: TRect; AIconCheckers: boolean = false);
+procedure DrawThumbnailCheckers(bmp: TBGRABitmap; ARect: TRect; AIconCheckers: boolean; AScale: single);
 
 var
   ImageCheckersColor1,ImageCheckersColor2  : TBGRAPixel;
@@ -47,7 +48,13 @@ uses base64, BGRAUTF8,
      DOM, XMLRead, BGRAReadJPEG, BGRAReadPng, BGRAReadGif, BGRAReadBMP,
      BGRAReadPSD, BGRAReadIco, UnzipperExt, BGRAReadLzp;
 
-procedure DrawThumbnailCheckers(bmp: TBGRABitmap; ARect: TRect; AIconCheckers: boolean; AScale: single = 1);
+procedure DrawThumbnailCheckers(bmp: TBGRABitmap; ARect: TRect;
+  AIconCheckers: boolean);
+begin
+  DrawThumbnailCheckers(bmp, ARect,  AIconCheckers, CheckersScale);
+end;
+
+procedure DrawThumbnailCheckers(bmp: TBGRABitmap; ARect: TRect; AIconCheckers: boolean; AScale: single);
 begin
   if AIconCheckers then
     bmp.DrawCheckers(ARect, IconCheckersColor1, IconCheckersColor2, round(8*AScale), round(8*AScale))

--- a/bgrabitmap/bgrathumbnail.pas
+++ b/bgrabitmap/bgrathumbnail.pas
@@ -34,7 +34,7 @@ function GetXwdThumbnail(AStream: TStream; AWidth, AHeight: integer; ABackColor:
 function GetXPixMapThumbnail(AStream: TStream; AWidth, AHeight: integer; ABackColor: TBGRAPixel; ACheckers: boolean; ADest: TBGRABitmap= nil): TBGRABitmap;
 function GetBmpMioMapThumbnail(AStream: TStream; AWidth, AHeight: integer; ABackColor: TBGRAPixel; ACheckers: boolean; ADest: TBGRABitmap= nil): TBGRABitmap;
 
-procedure DrawThumbnailCheckers(bmp: TBGRABitmap; ARect: TRect; AIconCheckers: boolean = false);
+procedure DrawThumbnailCheckers(bmp: TBGRABitmap; ARect: TRect; AIconCheckers: boolean = false; AScale: single = 1);
 
 var
   ImageCheckersColor1,ImageCheckersColor2  : TBGRAPixel;
@@ -46,12 +46,12 @@ uses base64, BGRAUTF8,
      DOM, XMLRead, BGRAReadJPEG, BGRAReadPng, BGRAReadGif, BGRAReadBMP,
      BGRAReadPSD, BGRAReadIco, UnzipperExt, BGRAReadLzp;
 
-procedure DrawThumbnailCheckers(bmp: TBGRABitmap; ARect: TRect; AIconCheckers: boolean);
+procedure DrawThumbnailCheckers(bmp: TBGRABitmap; ARect: TRect; AIconCheckers: boolean; AScale: single = 1);
 begin
   if AIconCheckers then
-    bmp.DrawCheckers(ARect, IconCheckersColor1, IconCheckersColor2)
+    bmp.DrawCheckers(ARect, IconCheckersColor1, IconCheckersColor2, round(8*AScale), round(8*AScale))
   else
-    bmp.DrawCheckers(ARect, ImageCheckersColor1, ImageCheckersColor2);
+    bmp.DrawCheckers(ARect, ImageCheckersColor1, ImageCheckersColor2, round(8*AScale), round(8*AScale));
 end;
 
 function InternalGetBitmapThumbnail(ABitmap: TBGRACustomBitmap; AWidth, AHeight: integer; ABackColor: TBGRAPixel; ACheckers: boolean;

--- a/bgrabitmap/bgratypewriter.pas
+++ b/bgrabitmap/bgratypewriter.pas
@@ -1109,8 +1109,7 @@ var
 begin
   if ATextUTF8 = '' then exit;
 
-  if BidiMode = fbmAuto then bidiArray := AnalyzeBidiUTF8(ATextUTF8)
-  else bidiArray := AnalyzeBidiUTF8(ATextUTF8, BidiMode = fbmRightToLeft);
+  bidiArray := AnalyzeBidiUTF8(ATextUTF8, BidiMode);
   if ADisplayOrder then OrderedCharInfo else UnorderedCharInfo;
 
   cur := 0;

--- a/bgrabitmap/bgraunicode.pas
+++ b/bgrabitmap/bgraunicode.pas
@@ -21,6 +21,7 @@ type
                       ubcMirroredNeutral);       //ubcOtherNeutrals with Mirrored property
   TUnicodeJoiningType = (ujtNonJoining{U}, ujtTransparent{T}, ujtRightJoining{R}, ujtLeftJoining{L},
                          ujtDualJoining{D}, ujtJoinCausing{C});
+  TFontBidiMode = (fbmAuto, fbmLeftToRight, fbmRightToLeft);
 
 const
   ubcNeutral = [ubcSegmentSeparator, ubcParagraphSeparator, ubcWhiteSpace, ubcOtherNeutrals];
@@ -173,6 +174,7 @@ function IsModifierCombiningMark(u: LongWord): boolean;
 { Analyze unicode and return bidi levels for each character.
   baseDirection can be either UNICODE_LEFT_TO_RIGHT_ISOLATE, UNICODE_RIGHT_TO_LEFT_ISOLATE or UNICODE_FIRST_STRONG_ISOLATE }
 function AnalyzeBidiUnicode(u: PLongWord; ALength: integer; baseDirection: LongWord): TUnicodeBidiArray;
+function AnalyzeBidiUnicode(u: PLongWord; ALength: integer; ABidiMode: TFontBidiMode): TUnicodeBidiArray;
 
 { Determine diplay order, provided the display surface is horizontally infinite }
 function GetUnicodeDisplayOrder(const AInfo: TUnicodeBidiArray): TUnicodeDisplayOrder; overload;
@@ -1179,6 +1181,17 @@ begin
         result[i].Flags := result[i].Flags OR BIDI_FLAG_MULTICHAR_START;
     end;
     SplitParagraphs;
+  end;
+end;
+
+function AnalyzeBidiUnicode(u: PLongWord; ALength: integer;
+  ABidiMode: TFontBidiMode): TUnicodeBidiArray;
+begin
+  case ABidiMode of
+    fbmLeftToRight: result := AnalyzeBidiUnicode(u, ALength, UNICODE_LEFT_TO_RIGHT_ISOLATE);
+    fbmRightToLeft: result := AnalyzeBidiUnicode(u, ALength, UNICODE_RIGHT_TO_LEFT_ISOLATE);
+  else
+    {fbmAuto} result := AnalyzeBidiUnicode(u, ALength, UNICODE_FIRST_STRONG_ISOLATE);
   end;
 end;
 

--- a/bgrabitmap/bgraunicodetext.pas
+++ b/bgrabitmap/bgraunicodetext.pas
@@ -334,10 +334,7 @@ var
   lineIndex, i: Integer;
   curParaIndex: integer;
 begin
-  if FBidiMode <> fbmAuto then
-    FBidi:= AnalyzeBidiUTF8(FText, FBidiMode = fbmRightToLeft)
-  else
-    FBidi:= AnalyzeBidiUTF8(FText);
+  FBidi:= AnalyzeBidiUTF8(FText, FBidiMode);
   FCharCount := length(FBidi);
 
   FUnbrokenLineCount := 1;
@@ -453,10 +450,7 @@ begin
   if (APosition < 0) or (APosition > CharCount) then raise exception.Create('Position out of bounds');
   if length(ATextUTF8)=0 then exit(0);
 
-  if FBidiMode <> fbmAuto then
-    newBidi:= AnalyzeBidiUTF8(ATextUTF8, FBidiMode = fbmRightToLeft)
-  else
-    newBidi:= AnalyzeBidiUTF8(ATextUTF8);
+  newBidi:= AnalyzeBidiUTF8(ATextUTF8, FBidiMode);
   result:= InternalInsertText(APosition, newBidi, ATextUTF8);
 end;
 
@@ -814,10 +808,7 @@ begin
   else
     utf8Count := FBidi[bidiEnd].Offset - (utf8Start-1);
 
-  if FBidiMode <> fbmAuto then
-    newBidi:= AnalyzeBidiUTF8(copy(FText, utf8Start, utf8Count), FBidiMode = fbmRightToLeft)
-  else
-    newBidi:= AnalyzeBidiUTF8(copy(FText, utf8Start, utf8Count));
+  newBidi:= AnalyzeBidiUTF8(copy(FText, utf8Start, utf8Count), FBidiMode);
 
   startDiff := maxLongint;
   endDiff := -maxLongint;

--- a/bgrabitmap/bgrautf8.pas
+++ b/bgrabitmap/bgrautf8.pas
@@ -100,8 +100,9 @@ function GetLastStrongBidiClassUTF8(const sUTF8: string): TUnicodeBidiClass;
 function IsRightToLeftUTF8(const sUTF8: string): boolean;
 function IsZeroWidthUTF8(const sUTF8: string): boolean;
 function AddParagraphBidiUTF8(s: string; ARightToLeft: boolean): string;
-function AnalyzeBidiUTF8(const sUTF8: string; ARightToLeft: boolean): TBidiUTF8Array; overload;
 function AnalyzeBidiUTF8(const sUTF8: string): TBidiUTF8Array; overload;
+function AnalyzeBidiUTF8(const sUTF8: string; ABidiMode: TFontBidiMode): TBidiUTF8Array; overload;
+function AnalyzeBidiUTF8(const sUTF8: string; ARightToLeft: boolean): TBidiUTF8Array; overload;
 function GetUTF8DisplayOrder(const ABidi: TBidiUTF8Array): TUnicodeDisplayOrder;
 function ContainsBidiIsolateOrFormattingUTF8(const sUTF8: string): boolean;
 
@@ -1205,7 +1206,7 @@ begin
   end;
 end;
 
-function AnalyzeBidiUTF8(const sUTF8: string; ABaseDirection: LongWord): TBidiUTF8Array;
+function AnalyzeBidiUTF8(const sUTF8: string; ABidiMode: TFontBidiMode): TBidiUTF8Array;
 var
   u: TUnicodeArray;
   ofs: TIntegerArray;
@@ -1217,7 +1218,7 @@ begin
   else
   begin
     UTF8ToUnicodeArray(sUTF8, u, ofs);
-    a := AnalyzeBidiUnicode(@u[0], length(u), ABaseDirection);
+    a := AnalyzeBidiUnicode(@u[0], length(u), ABidiMode);
     setlength(result, length(u));
     for i := 0 to high(result) do
     begin
@@ -1230,14 +1231,13 @@ end;
 function AnalyzeBidiUTF8(const sUTF8: string; ARightToLeft: boolean): TBidiUTF8Array;
 begin
   if ARightToLeft then
-    result := AnalyzeBidiUTF8(sUTF8, UNICODE_RIGHT_TO_LEFT_ISOLATE)
-  else
-    result := AnalyzeBidiUTF8(sUTF8, UNICODE_LEFT_TO_RIGHT_ISOLATE);
+    result := AnalyzeBidiUTF8(sUTF8, fbmRightToLeft)
+    else result := AnalyzeBidiUTF8(sUTF8, fbmLeftToRight);
 end;
 
 function AnalyzeBidiUTF8(const sUTF8: string): TBidiUTF8Array;
 begin
-  result := AnalyzeBidiUTF8(sUTF8, UNICODE_FIRST_STRONG_ISOLATE)
+  result := AnalyzeBidiUTF8(sUTF8, fbmAuto)
 end;
 
 function GetUTF8DisplayOrder(const ABidi: TBidiUTF8Array): TUnicodeDisplayOrder;

--- a/bgrabitmap/bgrautf8.pas
+++ b/bgrabitmap/bgrautf8.pas
@@ -18,6 +18,9 @@ const
   UTF8_NO_BREAK_SPACE = ' ';
   UTF8_ZERO_WIDTH_NON_JOINER = '‌';
   UTF8_ZERO_WIDTH_JOINER = '‍';
+  UTF8_LINE_SEPARATOR = #$E2#$80#$A8;       //equivalent of <br>
+  UTF8_PARAGRAPH_SEPARATOR = #$E2#$80#$A9;  //equivalent of </p>
+  UTF8_NEXT_LINE = #$C2#$85;                //equivalent of CRLF
 
 {$IFDEF BGRABITMAP_USE_LCL}
 type

--- a/bgrabitmap/geometrytypes.inc
+++ b/bgrabitmap/geometrytypes.inc
@@ -104,6 +104,7 @@ type
     function Union(const r: TRectF):TRectF; overload;
     function Union(const r: TRectF; ADiscardEmpty: boolean):TRectF; overload;
     procedure Include(const APoint: TPointF);
+    function Contains(const APoint: TPointF; AIncludeBottomRight: boolean = false): boolean;
     function IntersectsWith(const r: TRectF): boolean;
     function IsEmpty: boolean;
   end;
@@ -924,6 +925,16 @@ begin
     if APoint.y < Top then Top := APoint.y else
     if APoint.y > Bottom then Bottom := APoint.y;
   end;
+end;
+
+function TRectFHelper.Contains(const APoint: TPointF;
+  AIncludeBottomRight: boolean): boolean;
+begin
+  if isEmptyPointF(APoint) then result := false else
+  if (APoint.x < Left) or (APoint.y < Top) then result := false else
+  if AIncludeBottomRight and ((APoint.x > Right) or (APoint.y > Bottom)) then result := false else
+  if not AIncludeBottomRight and ((APoint.x >= Right) or (APoint.y >= Bottom)) then result := false
+  else result := true;
 end;
 
 function TRectFHelper.IntersectsWith(const r: TRectF): boolean;

--- a/test/testbgrafunc/utest32.pas
+++ b/test/testbgrafunc/utest32.pas
@@ -25,7 +25,7 @@ type
 
 implementation
 
-uses BGRAPath, BGRAVectorize, BGRAGradientScanner;
+uses BGRAPath, BGRAVectorize, BGRAGradientScanner, BGRAUTF8;
 
 { TTest32 }
 
@@ -138,7 +138,7 @@ begin
     direction := 1;
   end;
   cursor1.Position := position*cursor1.PathLength;
-  virtualScreen.TextOutCurved(cursor1, 'Curved text', BGRABlack, taLeftJustify, virtualScreen.FontFullHeight/8);
+  virtualScreen.TextOutCurved(cursor1, 'Curved text '+UTF8_ARABIC_LAM+UTF8_ARABIC_ALEPH, BGRABlack, taLeftJustify, virtualScreen.FontFullHeight/8);
   if cursor1.Position = cursor1.PathLength then direction := -1;
   cursor1.Free;
 

--- a/test/testbgrafunc/utest33.pas
+++ b/test/testbgrafunc/utest33.pas
@@ -66,7 +66,7 @@ begin
     y += h;
     virtualScreen.HorizLine(0,y,virtualScreen.Width,BGRA(255,255,255),dmDrawWithTransparency);
     virtualScreen.FontVerticalAnchor := textanchor;
-    virtualScreen.TextOut(h,y, FontVerticalAnchorToStr[textanchor], BGRABlack);
+    virtualScreen.TextOut(virtualScreen.Width/2,y, FontVerticalAnchorToStr[textanchor], BGRABlack, taCenter, h/3);
     y += h;
     if textanchor >= high(TFontVerticalAnchor) then break;
     textanchor:= succ(textanchor);

--- a/update_BGRABitmap.json
+++ b/update_BGRABitmap.json
@@ -10,12 +10,12 @@
       "ForceNotify" : false,
       "InternalVersion" : 1,
       "Name" : "bgrabitmappack.lpk",
-      "Version" : "11.2.2.0"
+      "Version" : "11.2.3.0"
     }
   ],
   "UpdatePackageData" : {
     "DisableInOPM" : false,
-    "DownloadZipURL" : "https://github.com/bgrabitmap/bgrabitmap/archive/v11.2.2.zip",
+    "DownloadZipURL" : "https://github.com/bgrabitmap/bgrabitmap/archive/v11.2.3.zip",
     "Name" : "bgrabitmap-master"
   }
 }


### PR DESCRIPTION
Layer originals
- Fixed reading undefined boolean value
- Catching loading error with OnOriginalLoadError event
- bigger pen size of editor points if points are big

Misc
- ParallelFloodFill can be done on universal bitmap
- added TRectF.Contains
- Thumbnail checkers have a scale property (scale 1 = 8 pixels)

Text
- Fix word break with line endings
- Handle unicode line endings
- added TextOut with letter spacing parameter
- added TGlyphCursorUTF8 in BGRAUTF8 to browse through multi chars
- save text baseline in Canvas2d state
