### PR TITLE
support for Avif images.

### DIFF
--- a/bgrabitmap/avifbgra.pas
+++ b/bgrabitmap/avifbgra.pas
@@ -1,0 +1,495 @@
+{  Encode/Decode avif images from/to BGRABitmap. }
+{* Author: Domingo Galmes <dgalmesp@gmail.com>  01-11-2021
+******************************************************************************
+* Copyright (c) 2021 Domingo Galmés
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO COORD SHALL
+* THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+* DEALINGS IN THE SOFTWARE.
+*****************************************************************************}
+
+unit avifbgra;
+
+{$mode ObjFPC}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, bgrabitmap;
+
+type
+  EAvifException = class(Exception);
+
+const
+  AVIF_DEFAULT_QUALITY = 30;
+
+procedure AvifLoadFromStream(AStream: TStream; aBitmap: TBGRABitmap);
+procedure AvifLoadFromFile(const AFilename: string; aBitmap: TBGRABitmap);
+procedure AvifLoadFromFileNative(const AFilename: string; aBitmap: TBGRABitmap);
+procedure AvifLoadFromMemory(AData: Pointer; ASize: cardinal; aBitmap: TBGRABitmap);
+//100 LOSSLESS
+function AvifSaveToStream(aBitmap: TBGRABitmap; AStream: TStream; aQuality0to100: integer = 30;aSpeed0to10:integer=6): cardinal;
+function AvifSaveToFile(aBitmap: TBGRABitmap; const AFilename: string; aQuality0to100: integer = 30;aSpeed0to10:integer=6): cardinal;
+//returns size of the resulting bitmap.
+function AvifSaveToMemory(aBitmap: TBGRABitmap; AData: Pointer; ASize: cardinal; aQuality0to100: integer = 30;aSpeed0to10:integer=6): cardinal;
+//aBuffer  12 first bytes of file.
+function AvifValidateHeaderSignature(aBuffer: Pointer): boolean;
+
+implementation
+
+uses
+  libavif, Math, BGRABitmapTypes;
+
+type
+  PavifIOStreamReader = ^avifIOStreamReader;
+
+  avifIOStreamReader = record
+    io: avifIO; // this must be the first member for easy casting to avifIO*
+    buffer: avifRWData;
+    Stream: TStream;
+  end;
+
+
+
+//aBuffer  12 first bytes of file.
+function AvifValidateHeaderSignature(aBuffer: Pointer): boolean;
+begin
+  if CompareMem(aBuffer + 4, pansichar('ftyp'), 4) then
+  begin
+    if CompareMem(aBuffer + 8, pansichar('avif'), 4) then
+      exit(True);
+    if CompareMem(aBuffer + 8, pansichar('avis'), 4) then
+      exit(True);
+    if CompareMem(aBuffer + 8, pansichar('mif1'), 4) then
+      exit(True);
+  end;
+  Result := False;
+end;
+
+
+function avifIOStreamReaderRead(io: PavifIO; readFlags: uint32; offset: uint64; size: size_type; output: PavifROData): avifResult; cdecl;
+var
+  reader: PavifIOStreamReader;
+  availableSize: uint64;
+  bytesRead: size_type;
+begin
+  if readFlags <> 0 then
+    exit(AVIF_RESULT_IO_ERROR);  // Unsupported readFlags
+  reader := PavifIOStreamReader(io);
+  // Sanitize/clamp incoming request
+  if offset > reader^.io.sizeHint then
+    exit(AVIF_RESULT_IO_ERROR);  // The offset is past the EOF.
+  availableSize := reader^.io.sizeHint - offset;
+  if size > availableSize then
+    size := availableSize;
+  if size > 0 then
+  begin
+    if (offset > MaxLongInt) then
+      exit(AVIF_RESULT_IO_ERROR);
+    if reader^.buffer.size < size then
+      avifRWDataRealloc(@reader^.buffer, size);
+    if (reader^.Stream.Seek(offset, soFromBeginning) <> offset) then
+      exit(AVIF_RESULT_IO_ERROR);
+    bytesRead := reader^.Stream.Read(reader^.buffer.Data^, size);
+    if size <> bytesRead then
+      size := bytesRead;
+  end;
+  output^.Data := reader^.buffer.Data;
+  output^.size := size;
+  exit(AVIF_RESULT_OK);
+end;
+
+procedure avifIOStreamReaderDestroy(io: PavifIO); cdecl;
+var
+  reader: PavifIOStreamReader;
+begin
+  reader := PavifIOStreamReader(io);
+  avifRWDataFree(@reader^.buffer);
+  avifFree(io);
+end;
+
+function avifIOCreateStreamReader(aStream: TStream): PavifIO; cdecl;
+var
+  reader: PavifIOStreamReader;
+  filesize: longint;
+begin
+  filesize := aStream.Size;
+  //aStream.Position:=0;
+  reader := avifAlloc(sizeof(avifIOStreamReader));
+  FillChar(reader^, sizeof(avifIOStreamReader), 0);
+  reader^.Stream := aStream;
+  reader^.io.Destroy := @avifIOStreamReaderDestroy;
+  reader^.io.Read := @avifIOStreamReaderRead;
+  reader^.io.sizeHint := fileSize;
+  reader^.io.persistent := AVIF_FALSE;
+  avifRWDataRealloc(@reader^.buffer, 1024);
+  exit(PavifIO(reader));
+end;
+
+
+function avifDecoderSetIOStream(decoder: PavifDecoder; aStream: TStream): avifResult; cdecl;
+var
+  io: PavifIO;
+begin
+  io := avifIOCreateStreamReader(aStream);
+  if io = nil then
+    exit(AVIF_RESULT_IO_ERROR);
+  avifDecoderSetIO(decoder, io);
+  exit(AVIF_RESULT_OK);
+end;
+
+procedure AvifDecode(decoder: PavifDecoder; aBitmap: TBGRABitmap);
+var
+  res: avifResult;
+  wrgb: avifRGBImage;
+begin
+  res := avifDecoderParse(decoder);
+  if res <> AVIF_RESULT_OK then
+    raise EAvifException.Create('Avif Error: ' + avifResultToString(res));
+  //  Memo1.Lines.Add(Format('Parsed AVIF: %ux%u (%ubpc)', [decoder^.image^.Width, decoder^.image^.Height, decoder^.image^.depth]));
+  if avifDecoderNextImage(decoder) = AVIF_RESULT_OK then
+  begin
+    //fillchar(wrgb, sizeof(wrgb), 0);
+    wrgb:=Default(avifRGBImage);
+    avifRGBImageSetDefaults(@wrgb, decoder^.image);
+    //aBitmap.LineOrder:=riloTopToBottom;
+    aBitmap.SetSize(wrgb.Width, wrgb.Height);
+    wrgb.pixels := PUint8(aBitmap.databyte);
+    wrgb.depth := 8;
+    {$push}{$warn 6018 off} //unreachable code
+    if TBGRAPixel_RGBAOrder then
+      wrgb.format := AVIF_RGB_FORMAT_RGBA
+    else
+      wrgb.format := AVIF_RGB_FORMAT_BGRA;
+    {$pop}
+    wrgb.rowBytes := wrgb.Width * 4;
+    //if aBitmap.LineOrder<>riloTopToBottom then
+    //begin
+    //  decoder^.image^.transformFlags:=decoder^.image^.transformFlags + Uint32(AVIF_TRANSFORM_IMIR);
+    //  decoder^.image^.imir.mode:=0;
+    //end;
+    //decoder^.image^.imir.axis:=0; //vertical mirror
+    res := avifImageYUVToRGB(decoder^.image, @wrgb);
+    if res <> AVIF_RESULT_OK then
+      raise EAvifException.Create('Avif Error: ' + avifResultToString(res));
+    if (aBitmap.LineOrder <> riloTopToBottom) and not
+      (((longword(decoder^.image^.transformFlags) and longword(AVIF_TRANSFORM_IMIR))) = longword(AVIF_TRANSFORM_IMIR)) and
+      (decoder^.image^.imir.mode = 0) then
+      aBitmap.VerticalFlip;
+    aBitmap.InvalidateBitmap;
+  end
+  else
+    raise EAvifException.Create('Avif Error: ' + avifResultToString(res));
+end;
+
+procedure AvifLoadFromStream(AStream: TStream; aBitmap: TBGRABitmap);
+var
+  decoder: PavifDecoder;
+  res: avifResult;
+begin
+  decoder := avifDecoderCreate();
+  try
+    // Override decoder defaults here (codecChoice, requestedSource, ignoreExif, ignoreXMP, etc)
+    //decoder^.maxThreads := 1;
+    // decoder^.codecChoice := AVIF_CODEC_CHOICE_AUTO;
+    // decoder^.imageSizeLimit := AVIF_DEFAULT_IMAGE_SIZE_LIMIT;
+    // decoder^.strictFlags := UInt32( AVIF_STRICT_ENABLED);
+    // decoder^.allowProgressive := AVIF_FALSE;
+    res := avifDecoderSetIOStream(decoder, aStream);
+    if res = AVIF_RESULT_OK then
+      AvifDecode(decoder, aBitmap)
+    else
+      raise EAvifException.Create('Avif Error: ' + avifResultToString(res));
+  finally
+    avifDecoderDestroy(decoder);
+  end;
+end;
+
+procedure AvifLoadFromFile(const AFilename: string; aBitmap: TBGRABitmap);
+var
+  Stream: TFileStream;
+begin
+  Stream := TFileStream.Create(AFileName, fmOpenRead);
+  try
+    AvifLoadFromStream(Stream,aBitmap);
+  finally
+    Stream.Free;
+  end;
+end;
+
+procedure AvifLoadFromFileNative(const AFilename: string; aBitmap: TBGRABitmap);
+var
+  decoder: PavifDecoder;
+  res: avifResult;
+begin
+  decoder := avifDecoderCreate();
+  try
+    // Override decoder defaults here (codecChoice, requestedSource, ignoreExif, ignoreXMP, etc)
+    //decoder^.maxThreads := 1;
+    // decoder^.codecChoice := AVIF_CODEC_CHOICE_AUTO;
+    // decoder^.imageSizeLimit := AVIF_DEFAULT_IMAGE_SIZE_LIMIT;
+    // decoder^.strictFlags := UInt32( AVIF_STRICT_ENABLED);
+    // decoder^.allowProgressive := AVIF_FALSE;
+    res := avifDecoderSetIOFile(decoder, pansichar(AFilename));
+    if res = AVIF_RESULT_OK then
+      AvifDecode(decoder, aBitmap)
+    else
+      raise EAvifException.Create('Avif Error: ' + avifResultToString(res));
+  finally
+    avifDecoderDestroy(decoder);
+  end;
+end;
+
+procedure AvifLoadFromMemory(AData: Pointer; ASize: cardinal; aBitmap: TBGRABitmap);
+var
+  decoder: PavifDecoder;
+  res: avifResult;
+begin
+  decoder := avifDecoderCreate();
+  try
+    // Override decoder defaults here (codecChoice, requestedSource, ignoreExif, ignoreXMP, etc)
+    //decoder^.maxThreads := 1;
+    // decoder^.codecChoice := AVIF_CODEC_CHOICE_AUTO;
+    // decoder^.imageSizeLimit := AVIF_DEFAULT_IMAGE_SIZE_LIMIT;
+    // decoder^.strictFlags := UInt32( AVIF_STRICT_ENABLED);
+    // decoder^.allowProgressive := AVIF_FALSE;
+    res := avifDecoderSetIOMemory(decoder, AData, ASize);
+    if res = AVIF_RESULT_OK then
+      AvifDecode(decoder, aBitmap)
+    else
+      raise EAvifException.Create('Avif Error: ' + avifResultToString(res));
+  finally
+    avifDecoderDestroy(decoder);
+  end;
+end;
+
+function Interpolate(x: double; x1, x2: double; v1, v2: double): double;
+begin
+  Result := v1 + (((v2 - v1) / (x2 - x1)) * (x - x1));
+end;
+
+
+function clamp(aValue:integer;aMin:integer;aMax:integer):integer;
+begin
+  result:=aValue;
+  if result<aMin then
+    result:=aMin;
+  if result>aMax then
+    result:=aMax;
+end;
+
+//https://github.com/AOMediaCodec/libavif/issues/545
+//https://gitmemory.com/issue/AOMediaCodec/libavif/545/802934788
+// aQuality0to100   0 worst quality, 100 best quality ( lossless ).
+procedure AvifEncode(aBitmap: TBGRABitmap; aQuality0to100: integer; aSpeed0to10:integer; var avifOutput: avifRWData);
+var
+  encoder: PavifEncoder;
+  wrgb: avifRGBImage;
+  image: PavifImage;
+  convertResult, addImageResult, finishResult: avifResult;
+  alpha_quantizer, min_quantizer, max_quantizer: integer;
+  quality: integer;
+const
+  LOSS_LESS_IMAGE_QUALITY = 100;
+begin
+  encoder := nil;
+  //FillChar(wrgb, sizeof(wrgb), 0);
+  wrgb:=Default(avifRGBImage);
+  try
+    if aQuality0to100 = LOSS_LESS_IMAGE_QUALITY then
+      image := avifImageCreate(aBitmap.Width, aBitmap.Height, 8, AVIF_PIXEL_FORMAT_YUV444)
+    else
+      image := avifImageCreate(aBitmap.Width, aBitmap.Height, 8, AVIF_PIXEL_FORMAT_YUV420{AVIF_PIXEL_FORMAT_YUV444});
+
+    // these values dictate what goes into the final AVIF
+    // Configure image here: (see avif/avif.h)
+    // * colorPrimaries
+    // * transferCharacteristics
+    // * matrixCoefficients
+    // * avifImageSetProfileICC()
+    // * avifImageSetMetadataExif()
+    // * avifImageSetMetadataXMP()
+    // * yuvRange
+    // * alphaRange
+    // * alphaPremultiplied
+    // * transforms (transformFlags, pasp, clap, irot, imir)
+    image^.colorPrimaries := AVIF_COLOR_PRIMARIES_BT709;
+    image^.transferCharacteristics := AVIF_TRANSFER_CHARACTERISTICS_SRGB;
+    image^.matrixCoefficients := AVIF_MATRIX_COEFFICIENTS_BT601;
+
+    // If you have RGB(A) data you want to encode, use this path
+    avifRGBImageSetDefaults(@wrgb, image);
+    // Override RGB(A)->YUV(A) defaults here: depth, format, chromaUpsampling, ignoreAlpha, alphaPremultiplied, libYUVUsage, etc
+    // Alternative: set rgb.pixels and rgb.rowBytes yourself, which should match your chosen rgb.format
+    // Be sure to use uint16_t* instead of uint8_t* for rgb.pixels/rgb.rowBytes if (rgb.depth > 8)
+    wrgb.Width := aBitmap.Width;
+    wrgb.Height := aBitmap.Height;
+    {$push}{$warn 6018 off} //unreachable code
+    if TBGRAPixel_RGBAOrder then
+      wrgb.format := AVIF_RGB_FORMAT_RGBA
+    else
+      wrgb.format := AVIF_RGB_FORMAT_BGRA;
+    {$pop}
+    wrgb.ignoreAlpha := 0;
+    wrgb.pixels := aBitmap.DataByte;
+    wrgb.rowBytes := aBitmap.Width * 4;
+    if aQuality0to100 = LOSS_LESS_IMAGE_QUALITY then
+    begin
+      image^.yuvRange := AVIF_RANGE_FULL;
+      image^.matrixCoefficients := AVIF_MATRIX_COEFFICIENTS_IDENTITY; // this is key for lossless
+    end;
+    convertResult := avifImageRGBToYUV(image, @wrgb);
+    if convertResult <> AVIF_RESULT_OK then
+      raise EAvifException.Create('Failed to convert to YUV(A): ' + avifResultToString(convertResult));
+    encoder := avifEncoderCreate();
+    // Configure your encoder here (see avif/avif.h):
+    // * maxThreads
+    // * minQuantizer
+    // * maxQuantizer
+    // * minQuantizerAlpha
+    // * maxQuantizerAlpha
+    // * tileRowsLog2
+    // * tileColsLog2
+    // * speed
+    // * keyframeInterval
+    // * timescale
+
+    aQuality0to100:=clamp(aQuality0to100,0,100);
+    aSpeed0to10:=clamp(aSpeed0to10,AVIF_SPEED_SLOWEST,AVIF_SPEED_FASTEST);
+
+    encoder^.maxThreads := 2;
+    encoder^.speed := aSpeed0to10;
+    if aQuality0to100 = LOSS_LESS_IMAGE_QUALITY then
+    begin
+      // Set defaults, and warn later on if anything looks incorrect
+      //input.requestedFormat = AVIF_PIXEL_FORMAT_YUV444; // don't subsample when using AVIF_MATRIX_COEFFICIENTS_IDENTITY
+      encoder^.minQuantizer := AVIF_QUANTIZER_LOSSLESS;
+      encoder^.maxQuantizer := AVIF_QUANTIZER_LOSSLESS;
+      encoder^.minQuantizerAlpha := AVIF_QUANTIZER_LOSSLESS;
+      encoder^.maxQuantizerAlpha := AVIF_QUANTIZER_LOSSLESS;
+      encoder^.codecChoice := AVIF_CODEC_CHOICE_AOM;              // rav1e doesn't support lossless transform yet:
+      // https://github.com/xiph/rav1e/issues/151
+      image^.yuvRange := AVIF_RANGE_FULL; // avoid limited range
+      image^.matrixCoefficients := AVIF_MATRIX_COEFFICIENTS_IDENTITY; // this is key for lossless
+    end
+    else
+    begin
+      // CONVERT 0..100  TO 63..0
+      quality := Trunc(interpolate(aQuality0to100, 0, 100, AVIF_QUANTIZER_WORST_QUALITY, AVIF_QUANTIZER_BEST_QUALITY));
+      max_quantizer := quality;
+      min_quantizer := 0;
+      alpha_quantizer := 0;
+      if (max_quantizer > 20) then
+      begin
+        min_quantizer := max_quantizer - 20;
+        if (max_quantizer > 40) then
+          alpha_quantizer := max_quantizer - 40;
+      end;
+      encoder^.minQuantizer := min_quantizer;
+      encoder^.maxQuantizer := max_quantizer;
+      encoder^.minQuantizerAlpha := 0;
+      encoder^.maxQuantizerAlpha := alpha_quantizer;
+    end;
+
+    if aBitmap.LineOrder <> riloTopToBottom then   //vertical mirror.
+    begin
+      image^.transformFlags := image^.transformFlags + uint32(AVIF_TRANSFORM_IMIR);
+      image^.imir.mode := 0;
+    end;
+
+    // Call avifEncoderAddImage() for each image in your sequence
+    // Only set AVIF_ADD_IMAGE_FLAG_SINGLE if you're not encoding a sequence
+    // Use avifEncoderAddImageGrid() instead with an array of avifImage* to make a grid image
+    addImageResult := avifEncoderAddImage(encoder, image, 1, uint32(AVIF_ADD_IMAGE_FLAG_SINGLE));
+    if addImageResult <> AVIF_RESULT_OK then
+      raise EAvifException.Create('Failed to add image to encoder: ' + avifResultToString(addImageResult));
+    finishResult := avifEncoderFinish(encoder, @avifOutput);
+    if finishResult <> AVIF_RESULT_OK then
+      raise EAvifException.Create('Failed to finish encode: ' + avifResultToString(finishResult));
+    //Memo1.Lines.Add('Encode success, total bytes: ' + IntToStr(avifOutput.size));
+  finally
+    if image <> nil then
+      avifImageDestroy(image);
+    if encoder <> nil then
+      avifEncoderDestroy(encoder);
+  end;
+end;
+
+function AvifSaveToFile(aBitmap: TBGRABitmap; const AFilename: string; aQuality0to100: integer;aSpeed0to10:integer=6): cardinal;
+var
+  Stream: TFileStream;
+begin
+  Stream := TFileStream.Create(AFileName, fmCreate);
+  try
+    Result := AvifSaveToStream(aBitmap, Stream, aQuality0to100, aSpeed0to10);
+  finally
+    Stream.Free;
+  end;
+end;
+
+function AvifSaveToStream(aBitmap: TBGRABitmap; AStream: TStream; aQuality0to100: integer;aSpeed0to10:integer): cardinal;
+var
+  avifOutput: avifRWData;
+  p:PByte;
+  remain,toWrite:LongWord;
+const
+  CopySize=65535;
+begin
+  try
+    avifOutput := AVIF_DATA_EMPTY;
+    AvifEncode(aBitmap, aQuality0to100,aSpeed0to10, avifOutput);
+    Result := avifOutput.size;
+    if avifOutput.Data <> nil then
+    begin
+      //AStream.WriteBuffer(avifOutput.Data^, avifOutput.size)
+      remain := avifOutput.size;
+      p := avifOutput.Data;
+      while remain > 0 do
+      begin
+        if remain > CopySize then
+          toWrite := CopySize
+        else
+          toWrite := remain;
+        AStream.WriteBuffer(p^, toWrite);
+        inc(p, toWrite);
+        dec(remain, toWrite);
+      end;
+    end
+    else
+      Result := 0;
+  finally
+    avifRWDataFree(@avifOutput);
+  end;
+end;
+
+//returns the size of the resulting bitmap.
+function AvifSaveToMemory(aBitmap: TBGRABitmap; AData: Pointer; ASize: cardinal; aQuality0to100: integer;aSpeed0to10:integer=6): cardinal;
+var
+  avifOutput: avifRWData;
+begin
+  try
+    avifOutput := AVIF_DATA_EMPTY;
+    AvifEncode(aBitmap, aQuality0to100, aSpeed0to10, avifOutput);
+    Result := avifOutput.size;
+    if avifOutput.Data <> nil then
+      Move(avifOutput.Data^, aData^, min(ASize, avifOutput.size));
+  finally
+    avifRWDataFree(@avifOutput);
+  end;
+end;
+
+end.

--- a/bgrabitmap/bgrabitmappack.lpk
+++ b/bgrabitmap/bgrabitmappack.lpk
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CONFIG>
-  <Package Version="4">
+  <Package Version="5">
     <PathDelim Value="\"/>
     <Name Value="BGRABitmapPack"/>
     <Author Value="Circular"/>
@@ -30,7 +30,7 @@
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
     <Version Major="11" Minor="4"/>
-    <Files Count="142">
+    <Files Count="146">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>
         <UnitName Value="BGRAAnimatedGif"/>
@@ -601,7 +601,24 @@
         <Filename Value="generatedunicode.inc"/>
         <Type Value="Include"/>
       </Item142>
+      <Item143>
+        <Filename Value="avifbgra.pas"/>
+        <UnitName Value="avifbgra"/>
+      </Item143>
+      <Item144>
+        <Filename Value="libavif.pas"/>
+        <UnitName Value="libavif"/>
+      </Item144>
+      <Item145>
+        <Filename Value="bgrawriteavif.pas"/>
+        <UnitName Value="BGRAWriteAvif"/>
+      </Item145>
+      <Item146>
+        <Filename Value="bgrareadavif.pas"/>
+        <UnitName Value="BGRAReadAvif"/>
+      </Item146>
     </Files>
+    <CompatibilityMode Value="True"/>
     <RequiredPkgs Count="2">
       <Item1>
         <PackageName Value="LCL"/>

--- a/bgrabitmap/bgrabitmappack.pas
+++ b/bgrabitmap/bgrabitmappack.pas
@@ -29,7 +29,8 @@ uses
   BGRAUnicode, BGRATextBidi, BGRALayerOriginal, BGRASVGOriginal, 
   BGRAGradientOriginal, BGRAUnicodeText, UniversalDrawer, LinearRGBABitmap, 
   XYZABitmap, BGRAWriteTiff, WordXYZABitmap, ExpandedBitmap, libwebp, 
-  linuxlib, BGRAReadWebP, BGRAWriteWebP, BGRAClasses;
+  linuxlib, BGRAReadWebP, BGRAWriteWebP, BGRAClasses, avifbgra, libavif, 
+  BGRAWriteAvif, BGRAReadAvif;
 
 implementation
 

--- a/bgrabitmap/bgrabitmaptypes.pas
+++ b/bgrabitmap/bgrabitmaptypes.pas
@@ -120,7 +120,10 @@ type
     {** Scalable Vector Graphic, vectorial, read-only as raster }
     ifSvg,
     {** Lossless or lossy compression using V8 algorithm (need libwebp library) }
-    ifWebP);
+    ifWebP,
+    {** Lossless or lossy compression using Avif algorithm (need libavif library) }
+    ifAvif
+    );
 
   {* Options when loading an image }
   TBGRALoadingOption = (
@@ -1235,6 +1238,21 @@ var
         inc(scores[ifWebP], 2);
     end;
 
+    if CompareMem(@magic[4], pansichar('ftyp'), 4) then  // maybe AVIF.
+    begin
+      AStream.Position:= streamStartPos+8;
+      setlength(moreMagic, 4);
+      if (AStream.Read(moreMagic[1],4) = 4) then
+      begin
+        if CompareMem(@moreMagic[1], pansichar('avif'), 4) then
+          inc(scores[ifAvif], 2)
+        else if CompareMem(@moreMagic[1], pansichar('avis'), 4) then
+          inc(scores[ifAvif], 2)
+        else if CompareMem(@moreMagic[1], pansichar('mif1'), 4) then
+          inc(scores[ifAvif], 2);
+      end;
+    end;
+
     AStream.Position := streamStartPos;
   end;
 
@@ -1296,7 +1314,8 @@ begin
   if (ext = '.oxo') then result := ifPhoxo else
   if (ext = '.svg') then result := ifSvg else
   if (ext = '.pbm') or (ext = '.pgm') or (ext = '.ppm') then result := ifPortableAnyMap else
-  if (ext = '.webp') then result := ifWebP;
+  if (ext = '.webp') then result := ifWebP else
+  if (ext = '.avif') then result := ifAvif;
 end;
 
 function SuggestImageExtension(AFormat: TBGRAImageFormat): string;
@@ -1322,6 +1341,7 @@ begin
     ifSvg: result := 'svg';
     ifPortableAnyMap: result := 'ppm';
     ifWebP: result := 'webp';
+    ifAvif: result := 'avif';
     else result := '?';
   end;
 end;

--- a/bgrabitmap/bgracustombitmap.inc
+++ b/bgrabitmap/bgracustombitmap.inc
@@ -217,7 +217,8 @@ type
 
   public
      constructor Create(AFPImage: TFPCustomImage); overload; virtual; abstract;
-     constructor Create(ABitmap: TBitmap; AUseTransparent: boolean = true); overload; virtual; abstract;
+     constructor Create(ABitmap: TBitmap); overload; virtual; abstract;
+     constructor Create(ABitmap: TBitmap; AUseTransparent: boolean); overload; virtual; abstract;
      constructor Create(AFilename: string); overload; virtual; abstract;
      constructor Create(AFilename: string; AIsUtf8Filename: boolean); overload; virtual; abstract;
      constructor Create(AFilename: string; AIsUtf8Filename: boolean; AOptions: TBGRALoadingOptions); overload; virtual; abstract;

--- a/bgrabitmap/bgradefaultbitmap.pas
+++ b/bgrabitmap/bgradefaultbitmap.pas
@@ -182,7 +182,7 @@ type
     {** Creates an image by copying the content of a ''TBitmap'', apply transparent color if specified and bitmap is masked }
     constructor Create(ABitmap: TBitmap); overload; override;
     {** Creates an image by copying the content of a ''TBitmap'', enforce/disable use of transparent color }
-    constructor Create(ABitmap: TBitmap; AUseTransparent: boolean); overload; override;
+    constructor Create(ABitmap: TBitmap; AUseTransparentColor: boolean); overload; override;
 
     {** Creates an image by loading its content from the file ''AFilename''.
         The encoding of the string is the default one for the operating system.
@@ -250,7 +250,8 @@ type
     {** Assign the content of the specified ''Source''. It can be a ''TBGRACustomBitmap'' or
         a ''TFPCustomImage'' }
     procedure Assign(Source: TPersistent); overload; override;
-    procedure Assign(Source: TBitmap; AUseTransparent: boolean); overload;
+    procedure AssignWithFixedTransparent(Source: TBitmap); overload;
+    procedure Assign(Source: TBitmap; AUseTransparentColor: boolean); overload;
 
     {** Stores the image in the stream without compression nor header }
     procedure Serialize(AStream: TStream); override;
@@ -1037,14 +1038,14 @@ end;
 constructor TBGRADefaultBitmap.Create(ABitmap: TBitmap);
 begin
   inherited Create;
-  Assign(ABitmap, ABitmap.Masked and (ABitmap.TransparentMode = tmFixed));
+  AssignWithFixedTransparent(ABitmap);
 end;
 
 { Creates an image of dimensions AWidth and AHeight and filled with transparent pixels. }
-constructor TBGRADefaultBitmap.Create(ABitmap: TBitmap; AUseTransparent: boolean);
+constructor TBGRADefaultBitmap.Create(ABitmap: TBitmap; AUseTransparentColor: boolean);
 begin
   inherited Create;
-  Assign(ABitmap, AUseTransparent);
+  Assign(ABitmap, AUseTransparentColor);
 end;
 
 { Creates an image by loading its content from the file AFilename.
@@ -1192,12 +1193,17 @@ begin
     inherited Assign(Source);
 end;
 
-procedure TBGRADefaultBitmap.Assign(Source: TBitmap; AUseTransparent: boolean);
+procedure TBGRADefaultBitmap.AssignWithFixedTransparent(Source: TBitmap);
+begin
+  Assign(Source, Source.Masked and (Source.TransparentMode = tmFixed));
+end;
+
+procedure TBGRADefaultBitmap.Assign(Source: TBitmap; AUseTransparentColor: boolean);
 var
   transpColor: TBGRAPixel;
 begin
   Assign(Source);
-  if AUseTransparent then
+  if AUseTransparentColor then
   begin
     if TBitmap(Source).TransparentMode = tmFixed then
       transpColor := ColorToBGRA(TBitmap(Source).TransparentColor)
@@ -4456,7 +4462,7 @@ end;
 
 { Make a copy of the transparent bitmap to a TBitmap with a background color
   instead of transparency }
-function TBGRADefaultBitmap.MakeBitmapCopy(BackgroundColor: TColor; AMasked: boolean): TBitmap;
+function TBGRADefaultBitmap.MakeBitmapCopy(BackgroundColor: TColor; {%H-}AMasked: boolean): TBitmap;
 var
   opaqueCopy: TBGRACustomBitmap;
 begin

--- a/bgrabitmap/bgradefaultbitmap.pas
+++ b/bgrabitmap/bgradefaultbitmap.pas
@@ -179,8 +179,10 @@ type
 
     {** Creates an image by copying the content of a ''TFPCustomImage'' }
     constructor Create(AFPImage: TFPCustomImage); overload; override;
-    {** Creates an image by copying the content of a ''TBitmap'' }
-    constructor Create(ABitmap: TBitmap; AUseTransparent: boolean = true); overload; override;
+    {** Creates an image by copying the content of a ''TBitmap'', apply transparent color if specified and bitmap is masked }
+    constructor Create(ABitmap: TBitmap); overload; override;
+    {** Creates an image by copying the content of a ''TBitmap'', enforce/disable use of transparent color }
+    constructor Create(ABitmap: TBitmap; AUseTransparent: boolean); overload; override;
 
     {** Creates an image by loading its content from the file ''AFilename''.
         The encoding of the string is the default one for the operating system.
@@ -1032,6 +1034,12 @@ begin
   Assign(AFPImage);
 end;
 
+constructor TBGRADefaultBitmap.Create(ABitmap: TBitmap);
+begin
+  inherited Create;
+  Assign(ABitmap, ABitmap.Masked and (ABitmap.TransparentMode = tmFixed));
+end;
+
 { Creates an image of dimensions AWidth and AHeight and filled with transparent pixels. }
 constructor TBGRADefaultBitmap.Create(ABitmap: TBitmap; AUseTransparent: boolean);
 begin
@@ -1189,7 +1197,7 @@ var
   transpColor: TBGRAPixel;
 begin
   Assign(Source);
-  if AUseTransparent and TBitmap(Source).Transparent then
+  if AUseTransparent then
   begin
     if TBitmap(Source).TransparentMode = tmFixed then
       transpColor := ColorToBGRA(TBitmap(Source).TransparentColor)

--- a/bgrabitmap/bgralclbitmap.pas
+++ b/bgrabitmap/bgralclbitmap.pas
@@ -1044,16 +1044,22 @@ procedure TBGRALCLBitmap.TakeScreenshotOfPrimaryMonitor;
 var primaryDC: THandle;
 begin
   primaryDC := LCLIntf.GetDC(0);
-  LoadFromDevice(primaryDC);
-  LCLIntf.ReleaseDC(0, primaryDC);
+  try
+    LoadFromDevice(primaryDC);
+  finally
+    LCLIntf.ReleaseDC(0, primaryDC);
+  end;
 end;
 
 procedure TBGRALCLBitmap.TakeScreenshot(ARect: TRect);
 var primaryDC: THandle;
 begin
   primaryDC := LCLIntf.GetDC(0);
-  LoadFromDevice(primaryDC, ARect);
-  LCLIntf.ReleaseDC(0, primaryDC);
+  try
+    LoadFromDevice(primaryDC, ARect);
+  finally
+    LCLIntf.ReleaseDC(0, primaryDC);
+  end;
 end;
 
 end.

--- a/bgrabitmap/bgrareadavif.pas
+++ b/bgrabitmap/bgrareadavif.pas
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: LGPL-3.0-linking-exception
+unit BGRAReadAvif;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  BGRAClasses, SysUtils, FPImage;
+
+type
+
+  { TBGRAReaderAvif }
+
+  TBGRAReaderAvif = class(TFPCustomImageReader)
+  protected
+    procedure InternalRead(Str: TStream; Img: TFPCustomImage); override;
+    function InternalCheck(Str: TStream): boolean; override;
+  end;
+
+implementation
+
+uses avifbgra,libavif{$ifdef linux}, linuxlib{$endif}, BGRABitmapTypes, BGRABitmap;
+
+var
+  MyLibAvifLoaded: boolean;
+
+procedure NeedLibAvif;
+begin
+  if not MyLibAvifLoaded then
+  begin
+    if not LibAvifLoad({$ifdef linux}FindLinuxLibrary('libavif.so', 0){$else}LibAvifFilename{$endif}) then
+      raise exception.Create('Cannot find libavif library ('+LibAvifFilename+')');
+    MyLibAvifLoaded:= true;
+  end;
+end;
+
+{ TBGRAReaderAvif }
+
+procedure TBGRAReaderAvif.InternalRead(Str: TStream; Img: TFPCustomImage);
+const
+  CopySize = 65536;
+var
+  oldPos: Int64;
+  mem, p: PByte;
+  totalSize, remain: LongWord;
+  toRead, w, h, x, y: integer;
+  loadInto: TBGRACustomBitmap;
+  pbgra: PBGRAPixel;
+  ok: Boolean;
+begin
+  NeedLibAvif;
+  if not InternalCheck(Str) then
+    raise exception.Create('Invalid avif header');
+  try
+    if Img is TBGRACustomBitmap then
+      loadInto := TBGRACustomBitmap(Img)
+    else
+      loadInto := BGRABitmapFactory.Create(w,h);
+    avifLoadFromStream(Str,TBGRABitmap(loadInto));
+    //if loadInto.LineOrder = riloBottomToTop then loadInto.VerticalFlip;
+    if Img <> loadInto then
+    begin
+      h:=loadInto.Height;
+      w:=loadInto.Width;
+      Img.SetSize(w, h);
+      Img.SetSize(w, h);
+      for y := 0 to h-1 do
+      begin
+        pbgra := loadInto.ScanLine[y];
+        for x := 0 to w-1 do
+        begin
+          Img.Colors[x,y] := pbgra^.ToFPColor;
+          inc(pbgra);
+        end;
+      end;
+    end;
+  finally
+    if Assigned(loadInto) and (loadInto <> Img) then loadInto.Free;
+  end;
+end;
+
+function TBGRAReaderAvif.InternalCheck(Str: TStream): boolean;
+var
+  oldPos: Int64;
+  header: array[0..11] of char;
+begin
+  oldPos := Str.Position;
+  try
+    fillchar({%H-}header, sizeof({%H-}header), 0);
+    Str.Read(header, sizeof(header));
+    result:=AvifValidateHeaderSignature(@header[0]);
+  finally
+    Str.Position:= OldPos;
+  end;
+end;
+
+initialization
+
+  DefaultBGRAImageReader[ifAvif] := TBGRAReaderAvif;
+
+finalization
+
+  if MyLibAvifLoaded then
+  begin
+    LibAvifUnload;
+    MyLibAvifLoaded:= false;
+  end;
+
+end.
+

--- a/bgrabitmap/bgrawinbitmap.pas
+++ b/bgrabitmap/bgrawinbitmap.pas
@@ -241,14 +241,16 @@ begin
   if (Width <> 0) and (Height <> 0) then
   begin
     ScreenDC := GetDC(0);
-    info     := DIBitmapInfo(Width, Height);
-    DIB_SectionHandle := CreateDIBSection(ScreenDC, info, DIB_RGB_COLORS, FDataByte, 0, 0);
+    try
+      info     := DIBitmapInfo(Width, Height);
+      DIB_SectionHandle := CreateDIBSection(ScreenDC, info, DIB_RGB_COLORS, FDataByte, 0, 0);
 
-    if (NbPixels > 0) and (FDataByte = nil) then
-      raise EOutOfMemory.Create('TBGRAWinBitmap.ReallocBitmap: Windows error ' +
-        IntToStr(GetLastError));
-
-    ReleaseDC(0, ScreenDC);
+      if (NbPixels > 0) and (FDataByte = nil) then
+        raise EOutOfMemory.Create('TBGRAWinBitmap.ReallocBitmap: Windows error ' +
+          IntToStr(GetLastError));
+    finally
+      ReleaseDC(0, ScreenDC);
+    end;
   end;
   InvalidateBitmap;
 end;

--- a/bgrabitmap/bgrawriteavif.pas
+++ b/bgrabitmap/bgrawriteavif.pas
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: LGPL-3.0-linking-exception
+unit BGRAWriteAvif;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  BGRAClasses, SysUtils, FPimage;
+
+type
+  { TBGRAWriterAvif }
+
+  TBGRAWriterAvif = class(TFPCustomImageWriter)
+  protected
+    FLossless: boolean;
+    FQualityPercent: Single;
+    procedure InternalWrite(Stream: TStream; Img: TFPCustomImage); override;
+  public
+    constructor Create; override;
+    property QualityPercent: single read FQualityPercent write FQualityPercent;
+    { If Lossless is set to True, the QualityPercent property is ignored }
+    property Lossless: boolean read FLossless write FLossless;
+
+  end;
+
+implementation
+
+uses avifbgra,libavif{$ifdef linux}, linuxlib{$endif}, BGRABitmapTypes, BGRABitmap;
+
+var
+  MyLibAvifLoaded: boolean;
+
+procedure NeedLibAvif;
+begin
+  if not MyLibAvifLoaded then
+  begin
+    if not LibAvifLoad({$ifdef linux}FindLinuxLibrary('libavif.so', 0){$else}LibAvifFilename{$endif}) then
+      raise exception.Create('Cannot find libavif library ('+LibAvifFilename+')');
+    MyLibAvifLoaded:= true;
+  end;
+end;
+
+{ TBGRAWriterAvif }
+
+procedure TBGRAWriterAvif.InternalWrite(Stream: TStream; Img: TFPCustomImage);
+var
+  saveFrom: TBGRACustomBitmap;
+  outSize: LongWord;
+  quality:integer;
+begin
+  NeedLibAvif;
+  saveFrom := BGRABitmapFactory.Create(Img);
+  try
+    quality:=Trunc(QualityPercent);
+    if LossLess then
+      quality:=100;
+    outsize:=avifSaveToStream(TBGRABitmap(saveFrom),Stream,quality);
+    if outSize = 0 then
+      raise exception.Create('Error encoding WebP');
+  finally
+    saveFrom.Free;
+  end;
+end;
+
+constructor TBGRAWriterAvif.Create;
+begin
+  inherited Create;
+//TODO: I thing that better default values are
+// FQualityPercent := 60;
+// FLossless:= False;
+  FQualityPercent := 100;
+  FLossless:= True;
+end;
+
+initialization
+
+  DefaultBGRAImageWriter[ifAvif] := TBGRAWriterAvif;
+
+finalization
+
+  if MyLibAvifLoaded then
+  begin
+    LibAvifUnload;
+    MyLibAvifLoaded:= false;
+  end;
+
+end.
+

--- a/bgrabitmap/libavif.pas
+++ b/bgrabitmap/libavif.pas
@@ -1,0 +1,1255 @@
+{FreePascal wrappper for libavif dynamic library}
+{This License applies only to this wrapper and not the libavif itself}
+{For the latest libavif visit https://github.com/AOMediaCodec/libavif   }
+{* Author: Domingo Galmes <dgalmesp@gmail.com>  01-11-2021
+******************************************************************************
+* Copyright (c) 2021 Domingo Galmés
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO COORD SHALL
+* THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+* DEALINGS IN THE SOFTWARE.
+*****************************************************************************}
+
+unit libavif;
+interface
+
+{
+  For windows there are prebuild dlls in
+  https://packages.msys2.org/queue
+
+  Install gcc/msys2 from
+  https://www.msys2.org/
+  and install
+
+  // 32 BITS
+  pacman -S --needed base-devel mingw-w64-i686-toolchain
+  pacman -S --needed mingw-w64-i686-libavif
+  (note that has many dependencies).
+
+  // 64 BITS
+  pacman -S --needed base-devel mingw-w64-x86_64-toolchain
+  pacman -S --needed mingw-w64-x86_64-libavif
+
+  THE dlls are in the bin folder.
+  C:\mingw64_32msys2\mingw64\bin
+
+}
+
+{$define LOAD_DYNAMICALLY}
+
+// if load_dynamically use () to call functions or procedures without parameters
+// wS:=avifVersion();  //ok  wS:=aviVersion;  //error.
+
+{$IFDEF LOAD_DYNAMICALLY}
+  {$DEFINE LD}
+{$ENDIF}
+
+//const APICALLTYPE=cdecl;    cdecl
+
+{
+  Partially converted by H2Pas 1.0.0 from avif.h
+  The following command line parameters were used:
+    -p
+    -D
+    -l
+    LIBAFIV
+    avif.h
+}
+
+    const
+      LibAvifFilename =
+      {$if defined(Win32)}
+        'libavif.dll'
+      {$elseif defined(Win64)}
+        'libavif.dll'
+      {$elseif defined(Darwin)}
+        'libavif.0.dylib'
+      {$elseif defined(Unix)}
+        'libavif.so.0'
+      {$else}
+        ''
+      {$endif};
+
+    type
+      size_type = NativeUInt;
+      float = single;
+
+{$IFDEF FPC}
+{$PACKRECORDS C}
+//{$PACKENUM 4}
+
+{$ENDIF}
+
+
+  { Copyright 2019 Joe Drago. All rights reserved. }
+  { SPDX-License-Identifier: BSD-2-Clause }
+{ C++ extern C conditionnal removed }
+  { --------------------------------------------------------------------------- }
+  { Export macros }
+  { AVIF_BUILDING_SHARED_LIBS should only be defined when libavif is being built }
+  { as a shared library. }
+  { AVIF_DLL should be defined if libavif is a shared library. If you are using }
+  { libavif as CMake dependency, through CMake package config file or through }
+  { pkg-config, this is defined automatically. }
+  { }
+  { Here's what AVIF_API will be defined as in shared build: }
+  { |       |        Windows        |                  Unix                  | }
+  { | Build | __declspec(dllexport) | __attribute__((visibility("default"))) | }
+  { |  Use  | __declspec(dllimport) |                                        | }
+  { }
+  { For static build, AVIF_API is always defined as nothing. }
+
+  { --------------------------------------------------------------------------- }
+  { Constants }
+  { AVIF_VERSION_DEVEL should always be 0 for official releases / version tags, }
+  { and non-zero during development of the next release. This should allow for }
+  { downstream projects to do greater-than preprocessor checks on AVIF_VERSION }
+  { to leverage in-development code without breaking their stable builds. }
+
+  const
+
+// THE LAST VERSION PREBUILD IN MSYS2*/
+{$define COMPATIBLE_OLD092}
+{$ifndef COMPATIBLE_OLD092}
+    AVIF_VERSION_MAJOR = 0;
+    AVIF_VERSION_MINOR = 9;    
+    AVIF_VERSION_PATCH = 3;    
+    AVIF_VERSION_DEVEL = 1;    
+    //AVIF_VERSION= ((AVIF_VERSION_MAJOR * 1000000) + (AVIF_VERSION_MINOR * 10000) + (AVIF_VERSION_PATCH * 100) + AVIF_VERSION_DEVEL)
+    AVIF_VERSION = 90301;  //90000+300+1
+{$else}
+AVIF_VERSION_MAJOR = 0;
+AVIF_VERSION_MINOR = 9;
+AVIF_VERSION_PATCH = 2;
+AVIF_VERSION_DEVEL = 0;
+//AVIF_VERSION= ((AVIF_VERSION_MAJOR * 1000000) + (AVIF_VERSION_MINOR * 10000) + (AVIF_VERSION_PATCH * 100) + AVIF_VERSION_DEVEL)
+AVIF_VERSION = 90200;  //90000+300+1
+{$endif}
+
+    type
+      PavifBool = ^avifBool;
+      avifBool = longint;
+
+    const
+      AVIF_TRUE = 1;      
+      AVIF_FALSE = 0;      
+      AVIF_DIAGNOSTICS_ERROR_BUFFER_SIZE = 256;      
+    { A reasonable default for maximum image size to avoid out-of-memory errors or integer overflow in }
+    { (32-bit) int or unsigned int arithmetic operations. }
+      AVIF_DEFAULT_IMAGE_SIZE_LIMIT = 16384*16384;      
+    { a 12 hour AVIF image sequence, running at 60 fps (a basic sanity check as this is quite ridiculous) }
+      AVIF_DEFAULT_IMAGE_COUNT_LIMIT = (12*3600)*60;      
+      AVIF_QUANTIZER_LOSSLESS = 0;      
+      AVIF_QUANTIZER_BEST_QUALITY = 0;      
+      AVIF_QUANTIZER_WORST_QUALITY = 63;      
+      AVIF_PLANE_COUNT_YUV = 3;      
+      AVIF_SPEED_DEFAULT = -(1);      
+      AVIF_SPEED_SLOWEST = 0;      
+      AVIF_SPEED_FASTEST = 10;      
+
+    type
+      TAvifArrayOf256AnsiChar = array[0..255] of AnsiChar;
+      TAvifArrayOf8Float= array[0..7] of float;
+
+      PavifPlanesFlag = ^avifPlanesFlag;
+      avifPlanesFlag = (AVIF_PLANES_YUV := 1 shl 0,AVIF_PLANES_A := 1 shl 1,
+        AVIF_PLANES_ALL := $ff);
+
+      PavifPlanesFlags = ^avifPlanesFlags;
+      avifPlanesFlags = UInt32;
+    { rgbPlanes }
+    { yuvPlanes }
+      avifChannelIndex = (AVIF_CHAN_R := 0,AVIF_CHAN_G := 1,
+        AVIF_CHAN_B := 2,AVIF_CHAN_Y := 0,
+        AVIF_CHAN_U := 1,AVIF_CHAN_V := 2
+        );
+    { --------------------------------------------------------------------------- }
+    { Version }
+    {$IFDEF LD}var{$ELSE}function{$ENDIF} avifVersion{$IFDEF LD}: function{$ENDIF}:PAnsiChar;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+    {$IFDEF LD}var{$ELSE}procedure{$ENDIF} avifCodecVersions{$IFDEF LD}: procedure{$ENDIF}(var outBuffer:TAvifArrayOf256AnsiChar);cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+    {$IFDEF LD}var{$ELSE}function{$ENDIF} avifLibYUVVersion{$IFDEF LD}: function{$ENDIF}:cardinal;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF} // returns 0 if libavif wasn't compiled with libyuv support
+    { Memory management }
+    {$IFDEF LD}var{$ELSE}function{$ENDIF} avifAlloc{$IFDEF LD}: function{$ENDIF}(size:size_type):pointer;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+    {$IFDEF LD}var{$ELSE}procedure{$ENDIF} avifFree{$IFDEF LD}: procedure{$ENDIF}(p:Pointer);cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+    { --------------------------------------------------------------------------- }
+    { avifResult }
+    { the avifIO field of avifDecoder is not set }
+    { similar to EAGAIN/EWOULDBLOCK, this means the avifIO doesn't have necessary data available yet }
+    { an argument passed into this function is invalid }
+    { a requested code path is not (yet) implemented }
+type
+      PavifResult = ^avifResult;
+      avifResult = (AVIF_RESULT_OK := 0,AVIF_RESULT_UNKNOWN_ERROR,
+        AVIF_RESULT_INVALID_FTYP,AVIF_RESULT_NO_CONTENT,
+        AVIF_RESULT_NO_YUV_FORMAT_SELECTED,
+        AVIF_RESULT_REFORMAT_FAILED,AVIF_RESULT_UNSUPPORTED_DEPTH,
+        AVIF_RESULT_ENCODE_COLOR_FAILED,AVIF_RESULT_ENCODE_ALPHA_FAILED,
+        AVIF_RESULT_BMFF_PARSE_FAILED,AVIF_RESULT_NO_AV1_ITEMS_FOUND,
+        AVIF_RESULT_DECODE_COLOR_FAILED,AVIF_RESULT_DECODE_ALPHA_FAILED,
+        AVIF_RESULT_COLOR_ALPHA_SIZE_MISMATCH,
+        AVIF_RESULT_ISPE_SIZE_MISMATCH,AVIF_RESULT_NO_CODEC_AVAILABLE,
+        AVIF_RESULT_NO_IMAGES_REMAINING,AVIF_RESULT_INVALID_EXIF_PAYLOAD,
+        AVIF_RESULT_INVALID_IMAGE_GRID,AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION,
+        AVIF_RESULT_TRUNCATED_DATA,AVIF_RESULT_IO_NOT_SET,
+        AVIF_RESULT_IO_ERROR,AVIF_RESULT_WAITING_ON_IO,
+        AVIF_RESULT_INVALID_ARGUMENT,AVIF_RESULT_NOT_IMPLEMENTED
+        );
+
+    {$IFDEF LD}var{$ELSE}function{$ENDIF} avifResultToString{$IFDEF LD}: function{$ENDIF}(AResult:avifResult):PAnsiChar;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+    { --------------------------------------------------------------------------- }
+    { avifROData/avifRWData: Generic raw memory storage }
+type
+      PavifROData = ^avifROData;
+      avifROData = record
+          data : PUInt8;
+          size : size_type;
+        end;
+    { Note: Use avifRWDataFree() if any avif*() function populates one of these. }
+
+      PavifRWData = ^avifRWData;
+      avifRWData = record
+          data : PUInt8;
+          size : size_type;
+        end;
+    { Initialize avifROData/avifRWData on the stack with this }
+
+//#define AVIF_DATA_EMPTY { NULL, 0 }
+const AVIF_DATA_EMPTY:avifRWData=(data:nil;size:0);
+
+  {$IFDEF LD}var{$ELSE}procedure{$ENDIF} avifRWDataRealloc{$IFDEF LD}: procedure{$ENDIF}(raw:PavifRWData;newSize:size_type);cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+  {$IFDEF LD}var{$ELSE}procedure{$ENDIF} avifRWDataSet{$IFDEF LD}: procedure{$ENDIF}(raw:PavifRWData; const data:PByte;len:size_type);cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+  {$IFDEF LD}var{$ELSE}procedure{$ENDIF} avifRWDataFree{$IFDEF LD}: procedure{$ENDIF}(raw:PavifRWData);cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+
+    { --------------------------------------------------------------------------- }
+    { avifPixelFormat }
+    { No pixels are present }
+type
+      PavifPixelFormat = ^avifPixelFormat;
+      avifPixelFormat = (AVIF_PIXEL_FORMAT_NONE := 0,AVIF_PIXEL_FORMAT_YUV444,
+        AVIF_PIXEL_FORMAT_YUV422,AVIF_PIXEL_FORMAT_YUV420,
+        AVIF_PIXEL_FORMAT_YUV400);
+
+    {$IFDEF LD}var{$ELSE}function{$ENDIF} avifPixelFormatToString{$IFDEF LD}: function{$ENDIF}(format:avifPixelFormat):PAnsiChar;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+type
+      PavifPixelFormatInfo = ^avifPixelFormatInfo;
+      avifPixelFormatInfo = record
+          monochrome : avifBool;
+          chromaShiftX : longint;
+          chromaShiftY : longint;
+        end;
+  {$IFDEF LD}var{$ELSE}procedure{$ENDIF} avifGetPixelFormatInfo{$IFDEF LD}: procedure{$ENDIF}(format: avifPixelFormat;info:PavifPixelFormatInfo);cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+    { --------------------------------------------------------------------------- }
+    { avifChromaSamplePosition }
+type
+      PavifChromaSamplePosition = ^avifChromaSamplePosition;
+      avifChromaSamplePosition = (AVIF_CHROMA_SAMPLE_POSITION_UNKNOWN := 0,
+        AVIF_CHROMA_SAMPLE_POSITION_VERTICAL := 1,
+        AVIF_CHROMA_SAMPLE_POSITION_COLOCATED := 2
+        );
+    { --------------------------------------------------------------------------- }
+    { avifRange }
+
+      PavifRange = ^avifRange;
+      avifRange = (AVIF_RANGE_LIMITED := 0,AVIF_RANGE_FULL := 1
+        );
+    { --------------------------------------------------------------------------- }
+    { CICP enums - https://www.itu.int/rec/T-REC-H.273-201612-I/en }
+
+
+    { This is actually reserved, but libavif uses it as a sentinel value. }
+const
+    AVIF_COLOR_PRIMARIES_UNKNOWN = 0;
+
+    AVIF_COLOR_PRIMARIES_BT709 = 1;
+    AVIF_COLOR_PRIMARIES_IEC61966_2_4 = 1;
+    AVIF_COLOR_PRIMARIES_UNSPECIFIED = 2;
+    AVIF_COLOR_PRIMARIES_BT470M = 4;
+    AVIF_COLOR_PRIMARIES_BT470BG = 5;
+    AVIF_COLOR_PRIMARIES_BT601 = 6;
+    AVIF_COLOR_PRIMARIES_SMPTE240 = 7;
+    AVIF_COLOR_PRIMARIES_GENERIC_FILM = 8;
+    AVIF_COLOR_PRIMARIES_BT2020 = 9;
+    AVIF_COLOR_PRIMARIES_XYZ = 10;
+    AVIF_COLOR_PRIMARIES_SMPTE431 = 11;
+    AVIF_COLOR_PRIMARIES_SMPTE432 = 12; // DCI P3
+    AVIF_COLOR_PRIMARIES_EBU3213 = 22;
+type
+
+      PavifColorPrimaries = ^avifColorPrimaries;
+      avifColorPrimaries = UInt16;
+    { AVIF_COLOR_PRIMARIES_* }
+    { outPrimaries: rX, rY, gX, gY, bX, bY, wX, wY }
+
+{$IFDEF LD}var{$ELSE}procedure{$ENDIF} avifColorPrimariesGetValues{$IFDEF LD}: procedure{$ENDIF}(acp:avifColorPrimaries;var outPrimaries:TAvifArrayOf8Float);cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifColorPrimariesFind{$IFDEF LD}: function{$ENDIF}(var inPrimaries:TAvifArrayOf8Float;outName:PPAnsiChar):avifColorPrimaries;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+
+const
+    // This is actually reserved, but libavif uses it as a sentinel value.
+    AVIF_TRANSFER_CHARACTERISTICS_UNKNOWN = 0;
+
+    AVIF_TRANSFER_CHARACTERISTICS_BT709 = 1;
+    AVIF_TRANSFER_CHARACTERISTICS_UNSPECIFIED = 2;
+    AVIF_TRANSFER_CHARACTERISTICS_BT470M = 4;  // 2.2 gamma
+    AVIF_TRANSFER_CHARACTERISTICS_BT470BG = 5; // 2.8 gamma
+    AVIF_TRANSFER_CHARACTERISTICS_BT601 = 6;
+    AVIF_TRANSFER_CHARACTERISTICS_SMPTE240 = 7;
+    AVIF_TRANSFER_CHARACTERISTICS_LINEAR = 8;
+    AVIF_TRANSFER_CHARACTERISTICS_LOG100 = 9;
+    AVIF_TRANSFER_CHARACTERISTICS_LOG100_SQRT10 = 10;
+    AVIF_TRANSFER_CHARACTERISTICS_IEC61966 = 11;
+    AVIF_TRANSFER_CHARACTERISTICS_BT1361 = 12;
+    AVIF_TRANSFER_CHARACTERISTICS_SRGB = 13;
+    AVIF_TRANSFER_CHARACTERISTICS_BT2020_10BIT = 14;
+    AVIF_TRANSFER_CHARACTERISTICS_BT2020_12BIT = 15;
+    AVIF_TRANSFER_CHARACTERISTICS_SMPTE2084 = 16; // PQ
+    AVIF_TRANSFER_CHARACTERISTICS_SMPTE428 = 17;
+    AVIF_TRANSFER_CHARACTERISTICS_HLG = 18;
+type
+
+      PavifTransferCharacteristics = ^avifTransferCharacteristics;
+      avifTransferCharacteristics = UInt16;
+    { AVIF_TRANSFER_CHARACTERISTICS_* }
+const 
+    AVIF_MATRIX_COEFFICIENTS_IDENTITY = 0;
+    AVIF_MATRIX_COEFFICIENTS_BT709 = 1;
+    AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED = 2;
+    AVIF_MATRIX_COEFFICIENTS_FCC = 4;
+    AVIF_MATRIX_COEFFICIENTS_BT470BG = 5;
+    AVIF_MATRIX_COEFFICIENTS_BT601 = 6;
+    AVIF_MATRIX_COEFFICIENTS_SMPTE240 = 7;
+    AVIF_MATRIX_COEFFICIENTS_YCGCO = 8;
+    AVIF_MATRIX_COEFFICIENTS_BT2020_NCL = 9;
+    AVIF_MATRIX_COEFFICIENTS_BT2020_CL = 10;
+    AVIF_MATRIX_COEFFICIENTS_SMPTE2085 = 11;
+    AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL = 12;
+    AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_CL = 13;
+    AVIF_MATRIX_COEFFICIENTS_ICTCP = 14;
+
+type
+      PavifMatrixCoefficients = ^avifMatrixCoefficients;
+      avifMatrixCoefficients = UInt16; { AVIF_MATRIX_COEFFICIENTS_* }
+    
+    { --------------------------------------------------------------------------- }
+    { avifDiagnostics }
+    { Upon receiving an error from any non-const libavif API call, if the toplevel structure used }
+    { in the API call (avifDecoder, avifEncoder) contains a diag member, this buffer may be }
+    { populated with a NULL-terminated, freeform error string explaining the most recent error in }
+    { more detail. It will be cleared at the beginning of every non-const API call. }
+
+      PavifDiagnostics = ^avifDiagnostics;
+      avifDiagnostics = record
+          error : array[0..(AVIF_DIAGNOSTICS_ERROR_BUFFER_SIZE)-1] of char;
+        end;
+
+{$IFDEF LD}var{$ELSE}procedure{$ENDIF} avifDiagnosticsClearError{$IFDEF LD}: procedure{$ENDIF}(diag:PavifDiagnostics );cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+    { --------------------------------------------------------------------------- }
+    { Optional transformation structs }
+type
+      PavifTransformFlag = ^avifTransformFlag;
+      avifTransformFlag = (AVIF_TRANSFORM_NONE := 0,AVIF_TRANSFORM_PASP := 1 shl 0,
+        AVIF_TRANSFORM_CLAP := 1 shl 1,AVIF_TRANSFORM_IROT := 1 shl 2,
+        AVIF_TRANSFORM_IMIR := 1 shl 3);
+
+      PavifTransformFlags = ^avifTransformFlags;
+      avifTransformFlags = UInt32;
+    { 'pasp' from ISO/IEC 14496-12:2015 12.1.4.3 }
+    { define the relative width and height of a pixel }
+
+      PavifPixelAspectRatioBox = ^avifPixelAspectRatioBox;
+      avifPixelAspectRatioBox = record
+          hSpacing : UInt32;
+          vSpacing : UInt32;
+        end;
+
+      PavifCleanApertureBox = ^avifCleanApertureBox;
+      avifCleanApertureBox = record
+    { 'clap' from ISO/IEC 14496-12:2015 12.1.4.3 }
+    { a fractional number which defines the exact clean aperture width, in counted pixels, of the video image }	  
+          widthN : UInt32;
+          widthD : UInt32;
+    { a fractional number which defines the exact clean aperture height, in counted pixels, of the video image }		  
+          heightN : UInt32;
+          heightD : UInt32;
+    { a fractional number which defines the horizontal offset of clean aperture centre minus (width-1)/2. Typically 0. }	  
+          horizOffN : UInt32;
+          horizOffD : UInt32;
+    { a fractional number which defines the vertical offset of clean aperture centre minus (height-1)/2. Typically 0. } 
+          vertOffN : UInt32;
+          vertOffD : UInt32;
+        end;
+
+      PavifImageRotation = ^avifImageRotation;
+      avifImageRotation = record
+    { 'irot' from ISO/IEC 23008-12:2017 6.5.10 }
+    { angle * 90 specifies the angle (in anti-clockwise direction) in units of degrees. } 
+          angle : UInt8;      { legal values: [0-3] }
+        end;
+    { 'imir' from ISO/IEC 23008-12:2017 6.5.12 (Draft Amendment 2): }
+    { }
+    {     'mode' specifies how the mirroring is performed: }
+    { }
+    {     0 indicates that the top and bottom parts of the image are exchanged; }
+    {     1 specifies that the left and right parts are exchanged. }
+    { }
+    {     NOTE In Exif, orientation tag can be used to signal mirroring operations. Exif }
+    {     orientation tag 4 corresponds to mode = 0 of ImageMirror, and Exif orientation tag 2 }
+    {     corresponds to mode = 1 accordingly. }
+    { }
+    { Legal values: [0, 1] }
+    { }
+    { NOTE: As of HEIF Draft Amendment 2, the name of this variable has changed from 'axis' to 'mode' as }
+    {       the logic behind it has been *inverted*. Please use the wording above describing the legal }
+    {       values for 'mode' and update any code that previously may have used `axis` to use }
+    {       the *opposite* value (0 now means top-to-bottom, where it used to mean left-to-right). }
+
+      PavifImageMirror = ^avifImageMirror;
+      avifImageMirror = record
+          mode : UInt8;
+        end;
+    { --------------------------------------------------------------------------- }
+    { avifCropRect - Helper struct/functions to work with avifCleanApertureBox }
+
+      PavifCropRect = ^avifCropRect;
+      avifCropRect = record
+          x : UInt32;
+          y : UInt32;
+          width : UInt32;
+          height : UInt32;
+        end;
+    { These will return AVIF_FALSE if the resultant values violate any standards, and if so, the output }
+    { values are not guaranteed to be complete or correct and should not be used. }
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifCropRectConvertCleanApertureBox{$IFDEF LD}: function{$ENDIF}(cropRect:PavifCropRect;
+                                                      clap:PavifCleanApertureBox;
+                                                      imageW:UInt32;
+                                                      imageH:UInt32;
+                                                      yuvFormat:avifPixelFormat;
+                                                      diag:PavifDiagnostics):avifBool;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifCleanApertureBoxConvertCropRect{$IFDEF LD}: function{$ENDIF}(clap:PavifCleanApertureBox;
+                                                      cropRect:PavifCropRect;
+                                                      imageW:UInt32; 
+                                                      imageH:UInt32; 
+                                                      yuvFormat:avifPixelFormat;
+                                                      diag:PavifDiagnostics):avifBool;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+
+    { --------------------------------------------------------------------------- }
+    { avifImage }
+type
+      PavifImage = ^avifImage;
+      PPavifImage = ^PavifImage;
+      avifImage = record
+    { Image information }	  
+          width : UInt32;
+          height : UInt32;
+          depth : UInt32;      { all planes must share this depth; if depth>8, all planes are UInt16 internally }
+          yuvFormat : avifPixelFormat;
+          yuvRange : avifRange;
+          yuvChromaSamplePosition : avifChromaSamplePosition;
+          yuvPlanes : array[0..(AVIF_PLANE_COUNT_YUV)-1] of PUInt8;
+          yuvRowBytes : array[0..(AVIF_PLANE_COUNT_YUV)-1] of UInt32;
+          imageOwnsYUVPlanes : avifBool;
+          alphaRange : avifRange;
+          alphaPlane : PUInt8;
+          alphaRowBytes : UInt32;
+          imageOwnsAlphaPlane : avifBool;
+          alphaPremultiplied : avifBool;
+    { ICC Profile }		  
+          icc : avifRWData;
+    { CICP information: }
+    { These are stored in the AV1 payload and used to signal YUV conversion. Additionally, if an }
+    { ICC profile is not specified, these will be stored in the AVIF container's `colr` box with }
+    { a type of `nclx`. If your system supports ICC profiles, be sure to check for the existence }
+    { of one (avifImage.icc) before relying on the values listed here! }
+		  
+          colorPrimaries : avifColorPrimaries;
+          transferCharacteristics : avifTransferCharacteristics;
+          matrixCoefficients : avifMatrixCoefficients;
+    { Transformations - These metadata values are encoded/decoded when transformFlags are set }
+    { appropriately, but do not impact/adjust the actual pixel buffers used (images won't be }
+    { pre-cropped or mirrored upon decode). Basic explanations from the standards are offered in }
+    { comments above, but for detailed explanations, please refer to the HEIF standard (ISO/IEC }
+    { 23008-12:2017) and the BMFF standard (ISO/IEC 14496-12:2015). }
+    { }
+    { To encode any of these boxes, set the values in the associated box, then enable the flag in }
+    { transformFlags. On decode, only honor the values in boxes with the associated transform flag set. }
+          transformFlags : avifTransformFlags;
+          pasp : avifPixelAspectRatioBox;
+          clap : avifCleanApertureBox;
+          irot : avifImageRotation;
+          imir : avifImageMirror;
+          { Metadata - set with avifImageSetMetadata*() before write, check .size>0 for existence after read }
+          exif : avifRWData;
+          xmp : avifRWData;
+        end;
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifImageCreate{$IFDEF LD}: function{$ENDIF}(width:integer;height:integer;depth:integer;yuvFormat:avifPixelFormat):PavifImage;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifImageCreateEmpty{$IFDEF LD}: function{$ENDIF}:PavifImage;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF} // helper for making an image to decode into
+{$IFDEF LD}var{$ELSE}procedure{$ENDIF} avifImageCopy{$IFDEF LD}: procedure{$ENDIF}(dstImage:PavifImage;srcImage:PavifImage;planes:avifPlanesFlags);cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF} // deep copy
+{$IFDEF LD}var{$ELSE}procedure{$ENDIF} avifImageDestroy{$IFDEF LD}: procedure{$ENDIF}(image:PavifImage);cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}procedure{$ENDIF} avifImageSetProfileICC{$IFDEF LD}: procedure{$ENDIF}(image:PavifImage;icc:PByte;iccSize:size_type);cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+    { Warning: If the Exif payload is set and invalid, avifEncoderWrite() may return AVIF_RESULT_INVALID_EXIF_PAYLOAD }
+{$IFDEF LD}var{$ELSE}procedure{$ENDIF} avifImageSetMetadataExif{$IFDEF LD}: procedure{$ENDIF}(image:PavifImage;exif:PByte;exifSize:size_type);cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}procedure{$ENDIF} avifImageSetMetadataXMP{$IFDEF LD}: procedure{$ENDIF}(image:PavifImage;xmp:PByte;xmpSize:size_type);cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}procedure{$ENDIF} avifImageAllocatePlanes{$IFDEF LD}: procedure{$ENDIF}(image:PavifImage;planes:avifPlanesFlags);cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF} // Ignores any pre-existing planes
+{$IFDEF LD}var{$ELSE}procedure{$ENDIF} avifImageFreePlanes{$IFDEF LD}: procedure{$ENDIF}(image:PavifImage;planes:avifPlanesFlags);cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}     // Ignores already-freed planes
+{$IFDEF LD}var{$ELSE}procedure{$ENDIF} avifImageStealPlanes{$IFDEF LD}: procedure{$ENDIF}(dstImage:PavifImage;srcImage:PavifImage;planes:avifPlanesFlags);cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+    { --------------------------------------------------------------------------- }
+    { Understanding maxThreads }
+    { }
+    { libavif's structures and API use the setting 'maxThreads' in a few places. The intent of this }
+    { setting is to limit concurrent thread activity/usage, not necessarily to put a hard ceiling on }
+    { how many sleeping threads happen to exist behind the scenes. The goal of this setting is to }
+    { ensure that at any given point during libavif's encoding or decoding, no more than *maxThreads* }
+    { threads are simultaneously **active and taking CPU time**. }
+    { }
+    { As an important example, when encoding an image sequence that has an alpha channel, two }
+    { long-lived underlying AV1 encoders must simultaneously exist (one for color, one for alpha). For }
+    { each additional frame fed into libavif, its YUV planes are fed into one instance of the AV1 }
+    { encoder, and its alpha plane is fed into another. These operations happen serially, so only one }
+    { of these AV1 encoders is ever active at a time. However, the AV1 encoders might pre-create a }
+    { pool of worker threads upon initialization, so during this process, twice the amount of worker }
+    { threads actually simultaneously exist on the machine, but half of them are guaranteed to be }
+    { sleeping. }
+    { }
+    { This design ensures that AV1 implementations are given as many threads as possible to ensure a }
+    { speedy encode or decode, despite the complexities of occasionally needing two AV1 codec instances }
+    { (due to alpha payloads being separate from color payloads). If your system has a hard ceiling on }
+    { the number of threads that can ever be in flight at a given time, please account for this }
+    { accordingly. }
+    { --------------------------------------------------------------------------- }
+    { Optional YUV<->RGB support }
+    { To convert to/from RGB, create an avifRGBImage on the stack, call avifRGBImageSetDefaults() on }
+    { it, and then tweak the values inside of it accordingly. At a minimum, you should populate }
+    { ->pixels and ->rowBytes with an appropriately sized pixel buffer, which should be at least }
+    { (->rowBytes * ->height) bytes, where ->rowBytes is at least (->width * avifRGBImagePixelSize()). }
+    { If you don't want to supply your own pixel buffer, you can use the }
+    { avifRGBImageAllocatePixels()/avifRGBImageFreePixels() convenience functions. }
+    { avifImageRGBToYUV() and avifImageYUVToRGB() will perform depth rescaling and limited<->full range }
+    { conversion, if necessary. Pixels in an avifRGBImage buffer are always full range, and conversion }
+    { routines will fail if the width and height don't match the associated avifImage. }
+    { If libavif is built with libyuv fast paths enabled, libavif will use libyuv for conversion from }
+    { YUV to RGB if the following requirements are met: }
+    { }
+    { * YUV depth: 8 }
+    { * RGB depth: 8 }
+    { * rgb.chromaUpsampling: AVIF_CHROMA_UPSAMPLING_AUTOMATIC, AVIF_CHROMA_UPSAMPLING_FASTEST }
+    { * rgb.format: AVIF_RGB_FORMAT_RGBA, AVIF_RGB_FORMAT_BGRA (420/422 support for AVIF_RGB_FORMAT_ABGR, AVIF_RGB_FORMAT_ARGB) }
+    { * CICP is one of the following combinations (CP/TC/MC/Range): }
+    {   * x/x/[2|5|6]/Full }
+    {   * [5|6]/x/12/Full }
+    {   * x/x/[1|2|5|6|9]/Limited }
+    {   * [1|2|5|6|9]/x/12/Limited }
+    { This is the default format set in avifRGBImageSetDefaults(). }
+type
+      PavifRGBFormat = ^avifRGBFormat;
+      avifRGBFormat = (AVIF_RGB_FORMAT_RGB := 0,AVIF_RGB_FORMAT_RGBA,
+        AVIF_RGB_FORMAT_ARGB,AVIF_RGB_FORMAT_BGR,
+        AVIF_RGB_FORMAT_BGRA,AVIF_RGB_FORMAT_ABGR
+        );
+
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifRGBFormatChannelCount{$IFDEF LD}: function{$ENDIF}(format:avifRGBFormat):UInt32;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifRGBFormatHasAlpha{$IFDEF LD}: function{$ENDIF}(format:avifRGBFormat):avifBool;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+type
+      PavifChromaUpsampling = ^avifChromaUpsampling;
+      avifChromaUpsampling = (AVIF_CHROMA_UPSAMPLING_AUTOMATIC := 0,     { Chooses best trade off of speed/quality (prefers libyuv, else uses BEST_QUALITY) }
+        AVIF_CHROMA_UPSAMPLING_FASTEST := 1,    { Chooses speed over quality (prefers libyuv, else uses NEAREST) }
+        AVIF_CHROMA_UPSAMPLING_BEST_QUALITY := 2,    { Chooses the best quality upsampling, given settings (avoids libyuv) }
+        AVIF_CHROMA_UPSAMPLING_NEAREST := 3,    { Uses nearest-neighbor filter (built-in) }
+        AVIF_CHROMA_UPSAMPLING_BILINEAR := 4    { Uses bilinear filter (built-in) }
+
+        );
+    
+      PavifRGBImage = ^avifRGBImage;
+      avifRGBImage = record
+          width : UInt32;      { must match associated avifImage }
+          height : UInt32;    { must match associated avifImage }
+          depth : UInt32;    { legal depths [8, 10, 12, 16]. if depth>8, pixels must be UInt16 internally }
+          format : avifRGBFormat;  { all channels are always full range }
+          chromaUpsampling : avifChromaUpsampling;     { Defaults to AVIF_CHROMA_UPSAMPLING_AUTOMATIC: How to upsample non-4:4:4 UV (ignored for 444) when converting to RGB. }
+    { Unused when converting to YUV. avifRGBImageSetDefaults() prefers quality over speed. }
+    { Used for XRGB formats, treats formats containing alpha (such as ARGB) as if they were }
+    { RGB, treating the alpha bits as if they were all 1. }
+          ignoreAlpha : avifBool;
+          alphaPremultiplied : avifBool;     { indicates if RGB value is pre-multiplied by alpha. Default: false }
+          pixels : PUInt8;
+          rowBytes : UInt32;
+        end;
+    { Sets rgb->width, rgb->height, and rgb->depth to image->width, image->height, and image->depth. }
+    { Sets rgb->pixels to NULL and rgb->rowBytes to 0. Sets the other fields of 'rgb' to default }
+    { values. }
+
+{$IFDEF LD}var{$ELSE}procedure{$ENDIF} avifRGBImageSetDefaults{$IFDEF LD}: procedure{$ENDIF}(rgb:PavifRGBImage;image:PavifImage);cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifRGBImagePixelSize{$IFDEF LD}: function{$ENDIF}(rgb:PavifRGBImage):UInt32;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+
+    { Convenience functions. If you supply your own pixels/rowBytes, you do not need to use these. }
+{$IFDEF LD}var{$ELSE}procedure{$ENDIF} avifRGBImageAllocatePixels{$IFDEF LD}: procedure{$ENDIF}(rgb:PavifRGBImage);cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}procedure{$ENDIF} avifRGBImageFreePixels{$IFDEF LD}: procedure{$ENDIF}(rgb:PavifRGBImage);cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+
+    { The main conversion functions }
+
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifImageRGBToYUV{$IFDEF LD}: function{$ENDIF}(image:PavifImage;rgb:PavifRGBImage):avifResult;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifImageYUVToRGB{$IFDEF LD}: function{$ENDIF}(image:PavifImage;rgb:PavifRGBImage):avifResult;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+
+    { Premultiply handling functions. }
+    { (Un)premultiply is automatically done by the main conversion functions above, }
+    { so usually you don't need to call these. They are there for convenience. }
+
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifRGBImagePremultiplyAlpha{$IFDEF LD}: function{$ENDIF}(rgb:PavifRGBImage):avifResult;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifRGBImageUnpremultiplyAlpha{$IFDEF LD}: function{$ENDIF}(rgb:PavifRGBImage):avifResult;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+
+    { --------------------------------------------------------------------------- }
+    { YUV Utils }
+
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifFullToLimitedY{$IFDEF LD}: function{$ENDIF}(depth:integer;v:integer):integer;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifFullToLimitedUV{$IFDEF LD}: function{$ENDIF}(depth:integer;v:integer):integer;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifLimitedToFullY{$IFDEF LD}: function{$ENDIF}(depth:integer;v:integer):integer;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifLimitedToFullUV{$IFDEF LD}: function{$ENDIF}(depth:integer;v:integer):integer;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+
+    { --------------------------------------------------------------------------- }
+    { Codec selection }
+type
+      PavifCodecChoice = ^avifCodecChoice;
+      avifCodecChoice = (AVIF_CODEC_CHOICE_AUTO := 0,AVIF_CODEC_CHOICE_AOM,
+        AVIF_CODEC_CHOICE_DAV1D,     { Decode only }
+		AVIF_CODEC_CHOICE_LIBGAV1,     { Decode only }
+        AVIF_CODEC_CHOICE_RAV1E,    { Encode only }
+		AVIF_CODEC_CHOICE_SVT    { Encode only }
+      );
+
+      PavifCodecFlag = ^avifCodecFlag;
+      avifCodecFlag = (
+	  AVIF_CODEC_FLAG_CAN_DECODE := 1 shl 0,
+	  AVIF_CODEC_FLAG_CAN_ENCODE := 1 shl 1
+        );
+
+      PavifCodecFlags = ^avifCodecFlags;
+      avifCodecFlags = UInt32;
+    { If this returns NULL, the codec choice/flag combination is unavailable }
+
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifCodecName{$IFDEF LD}: function{$ENDIF}(choice:avifCodecChoice;requiredFlags:avifCodecFlags):PAnsiChar;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifCodecChoiceFromName{$IFDEF LD}: function{$ENDIF}(name:PAnsiChar):avifCodecChoice;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+type
+      PavifCodecConfigurationBox = ^avifCodecConfigurationBox;
+      avifCodecConfigurationBox = record
+    { [skipped; is constant] unsigned int (1)marker = 1; }
+    { [skipped; is constant] unsigned int (7)version = 1; }
+          seqProfile : UInt8; { unsigned int (3) seq_profile; }
+          seqLevelIdx0 : UInt8; { unsigned int (5) seq_level_idx_0; }
+          seqTier0 : UInt8;    { unsigned int (1) seq_tier_0; }
+          highBitdepth : UInt8;     { unsigned int (1) high_bitdepth; }
+          twelveBit : UInt8;     { unsigned int (1) twelve_bit; }
+          monochrome : UInt8;      { unsigned int (1) monochrome; }
+          chromaSubsamplingX : UInt8;     { unsigned int (1) chroma_subsampling_x; }
+          chromaSubsamplingY : UInt8;    { unsigned int (1) chroma_subsampling_y; }
+          chromaSamplePosition : UInt8;      { unsigned int (2) chroma_sample_position; }
+    { unsigned int (3)reserved = 0; }
+    { unsigned int (1)initial_presentation_delay_present; }
+    { if (initial_presentation_delay_present)  }
+    {     unsigned int (4)initial_presentation_delay_minus_one; }
+    {  else  }
+    {     unsigned int (4)reserved = 0; }
+    {  }
+        end;
+    { --------------------------------------------------------------------------- }
+    { avifIO }
+      PavifIO = ^avifIO;
+      //avifIO = record
+      //    {undefined structure}
+      //  end;
+
+    { Destroy must completely destroy all child structures *and* free the avifIO object itself. }
+    { This function pointer is optional, however, if the avifIO object isn't intended to be owned by }
+    { a libavif encoder/decoder. }
+
+      avifIODestroyFunc = procedure (io:PavifIO);cdecl;
+    { This function should return a block of memory that *must* remain valid until another read call to }
+    { this avifIO struct is made (reusing a read buffer is acceptable/expected). }
+    { }
+    { * If offset exceeds the size of the content (past EOF), return AVIF_RESULT_IO_ERROR. }
+    { * If offset is *exactly* at EOF, provide a 0-byte buffer and return AVIF_RESULT_OK. }
+    { * If (offset+size) exceeds the contents' size, it must truncate the range to provide all }
+    {   bytes from the offset to EOF. }
+    { * If the range is unavailable yet (due to network conditions or any other reason), }
+    {   return AVIF_RESULT_WAITING_ON_IO. }
+    { * Otherwise, provide the range and return AVIF_RESULT_OK. }
+
+      avifIOReadFunc = function (io:PavifIO; readFlags:UInt32; offset:UInt64; size:size_type; output:PavifROData):avifResult;cdecl;
+
+      avifIOWriteFunc = function (io:PavifIO; writeFlags:UInt32; offset:UInt64; data:PUInt8; size:size_type):avifResult;cdecl;
+
+//      PavifIO = ^avifIO;
+      avifIO = record
+          destroy : avifIODestroyFunc;
+          read : avifIOReadFunc;
+    { This is reserved for future use - but currently ignored. Set it to a null pointer. }		  
+          write : avifIOWriteFunc;
+    { If non-zero, this is a hint to internal structures of the max size offered by the content }
+    { this avifIO structure is reading. If it is a static memory source, it should be the size of }
+    { the memory buffer; if it is a file, it should be the file's size. If this information cannot }
+    { be known (as it is streamed-in), set a reasonable upper boundary here (larger than the file }
+    { can possibly be for your environment, but within your environment's memory constraints). This }
+    { is used for sanity checks when allocating internal buffers to protect against }
+    { malformed/malicious files. }		  
+          sizeHint : UInt64;
+    { If true, *all* memory regions returned from *all* calls to read are guaranteed to be }
+    { persistent and exist for the lifetime of the avifIO object. If false, libavif will make }
+    { in-memory copies of samples and metadata content, and a memory region returned from read must }
+    { only persist until the next call to read. }		  
+          persistent : avifBool;
+    { The contents of this are defined by the avifIO implementation, and should be fully destroyed }
+    { by the implementation of the associated destroy function, unless it isn't owned by the avifIO }
+    { struct. It is not necessary to use this pointer in your implementation. }		  
+          data : pointer;
+        end;
+
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifIOCreateMemoryReader{$IFDEF LD}: function{$ENDIF}(data:PByte;size:size_type): PavifIO;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifIOCreateFileReader{$IFDEF LD}: function{$ENDIF}(filename:PAnsiChar):PavifIO;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}procedure{$ENDIF} avifIODestroy{$IFDEF LD}: procedure{$ENDIF}(io:PavifIO);cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+
+    { --------------------------------------------------------------------------- }
+    { avifDecoder }
+    { Some encoders (including very old versions of avifenc) do not implement the AVIF standard }
+    { perfectly, and thus create invalid files. However, these files are likely still recoverable / }
+    { decodable, if it wasn't for the strict requirements imposed by libavif's decoder. These flags }
+    { allow a user of avifDecoder to decide what level of strictness they want in their project. }
+
+type
+
+      PavifStrictFlag = ^avifStrictFlag;
+      avifStrictFlag = (
+    { Disables all strict checks. }	  
+	  AVIF_STRICT_DISABLED := 0,
+    { Requires the PixelInformationProperty ('pixi') be present in AV1 image items. libheif v1.11.0 }
+    { or older does not add the 'pixi' item property to AV1 image items. If you need to decode AVIF }
+    { images encoded by libheif v1.11.0 or older, be sure to disable this bit. (This issue has been }
+    { corrected in libheif v1.12.0.) }
+	  
+	  AVIF_STRICT_PIXI_REQUIRED := 1 shl 0,
+    { This demands that the values surfaced in the clap box are valid, determined by attempting to }
+    { convert the clap box to a crop rect using avifCropRectConvertCleanApertureBox(). If this }
+    { function returns AVIF_FALSE and this strict flag is set, the decode will fail. }
+	  
+        AVIF_STRICT_CLAP_VALID := 1 shl 1,
+    { Requires the ImageSpatialExtentsProperty ('ispe') be present in alpha auxiliary image items. }
+    { avif-serialize 0.7.3 or older does not add the 'ispe' item property to alpha auxiliary image }
+    { items. If you need to decode AVIF images encoded by the cavif encoder with avif-serialize }
+    { 0.7.3 or older, be sure to disable this bit. (This issue has been corrected in avif-serialize }
+    { 0.7.4.) See https://github.com/kornelski/avif-serialize/issues/3 and }
+    { https://crbug.com/1246678. }
+		
+		AVIF_STRICT_ALPHA_ISPE_REQUIRED := 1 shl 2,
+    { Maximum strictness; enables all bits above. This is avifDecoder's default. }
+		
+        AVIF_STRICT_ENABLED := (AVIF_STRICT_PIXI_REQUIRED + AVIF_STRICT_CLAP_VALID) + AVIF_STRICT_ALPHA_ISPE_REQUIRED);
+
+      PavifStrictFlags = ^avifStrictFlags;
+      avifStrictFlags = UInt32;
+    { Useful stats related to a read/write }
+
+      PavifIOStats = ^avifIOStats;
+      avifIOStats = record
+          colorOBUSize : size_type;
+          alphaOBUSize : size_type;
+        end;
+      PavifDecoderData = ^avifDecoderData;
+      avifDecoderData = record
+          {undefined structure}
+        end;
+
+
+      PavifDecoderSource = ^avifDecoderSource;
+      avifDecoderSource = (
+    { Honor the major brand signaled in the beginning of the file to pick between an AVIF sequence }
+    { ('avis', tracks-based) or a single image ('avif', item-based). If the major brand is neither }
+    { of these, prefer the AVIF sequence ('avis', tracks-based), if present. } 
+	  AVIF_DECODER_SOURCE_AUTO := 0,
+    { Use the primary item and the aux (alpha) item in the avif(s). }
+    { This is where single-image avifs store their image. }
+	  AVIF_DECODER_SOURCE_PRIMARY_ITEM,
+    { Use the chunks inside primary/aux tracks in the moov block. }
+    { This is where avifs image sequences store their images. }
+	  
+        AVIF_DECODER_SOURCE_TRACKS
+    { Decode the thumbnail item. Currently unimplemented. }
+    { AVIF_DECODER_SOURCE_THUMBNAIL_ITEM }
+	);
+	
+    { Information about the timing of a single image in an image sequence }
+
+      PavifImageTiming = ^avifImageTiming;
+      avifImageTiming = record
+          timescale : UInt64;     { timescale of the media (Hz) }
+          pts : double;       { presentation timestamp in seconds (ptsInTimescales / timescale) }
+          ptsInTimescales : UInt64;      { presentation timestamp in "timescales" }
+          duration : double;        { in seconds (durationInTimescales / timescale) }
+          durationInTimescales : UInt64;       { duration in "timescales" }
+        end;
+		
+
+      PavifProgressiveState = ^avifProgressiveState;
+      avifProgressiveState = (
+    { The current AVIF/Source does not offer a progressive image. This will always be the state }
+    { for an image sequence. }
+	  AVIF_PROGRESSIVE_STATE_UNAVAILABLE := 0,
+     { The current AVIF/Source offers a progressive image, but avifDecoder.allowProgressive is not }
+    { enabled, so it will behave as if the image was not progressive and will simply decode the }
+    { best version of this item. }     
+	  AVIF_PROGRESSIVE_STATE_AVAILABLE,
+    { The current AVIF/Source offers a progressive image, and avifDecoder.allowProgressive is true. }
+    { In this state, avifDecoder.imageCount will be the count of all of the available progressive }
+    { layers, and any specific layer can be decoded using avifDecoderNthImage() as if it was an }
+    { image sequence, or simply using repeated calls to avifDecoderNextImage() to decode better and }
+    { better versions of this image. }
+	  
+	  AVIF_PROGRESSIVE_STATE_ACTIVE
+        );
+
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifProgressiveStateToString{$IFDEF LD}: function{$ENDIF}( progressiveState:avifProgressiveState):PAnsiChar;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+
+type
+      PavifDecoder = ^avifDecoder;
+      avifDecoder = record
+    { -------------------------------------------------------------------------------------------- }
+  
+    { Inputs }
+	
+    { Defaults to AVIF_CODEC_CHOICE_AUTO: Preference determined by order in availableCodecs table (avif.c) }	  
+          codecChoice : avifCodecChoice;
+    { Defaults to 1. -- NOTE: Please see the "Understanding maxThreads" comment block above }		  
+          maxThreads : longint;
+    { avifs can have multiple sets of images in them. This specifies which to decode. }
+    { Set this via avifDecoderSetSource(). }		  
+          requestedSource : avifDecoderSource;
+    { If this is true and a progressive AVIF is decoded, avifDecoder will behave as if the AVIF is }
+    { an image sequence, in that it will set imageCount to the number of progressive frames }
+    { available, and avifDecoderNextImage()/avifDecoderNthImage() will allow for specific layers }
+    { of a progressive image to be decoded. To distinguish between a progressive AVIF and an AVIF }
+    { image sequence, inspect avifDecoder.progressiveState. }
+{$ifndef COMPATIBLE_OLD092}
+          allowProgressive : avifBool;
+    { Enable any of these to avoid reading and surfacing specific data to the decoded avifImage. }
+    { These can be useful if your avifIO implementation heavily uses AVIF_RESULT_WAITING_ON_IO for }
+    { streaming data, as some of these payloads are (unfortunately) packed at the end of the file, }
+    { which will cause avifDecoderParse() to return AVIF_RESULT_WAITING_ON_IO until it finds them. }
+    { If you don't actually leverage this data, it is best to ignore it here. }		  
+         ignoreExif : avifBool;
+         ignoreXMP : avifBool;
+    { This represents the maximum size of a image (in pixel count) that libavif and the underlying }
+    { AV1 decoder should attempt to decode. It defaults to AVIF_DEFAULT_IMAGE_SIZE_LIMIT, and can be }
+    { set to a smaller value. The value 0 is reserved. }
+    { Note: Only some underlying AV1 codecs support a configurable size limit (such as dav1d). }		  
+         imageSizeLimit : UInt32;
+    { This provides an upper bound on how many images the decoder is willing to attempt to decode, }
+    { to provide a bit of protection from malicious or malformed AVIFs citing millions upon }
+    { millions of frames, only to be invalid later. The default is AVIF_DEFAULT_IMAGE_COUNT_LIMIT }
+    { (see comment above), and setting this to 0 disables the limit. }		  
+         imageCountLimit : UInt32;
+    { Strict flags. Defaults to AVIF_STRICT_ENABLED. See avifStrictFlag definitions above. }  
+          strictFlags : avifStrictFlags;
+{$endif}
+    { -------------------------------------------------------------------------------------------- }
+    { Outputs }
+		  
+    { All decoded image data; owned by the decoder. All information in this image is incrementally }
+    { added and updated as avifDecoder*() functions are called. After a successful call to }
+    { avifDecoderParse(), all values in decoder->image (other than the planes/rowBytes themselves) }
+    { will be pre-populated with all information found in the outer AVIF container, prior to any }
+    { AV1 decoding. If the contents of the inner AV1 payload disagree with the outer container, }
+    { these values may change after calls to avifDecoderRead*(),avifDecoderNextImage(), or }
+    { avifDecoderNthImage(). }
+    { }
+    { The YUV and A contents of this image are likely owned by the decoder, so be sure to copy any }
+    { data inside of this image before advancing to the next image or reusing the decoder. It is }
+    { legal to call avifImageYUVToRGB() on this in between calls to avifDecoderNextImage(), but use }
+    { avifImageCopy() if you want to make a complete, permanent copy of this image's YUV content or }
+    { metadata. }		  
+          image : PavifImage;
+    { Counts and timing for the current image in an image sequence. Uninteresting for single image files. }	  
+          imageIndex : longint;      { 0-based }
+          imageCount : longint;      { Always 1 for non-progressive, non-sequence AVIFs. }
+{$ifndef COMPATIBLE_OLD092}
+          progressiveState : avifProgressiveState;      { See avifProgressiveState declaration }
+{$endif}
+          imageTiming : avifImageTiming;      { }
+          timescale : UInt64;      { timescale of the media (Hz) }
+          duration : double;      { in seconds (durationInTimescales / timescale) }
+          durationInTimescales : UInt64;    { duration in "timescales" }
+    { This is true when avifDecoderParse() detects an alpha plane. Use this to find out if alpha is }
+    { present after a successful call to avifDecoderParse(), but prior to any call to }
+    { avifDecoderNextImage() or avifDecoderNthImage(), as decoder->image->alphaPlane won't exist yet. }		  
+          alphaPresent : avifBool;
+{$ifdef COMPATIBLE_OLD092}
+ignoreExif : avifBool;     //CHANGED ORDER IN NEW VERSION.
+ignoreXMP : avifBool;       //CHANGED ORDER IN NEW VERSION.
+imageCountLimit : UInt32;   //CHANGED ORDER IN NEW VERSION.
+strictFlags : avifStrictFlags;//CHANGED ORDER IN NEW VERSION.
+{$endif}
+    { stats from the most recent read, possibly 0s if reading an image sequence }		  		  
+          ioStats : avifIOStats;
+    { Additional diagnostics (such as detailed error state) }
+{$ifdef COMPATIBLE_OLD092}
+io : PavifIO; //CHANGED ORDER IN NEW VERSION.
+{$endif}
+
+          diag : avifDiagnostics;
+    { -------------------------------------------------------------------------------------------- }
+    { Internals }
+    { Use one of the avifDecoderSetIO*() functions to set this }
+{$ifndef COMPATIBLE_OLD092}
+          io : PavifIO;
+{$endif}
+    { Internals used by the decoder }		  
+          data : PavifDecoderData;
+        end;
+		
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifDecoderCreate{$IFDEF LD}: function{$ENDIF}:PavifDecoder;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}procedure{$ENDIF} avifDecoderDestroy{$IFDEF LD}: procedure{$ENDIF}(decoder:PavifDecoder);cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+
+    { Simple interfaces to decode a single image, independent of the decoder afterwards (decoder may be destroyed). }
+
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifDecoderRead{$IFDEF LD}: function{$ENDIF}(decoder:PavifDecoder;image:PavifImage):avifResult;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF} // call avifDecoderSetIO*() first
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifDecoderReadMemory{$IFDEF LD}: function{$ENDIF}(decoder:PavifDecoder; image:PavifImage;data:PByte;size:size_type):avifResult;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifDecoderReadFile{$IFDEF LD}: function{$ENDIF}(decoder:PavifDecoder;image:PavifImage;filename:PAnsiChar):avifResult;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+
+    { Multi-function alternative to avifDecoderRead() for image sequences and gaining direct access }
+    { to the decoder's YUV buffers (for performance's sake). Data passed into avifDecoderParse() is NOT }
+    { copied, so it must continue to exist until the decoder is destroyed. }
+    { }
+    { Usage / function call order is: }
+    { * avifDecoderCreate() }
+    { * avifDecoderSetSource() - optional, the default (AVIF_DECODER_SOURCE_AUTO) is usually sufficient }
+    { * avifDecoderSetIO*() }
+    { * avifDecoderParse() }
+    { * avifDecoderNextImage() - in a loop, using decoder->image after each successful call }
+    { * avifDecoderDestroy() }
+    { }
+    { NOTE: Until avifDecoderParse() returns AVIF_RESULT_OK, no data in avifDecoder should }
+    {       be considered valid, and no queries (such as Keyframe/Timing/MaxExtent) should be made. }
+    { }
+    { You can use avifDecoderReset() any time after a successful call to avifDecoderParse() }
+    { to reset the internal decoder back to before the first frame. Calling either }
+    { avifDecoderSetSource() or avifDecoderParse() will automatically Reset the decoder. }
+    { }
+    { avifDecoderSetSource() allows you not only to choose whether to parse tracks or }
+    { items in a file containing both, but switch between sources without having to }
+    { Parse again. Normally AVIF_DECODER_SOURCE_AUTO is enough for the common path. }
+
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifDecoderSetSource{$IFDEF LD}: function{$ENDIF}(decoder:PavifDecoder;source:avifDecoderSource):avifResult;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+
+    { Note: When avifDecoderSetIO() is called, whether 'decoder' takes ownership of 'io' depends on }
+    { whether io->destroy is set. avifDecoderDestroy(decoder) calls avifIODestroy(io), which calls }
+    { io->destroy(io) if io->destroy is set. Therefore, if io->destroy is not set, then }
+    { avifDecoderDestroy(decoder) has no effects on 'io'. }
+
+{$IFDEF LD}var{$ELSE}procedure{$ENDIF} avifDecoderSetIO{$IFDEF LD}: procedure{$ENDIF}(decoder:PavifDecoder;io:PavifIO);cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifDecoderSetIOMemory{$IFDEF LD}: function{$ENDIF}(decoder:PavifDecoder; data:PByte;size:size_type):avifResult;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifDecoderSetIOFile{$IFDEF LD}: function{$ENDIF}(decoder:PavifDecoder;filename:PAnsiChar):avifResult;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifDecoderParse{$IFDEF LD}: function{$ENDIF}(decoder:PavifDecoder):avifResult;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifDecoderNextImage{$IFDEF LD}: function{$ENDIF}(decoder:PavifDecoder):avifResult;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifDecoderNthImage{$IFDEF LD}: function{$ENDIF}(decoder:PavifDecoder;frameIndex: UInt32):avifResult;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifDecoderReset{$IFDEF LD}: function{$ENDIF}(decoder:PavifDecoder):avifResult;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+
+    { Keyframe information }
+    { frameIndex - 0-based, matching avifDecoder->imageIndex, bound by avifDecoder->imageCount }
+    { "nearest" keyframe means the keyframe prior to this frame index (returns frameIndex if it is a keyframe) }
+    { These functions may be used after a successful call (AVIF_RESULT_OK) to avifDecoderParse(). }
+
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifDecoderIsKeyframe{$IFDEF LD}: function{$ENDIF}(decoder:PavifDecoder; frameindex:UInt32):avifBool;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifDecoderNearestKeyframe{$IFDEF LD}: function{$ENDIF}(decoder:PavifDecoder; frameIndex:UInt32):UInt32;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+ 
+    { Timing helper - This does not change the current image or invoke the codec (safe to call repeatedly) }
+    { This function may be used after a successful call (AVIF_RESULT_OK) to avifDecoderParse(). }
+ 
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifDecoderNthImageTiming{$IFDEF LD}: function{$ENDIF}(decoder:PavifDecoder; frameIndex:UInt32;outTiming:PavifImageTiming):avifResult;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+
+    { --------------------------------------------------------------------------- }
+    { avifExtent }
+type
+      PavifExtent = ^avifExtent;
+      avifExtent = record
+          offset : UInt64;
+          size : size_type;
+        end;
+    { Streaming data helper - Use this to calculate the maximal AVIF data extent encompassing all AV1 }
+    { sample data needed to decode the Nth image. The offset will be the earliest offset of all }
+    { required AV1 extents for this frame, and the size will create a range including the last byte of }
+    { the last AV1 sample needed. Note that this extent may include non-sample data, as a frame's }
+    { sample data may be broken into multiple extents and interleaved with other data, or in }
+    { non-sequential order. This extent will also encompass all AV1 samples that this frame's sample }
+    { depends on to decode (such as samples for reference frames), from the nearest keyframe up to this }
+    { Nth frame. }
+    { }
+    { If avifDecoderNthImageMaxExtent() returns AVIF_RESULT_OK and the extent's size is 0 bytes, this }
+    { signals that libavif doesn't expect to call avifIO's Read for this frame's decode. This happens if }
+    { data for this frame was read as a part of avifDecoderParse() (typically in an idat box inside of }
+    { a meta box). }
+    { }
+    { This function may be used after a successful call (AVIF_RESULT_OK) to avifDecoderParse(). }
+
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifDecoderNthImageMaxExtent{$IFDEF LD}: function{$ENDIF}(decoder:PavifDecoder; frameIndex:UInt32;outExtend:PavifExtent):avifResult;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+type
+    { --------------------------------------------------------------------------- }
+    { avifEncoder }
+      PavifEncoderData = ^avifEncoderData;
+      avifEncoderData = record
+          {undefined structure}
+        end;
+
+      PavifCodecSpecificOptions = ^avifCodecSpecificOptions;
+      avifCodecSpecificOptions = record
+          {undefined structure}
+        end;
+
+    { Notes: }
+    { * If avifEncoderWrite() returns AVIF_RESULT_OK, output must be freed with avifRWDataFree() }
+    { * If (maxThreads < 2), multithreading is disabled }
+    {   * NOTE: Please see the "Understanding maxThreads" comment block above }
+    { * Quality range: [AVIF_QUANTIZER_BEST_QUALITY - AVIF_QUANTIZER_WORST_QUALITY] }
+    { * To enable tiling, set tileRowsLog2 > 0 and/or tileColsLog2 > 0. }
+    {   Tiling values range [0-6], where the value indicates a request for 2^n tiles in that dimension. }
+    { * Speed range: [AVIF_SPEED_SLOWEST - AVIF_SPEED_FASTEST]. Slower should make for a better quality }
+    {   image in less bytes. AVIF_SPEED_DEFAULT means "Leave the AV1 codec to its default speed settings"./ }
+    {   If avifEncoder uses rav1e, the speed value is directly passed through (0-10). If libaom is used, }
+    {   a combination of settings are tweaked to simulate this speed range. }
+	
+      PavifEncoder = ^avifEncoder;
+      avifEncoder = record
+    { Defaults to AVIF_CODEC_CHOICE_AUTO: Preference determined by order in availableCodecs table (avif.c) }	  
+          codecChoice : avifCodecChoice;
+    { settings (see Notes above) }		  
+          maxThreads : longint;
+          minQuantizer : longint;
+          maxQuantizer : longint;
+          minQuantizerAlpha : longint;
+          maxQuantizerAlpha : longint;
+          tileRowsLog2 : longint;
+          tileColsLog2 : longint;
+          speed : longint;
+          keyframeInterval : longint;       { How many frames between automatic forced keyframes; 0 to disable (default). }
+          timescale : UInt64;      { timescale of the media (Hz) }
+    { stats from the most recent write }		  
+          ioStats : avifIOStats;
+    { Additional diagnostics (such as detailed error state) }		  
+          diag : avifDiagnostics;
+    { Internals used by the encoder }		  
+          data : PavifEncoderData;
+          csOptions : PavifCodecSpecificOptions;
+        end;
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifEncoderCreate{$IFDEF LD}: function{$ENDIF}:PavifEncoder;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifEncoderWrite{$IFDEF LD}: function{$ENDIF}(encoder:PavifEncoder;image:PavifImage;output:PavifRWData):avifResult;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}procedure{$ENDIF} avifEncoderDestroy{$IFDEF LD}: procedure{$ENDIF}(encoder:PavifEncoder);cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+type
+    { Force this frame to be a keyframe (sync frame). }
+    { Use this flag when encoding a single image. Signals "still_picture" to AV1 encoders, which }
+    { tweaks various compression rules. This is enabled automatically when using the }
+    { avifEncoderWrite() single-image encode path. }
+      PavifAddImageFlag = ^avifAddImageFlag;
+      avifAddImageFlag = (AVIF_ADD_IMAGE_FLAG_NONE := 0,AVIF_ADD_IMAGE_FLAG_FORCE_KEYFRAME := 1 shl 0,
+        AVIF_ADD_IMAGE_FLAG_SINGLE := 1 shl 1);
+
+      PavifAddImageFlags = ^avifAddImageFlags;
+      avifAddImageFlags = UInt32;
+{ Multi-function alternative to avifEncoderWrite() for image sequences. }
+{ }
+{ Usage / function call order is: }
+{ * avifEncoderCreate() }
+{ * Set encoder->timescale (Hz) correctly }
+{ * avifEncoderAddImage() ... [repeatedly; at least once] }
+{   OR }
+{ * avifEncoderAddImageGrid() [exactly once, AVIF_ADD_IMAGE_FLAG_SINGLE is assumed] }
+{ * avifEncoderFinish() }
+{ * avifEncoderDestroy() }
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifEncoderAddImage{$IFDEF LD}: function{$ENDIF}(encoder:PavifEncoder; image:PavifImage;durationInTimescales:UInt64;addImageFlags:avifAddImageFlags):avifResult;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifEncoderAddImageGrid{$IFDEF LD}: function{$ENDIF}(encoder:PavifEncoder;
+                                            gridCols:UInt32;
+                                            gridRows:UInt32;
+                                            cellImages:PPavifImage;
+                                            addImageFlags:avifAddImageFlags):avifResult;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifEncoderFinish{$IFDEF LD}: function{$ENDIF}(encoder:PavifEncoder; output:PavifRWData):avifResult;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+
+{ Codec-specific, optional "advanced" tuning settings, in the form of string key/value pairs. These }
+{ should be set as early as possible, preferably just after creating avifEncoder but before }
+{ performing any other actions. }
+{ key must be non-NULL, but passing a NULL value will delete that key, if it exists. }
+{ Setting an incorrect or unknown option for the current codec will cause errors of type }
+{ AVIF_RESULT_INVALID_CODEC_SPECIFIC_OPTION from avifEncoderWrite() or avifEncoderAddImage(). }
+{$IFDEF LD}var{$ELSE}procedure{$ENDIF} avifEncoderSetCodecSpecificOption{$IFDEF LD}: procedure{$ENDIF}(encoder:PavifEncoder;key:PAnsiChar;value:PAnsiChar);cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+
+{ Helpers }
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifImageUsesU16{$IFDEF LD}: function{$ENDIF}(image:PavifImage):avifBool;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+{ Returns AVIF_TRUE if input begins with a valid FileTypeBox (ftyp) that supports }
+{ either the brand 'avif' or 'avis' (or both), without performing any allocations. }
+{$IFDEF LD}var{$ELSE}function{$ENDIF} avifPeekCompatibleFileType{$IFDEF LD}: function{$ENDIF}(input:PavifROData):avifBool ;cdecl;{$IFNDEF LD}external LibAvifFilename;{$ENDIF}
+
+function LibAvifLoaded : boolean;
+Function LibAvifLoad(const libfilename:string = ''): boolean; // load the lib
+Procedure LibAvifUnload; // unload and frees the lib from memory : do not forget to call it before close application.
+
+implementation
+{$IFDEF LOAD_DYNAMICALLY}
+
+uses
+    SysUtils, DynLibs;
+var
+  LibAvifHandle: TLibHandle = dynlibs.NilHandle; // this will hold our handle for the lib; it functions nicely as a mutli-lib prevention unit as well...
+  LibAvifRefCount : LongWord = 0;  // Reference counter
+
+
+function LibAvifLoaded: boolean;
+begin
+ Result := (LibAvifHandle <> dynlibs.NilHandle);
+end;
+
+Function LibAvifLoad (const libfilename:string) :boolean;
+var
+  thelib: string;
+begin
+  Result := False;
+  if LibAvifHandle<>0 then
+  begin
+   Inc(LibAvifRefCount);
+   result:=true {is it already there ?}
+  end else
+  begin {go & load the library}
+    if Length(libfilename) = 0 then
+    begin
+      thelib := LibAvifFilename;
+      if thelib = '' then exit(false);
+      //thelib := ExtractFilePath(ParamStr(0)) + DirectorySeparator + thelib;
+    end
+    else
+      thelib := libfilename;
+    LibAvifHandle := DynLibs.SafeLoadLibrary(thelib); // obtain the handle we want
+    {$IFDEF WINDOWS}
+    // second try on Windows
+    if LibAvifHandle = DynLibs.NilHandle then
+    begin
+      thelib := ExtractFilePath(ParamStr(0)) + DirectorySeparator + LibAvifFilename;
+      LibAvifHandle := DynLibs.SafeLoadLibrary(thelib); // obtain the handle we want
+    end;
+    {$ENDIF}
+    if LibAvifHandle <> DynLibs.NilHandle then
+    begin {now we tie the functions to the VARs from above}
+      Pointer(avifAlloc):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifAlloc'));
+      Pointer(avifCleanApertureBoxConvertCropRect):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifCleanApertureBoxConvertCropRect'));
+      Pointer(avifCodecChoiceFromName):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifCodecChoiceFromName'));
+      Pointer(avifCodecName):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifCodecName'));
+      Pointer(avifCodecVersions):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifCodecVersions'));
+      Pointer(avifColorPrimariesFind):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifColorPrimariesFind'));
+      Pointer(avifColorPrimariesGetValues):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifColorPrimariesGetValues'));
+      Pointer(avifCropRectConvertCleanApertureBox):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifCropRectConvertCleanApertureBox'));
+      Pointer(avifDecoderCreate):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifDecoderCreate'));
+      Pointer(avifDecoderDestroy):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifDecoderDestroy'));
+      Pointer(avifDecoderIsKeyframe):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifDecoderIsKeyframe'));
+      Pointer(avifDecoderNearestKeyframe):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifDecoderNearestKeyframe'));
+      Pointer(avifDecoderNextImage):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifDecoderNextImage'));
+      Pointer(avifDecoderNthImage):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifDecoderNthImage'));
+      Pointer(avifDecoderNthImageMaxExtent):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifDecoderNthImageMaxExtent'));
+      Pointer(avifDecoderNthImageTiming):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifDecoderNthImageTiming'));
+      Pointer(avifDecoderParse):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifDecoderParse'));
+      Pointer(avifDecoderRead):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifDecoderRead'));
+      Pointer(avifDecoderReadFile):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifDecoderReadFile'));
+      Pointer(avifDecoderReadMemory):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifDecoderReadMemory'));
+      Pointer(avifDecoderReset):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifDecoderReset'));
+      Pointer(avifDecoderSetIO):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifDecoderSetIO'));
+      Pointer(avifDecoderSetIOFile):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifDecoderSetIOFile'));
+      Pointer(avifDecoderSetIOMemory):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifDecoderSetIOMemory'));
+      Pointer(avifDecoderSetSource):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifDecoderSetSource'));
+      Pointer(avifDiagnosticsClearError):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifDiagnosticsClearError'));
+      Pointer(avifEncoderAddImage):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifEncoderAddImage'));
+      Pointer(avifEncoderAddImageGrid):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifEncoderAddImageGrid'));
+      Pointer(avifEncoderCreate):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifEncoderCreate'));
+      Pointer(avifEncoderDestroy):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifEncoderDestroy'));
+      Pointer(avifEncoderFinish):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifEncoderFinish'));
+      Pointer(avifEncoderSetCodecSpecificOption):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifEncoderSetCodecSpecificOption'));
+      Pointer(avifEncoderWrite):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifEncoderWrite'));
+      Pointer(avifFree):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifFree'));
+      Pointer(avifFullToLimitedUV):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifFullToLimitedUV'));
+      Pointer(avifFullToLimitedY):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifFullToLimitedY'));
+      Pointer(avifGetPixelFormatInfo):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifGetPixelFormatInfo'));
+      Pointer(avifImageAllocatePlanes):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifImageAllocatePlanes'));
+      Pointer(avifImageCopy):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifImageCopy'));
+      Pointer(avifImageCreate):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifImageCreate'));
+      Pointer(avifImageCreateEmpty):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifImageCreateEmpty'));
+      Pointer(avifImageDestroy):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifImageDestroy'));
+      Pointer(avifImageFreePlanes):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifImageFreePlanes'));
+      Pointer(avifImageRGBToYUV):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifImageRGBToYUV'));
+      Pointer(avifImageSetMetadataExif):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifImageSetMetadataExif'));
+      Pointer(avifImageSetMetadataXMP):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifImageSetMetadataXMP'));
+      Pointer(avifImageSetProfileICC):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifImageSetProfileICC'));
+      Pointer(avifImageStealPlanes):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifImageStealPlanes'));
+      Pointer(avifImageUsesU16):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifImageUsesU16'));
+      Pointer(avifImageYUVToRGB):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifImageYUVToRGB'));
+      Pointer(avifIOCreateFileReader):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifIOCreateFileReader'));
+      Pointer(avifIOCreateMemoryReader):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifIOCreateMemoryReader'));
+      Pointer(avifIODestroy):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifIODestroy'));
+      Pointer(avifLibYUVVersion):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifLibYUVVersion'));
+      Pointer(avifLimitedToFullUV):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifLimitedToFullUV'));
+      Pointer(avifLimitedToFullY):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifLimitedToFullY'));
+      Pointer(avifPeekCompatibleFileType):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifPeekCompatibleFileType'));
+      Pointer(avifPixelFormatToString):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifPixelFormatToString'));
+      Pointer(avifProgressiveStateToString):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifProgressiveStateToString'));
+      Pointer(avifResultToString):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifResultToString'));
+      Pointer(avifRGBFormatChannelCount):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifRGBFormatChannelCount'));
+      Pointer(avifRGBFormatHasAlpha):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifRGBFormatHasAlpha'));
+      Pointer(avifRGBImageAllocatePixels):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifRGBImageAllocatePixels'));
+      Pointer(avifRGBImageFreePixels):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifRGBImageFreePixels'));
+      Pointer(avifRGBImagePixelSize):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifRGBImagePixelSize'));
+      Pointer(avifRGBImagePremultiplyAlpha):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifRGBImagePremultiplyAlpha'));
+      Pointer(avifRGBImageSetDefaults):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifRGBImageSetDefaults'));
+      Pointer(avifRGBImageUnpremultiplyAlpha):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifRGBImageUnpremultiplyAlpha'));
+      Pointer(avifRWDataFree):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifRWDataFree'));
+      Pointer(avifRWDataRealloc):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifRWDataRealloc'));
+      Pointer(avifRWDataSet):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifRWDataSet'));
+      Pointer(avifVersion):=DynLibs.GetProcedureAddress(LibAvifHandle,PAnsiChar('avifVersion'));
+    end;
+    Result := LibAvifLoaded;
+    LibAvifRefCount:=1;
+  end;
+end;
+
+Procedure LibAvifUnload;
+begin
+  // < Reference counting
+  if LibAvifRefCount > 0 then
+    dec(LibAvifRefCount);
+  if LibAvifRefCount > 0 then
+    exit;
+  // >
+  if LibAvifLoaded then
+  begin
+    DynLibs.UnloadLibrary(LibAvifHandle);
+    LibAvifHandle:=DynLibs.NilHandle;
+  end;
+end;
+{$ELSE}
+function LibAvifLoaded: boolean;
+begin
+  result:=true;
+end;
+function LibAvifLoad (const libfilename:string) :boolean;
+begin
+  //do nothing
+end;
+
+procedure LibAvifUnload;
+begin
+  //do nothing
+end;
+{$ENDIF}
+
+end.

--- a/bgrabitmap/linuxlib.pas
+++ b/bgrabitmap/linuxlib.pas
@@ -58,6 +58,18 @@ implementation
 
 uses process;
 
+function FindBinPath(AFilename: string): string;
+const
+  BinPaths: array[0..5] of string =
+  ('/usr/local/sbin','/usr/local/bin','/usr/sbin','/usr/bin','/sbin','/bin');
+var i: integer;
+begin
+  for i := 0 to high(BinPaths) do
+    If FileExists(BinPaths[i] + '/' + AFilename) then
+      exit(BinPaths[i] + '/' + AFilename);
+  exit(AFilename);
+end;
+
 function FindLinuxLibrary(ALinkerName: string; AMinimumVersion: integer): string;
 const
   OpenBracket = ' (';
@@ -71,7 +83,7 @@ var
 begin
   result := '';
   maxVersionInt := AMinimumVersion-1;
-  RunCommand('ldconfig', ['-p'], dataText, []);
+  RunCommand(FindBinPath('ldconfig'), ['-p'], dataText, []);
   dataList := TStringList.Create;
   dataList.Text := dataText;
   flagList := TStringList.Create;


### PR DESCRIPTION
Hi circular,

I have been working in adding avif image files support to BGRABITMAP.

Sadly I have messed things up a bit with git in my fork of the repository so the pull request includes unwanted changes.
I include a patch file with the corret changes and the latest version for windows of the binaries of the libraries in case you consider that it is interesting to incorporate the support for avif files to BGRABITMAP.

The patch uses a freepascal binding of libavif from https://github.com/AOMediaCodec/libavif,  

The windows prebuild binaries for dll are taken from MSYS2 project.

Greetings Domingo.

[BGRABITMAP_add_avif_support.diff.txt](https://github.com/bgrabitmap/bgrabitmap/files/7492464/BGRABITMAP_add_avif_support.diff.txt)
[libavifDlls_0_9_2.zip](https://github.com/bgrabitmap/bgrabitmap/files/7492465/libavifDlls_0_9_2.zip)

 