### PR TITLE
Dev bgrabitmap v11.2.5

### DIFF
--- a/bgrabitmap/bgrabitmappack.lpk
+++ b/bgrabitmap/bgrabitmappack.lpk
@@ -17,15 +17,10 @@
       </Parsing>
       <CodeGeneration>
         <Optimizations>
-          <OptimizationLevel Value="3"/>
+          <OptimizationLevel Value="0"/>
           <VariablesInRegisters Value="True"/>
         </Optimizations>
       </CodeGeneration>
-      <Linking>
-        <Debugging>
-          <GenerateDebugInfo Value="False"/>
-        </Debugging>
-      </Linking>
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>

--- a/bgrabitmap/bgrabitmappack.lpk
+++ b/bgrabitmap/bgrabitmappack.lpk
@@ -29,7 +29,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="11" Minor="2" Release="4"/>
+    <Version Major="11" Minor="2" Release="5"/>
     <Files Count="142">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack.lpk
+++ b/bgrabitmap/bgrabitmappack.lpk
@@ -17,10 +17,15 @@
       </Parsing>
       <CodeGeneration>
         <Optimizations>
-          <OptimizationLevel Value="0"/>
+          <OptimizationLevel Value="3"/>
           <VariablesInRegisters Value="True"/>
         </Optimizations>
       </CodeGeneration>
+      <Linking>
+        <Debugging>
+          <GenerateDebugInfo Value="False"/>
+        </Debugging>
+      </Linking>
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>

--- a/bgrabitmap/bgrabitmappack4fpgui.lpk
+++ b/bgrabitmap/bgrabitmappack4fpgui.lpk
@@ -33,7 +33,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="11" Minor="2" Release="4"/>
+    <Version Major="11" Minor="2" Release="5"/>
     <Files Count="105">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack4nogui.lpk
+++ b/bgrabitmap/bgrabitmappack4nogui.lpk
@@ -35,7 +35,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="11" Minor="2" Release="4"/>
+    <Version Major="11" Minor="2" Release="5"/>
     <Files Count="108">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmaptypes.pas
+++ b/bgrabitmap/bgrabitmaptypes.pas
@@ -25,7 +25,7 @@ uses
 
 
 const
-  BGRABitmapVersion = 11020400;
+  BGRABitmapVersion = 11020500;
 
   function BGRABitmapVersionStr: string;
 

--- a/bgrabitmap/bgracanvas2d.pas
+++ b/bgrabitmap/bgracanvas2d.pas
@@ -1339,8 +1339,20 @@ begin
 end;
 
 procedure TBGRACanvas2D.lineStyle(const AValue: array of single);
+var a: array of single;
+  i: Integer;
 begin
-  currentState.penStroker.CustomPenStyle := DuplicatePenStyle(AValue);
+  if odd(length(AValue)) then
+  begin
+    setlength(a, length(AValue)*2);
+    for i := 0 to high(AValue) do
+    begin
+      a[i] := AValue[i];
+      a[i + length(AValue)] := AValue[i];
+    end;
+  end else
+    a := DuplicatePenStyle(AValue);
+  currentState.penStroker.CustomPenStyle := a;
 end;
 
 procedure TBGRACanvas2D.lineStyle(AStyle: TPenStyle);

--- a/bgrabitmap/bgracustombitmap.inc
+++ b/bgrabitmap/bgracustombitmap.inc
@@ -508,7 +508,8 @@ type
      procedure CrossFade(ARect: TRect; Source1, Source2: IBGRAScanner; AFadePosition: byte; mode: TDrawMode = dmDrawWithTransparency); overload; virtual; abstract;
      procedure CrossFade(ARect: TRect; Source1, Source2: IBGRAScanner; AFadeMask: IBGRAScanner; mode: TDrawMode = dmDrawWithTransparency); overload; virtual; abstract;
      procedure PutImage(x, y: integer; Source: TBitmap; mode: TDrawMode; AOpacity: byte = 255); overload;
-     procedure StretchPutImage(ARect: TRect; Source: TBGRACustomBitmap; mode: TDrawMode; AOpacity: byte = 255); virtual; abstract;
+     procedure StretchPutImage(ARect: TRect; Source: TBitmap; mode: TDrawMode; AOpacity: byte = 255); overload;
+     procedure StretchPutImage(ARect: TRect; Source: TBGRACustomBitmap; mode: TDrawMode; AOpacity: byte = 255); overload; virtual; abstract;
      procedure StretchPutImageProportionally(ARect: TRect; AHorizAlign: TAlignment; AVertAlign: TTextLayout; Source: TBGRACustomBitmap; mode: TDrawMode; AOpacity: byte = 255);
      procedure PutImageSubpixel(x, y: single; Source: TBGRACustomBitmap; AOpacity: byte = 255);
      procedure PutImagePart(x,y: integer; Source: TBGRACustomBitmap; SourceRect: TRect; mode: TDrawMode; AOpacity: byte = 255);
@@ -1375,6 +1376,15 @@ var bgra: TBGRACustomBitmap;
 begin
   bgra := BGRABitmapFactory.create(Source);
   PutImage(x,y, bgra, mode, AOpacity);
+  bgra.free;
+end;
+
+procedure TBGRACustomBitmap.StretchPutImage(ARect: TRect; Source: TBitmap;
+  mode: TDrawMode; AOpacity: byte);
+var bgra: TBGRACustomBitmap;
+begin
+  bgra := BGRABitmapFactory.create(Source);
+  StretchPutImage(ARect, bgra, mode, AOpacity);
   bgra.free;
 end;
 

--- a/bgrabitmap/bgradefaultbitmap.pas
+++ b/bgrabitmap/bgradefaultbitmap.pas
@@ -2057,13 +2057,15 @@ begin
 
   if (ABorderColor.alpha = 0) and (AFillColor.alpha = 0) then exit;
 
-  if abs(StartAngleRad-EndAngleRad) >= 2*PI - 1e-6 then
+  if (abs(StartAngleRad-EndAngleRad) >= 2*PI - 1e-6) or (StartAngleRad = EndAngleRad) then
   begin
-    if aoPie in AOptions then
+    if (aoPie in AOptions) or not (PenStyle in [psSolid, psClear]) then
       EndAngleRad:= StartAngleRad+2*PI
     else
+    begin
       EllipseAntialias(cx,cy,rx,ry,ABorderColor,w,AFillColor);
-    exit;
+      exit;
+    end;
   end;
 
   if EndAngleRad < StartAngleRad then
@@ -2077,6 +2079,7 @@ begin
   if aoPie in AOptions then pts := ConcatPointsF([PointsF([PointF(cx,cy)]),pts]);
 
   multi := TBGRAMultishapeFiller.Create;
+  multi.FillMode := fmWinding;
   multi.PolygonOrder := poLastOnTop;
   if AFillColor.alpha <> 0 then
   begin

--- a/bgrabitmap/bgraopenraster.pas
+++ b/bgrabitmap/bgraopenraster.pas
@@ -706,8 +706,13 @@ end;
 procedure TBGRAOpenRasterDocument.ZipToStream(AStream: TStream);
 var zip: TZipper;
   i: integer;
+  tempFile: String;
 begin
   zip := TZipper.Create;
+  tempFile := ChangeFileExt(GetTempFileName, '');
+  if ExtractFileExt(tempFile) = '.tmp' then
+    tempFile := ChangeFileExt(tempFile, '');
+  zip.FileName:= tempFile;
   try
     for i := 0 to high(FFiles) do
     begin

--- a/bgrabitmap/bgrapath.pas
+++ b/bgrabitmap/bgrapath.pas
@@ -782,8 +782,15 @@ end;
 
 function ComputeArcRad(x, y, rx, ry: single; startRadCCW, endRadCCW: single;
   quality: single): ArrayOfTPointF;
+var
+  start65536, end65536: Int64;
 begin
-  result := ComputeArc65536(x,y,rx,ry,round(startRadCCW*32768/Pi) and $ffff,round(endRadCCW*32768/Pi) and $ffff,quality);
+  start65536 := round(startRadCCW*32768/Pi);
+  end65536 := round(endRadCCW*32768/Pi);
+  //if arc is very small but non zero, it is not a circle
+  if (start65536 = end65536) and (startRadCCW <> endRadCCW) then
+    setlength(result,2) else
+    result := ComputeArc65536(x,y,rx,ry,start65536 and $ffff,end65536 and $ffff,quality);
   result[0] := PointF(x+cos(startRadCCW)*rx,y-sin(startRadCCW)*ry);
   result[high(result)] := PointF(x+cos(endRadCCW)*rx,y-sin(endRadCCW)*ry);
 end;

--- a/bgrabitmap/bgrathumbnail.pas
+++ b/bgrabitmap/bgrathumbnail.pas
@@ -234,6 +234,14 @@ begin
       begin
         png.Position:= 0;
         result := GetPngThumbnail(png,AWidth,AHeight,ABackColor,ACheckers,ADest);
+      end else
+      begin
+        png.Clear;
+        if unzip.UnzipFileToStream('mergedimage.png', png, False) then
+        begin
+          png.Position:= 0;
+          result := GetPngThumbnail(png,AWidth,AHeight,ABackColor,ACheckers,ADest);
+        end;
       end;
     finally
       png.Free;

--- a/update_BGRABitmap.json
+++ b/update_BGRABitmap.json
@@ -10,12 +10,12 @@
       "ForceNotify" : false,
       "InternalVersion" : 1,
       "Name" : "bgrabitmappack.lpk",
-      "Version" : "11.2.4.0"
+      "Version" : "11.2.5.0"
     }
   ],
   "UpdatePackageData" : {
     "DisableInOPM" : false,
-    "DownloadZipURL" : "https://github.com/bgrabitmap/bgrabitmap/archive/v11.2.4.zip",
+    "DownloadZipURL" : "https://github.com/bgrabitmap/bgrabitmap/archive/v11.2.5.zip",
     "Name" : "bgrabitmap-master"
   }
 }


### PR DESCRIPTION
OpenRaster format:
- get thumbnail from merged image if the thumbnail is not provided
- ensure adequate temporary file is used when zipping (when saving as OpenRaster) 

Geometry:
- Canvas2d: accept odd number of values in dash array
- TBGRABitmap: fix edge cases of arcs

Misc:
- StretchPutImage now accepts TBitmap
