### PR TITLE
added BigTif (only from fpc 3.3.1), solved Read 16 bit data with predictor fails

### DIFF
--- a/bgrabitmap/bgrareadtiff.pas
+++ b/bgrabitmap/bgrareadtiff.pas
@@ -3163,8 +3163,8 @@ var
         ycbcr :=TYCbCr.New(ChannelValues[0]/$ffff, ChannelValues[1]/$ffff, ChannelValues[2]/$ffff);
 
         if IFD.YCbCr_LumaRed<>0
-        then FPColorValue :=ycbcr.ToLinearRGBA(IFD.YCbCr_LumaRed, IFD.YCbCr_LumaGreen, IFD.YCbCr_LumaBlue).ToExpandedPixel.ToFPColor(false)
-        else FPColorValue :=ycbcr.ToLinearRGBA(YCbCr_601).ToExpandedPixel.ToFPColor(false);
+        then FPColorValue :=ycbcr.ToStdRGBA(IFD.YCbCr_LumaRed, IFD.YCbCr_LumaGreen, IFD.YCbCr_LumaBlue).ToExpandedPixel.ToFPColor(false)
+        else FPColorValue :=ycbcr.ToStdRGBA(YCbCr_601).ToExpandedPixel.ToFPColor(false);
       end;
 
     else

--- a/bgrabitmap/bgrareadtiff.pas
+++ b/bgrabitmap/bgrareadtiff.pas
@@ -24,7 +24,6 @@
    Compression: FAX, Jpeg...
    Color format: YCbCr, ITU L*a*b*
    PlanarConfiguration: 2 (one chunk for each channel)
-   bigtiff 64bit offsets
    XMP tag 700
    ICC profile tag 34675
 
@@ -36,6 +35,9 @@
 {
   2023-06  - Massimo Magnano
            - added Resolution support
+       07  - added BigTif (only from fpc 3.3.1),
+             solved Read 16 bit data with predictor fails
+             conditional compilation for 3.3.1 (now the class is derived from TFPReaderTiff)
 }
 {*****************************************************************************}
 unit BGRAReadTiff;
@@ -48,9 +50,10 @@ interface
 
 uses
   Math, BGRAClasses, SysUtils, ctypes, zinflate, zbase, FPimage, FPTiffCmn,
-  BGRABitmapTypes;
+  BGRABitmapTypes {$IF FPC_FULLVERSION>=30301}, FPReadTiff{$ENDIF};
 
 type
+  {$IF FPC_FULLVERSION<30301}
   TBGRAReaderTiff = class;
 
   TTiffCreateCompatibleImgEvent = procedure(Sender: TBGRAReaderTiff;
@@ -151,9 +154,19 @@ function DecompressDeflate(Compressed: PByte; CompressedCount: LongWord;
 
 function TifResolutionUnitToResolutionUnit(ATifResolutionUnit: DWord): TResolutionUnit;
 function ResolutionUnitToTifResolutionUnit(AResolutionUnit: TResolutionUnit): DWord;
+{$ELSE}
+  { TBGRAReaderTiff }
+
+  TBGRAReaderTiff = class(TFPReaderTiff)
+  public
+     procedure LoadImageFromStream(IFD: TTiffIFD); override;
+  end;
+
+{$ENDIF}
 
 implementation
 
+{$IF FPC_FULLVERSION<30301}
 function CMYKToFPColor(C,M,Y,K: Word): TFPColor;
 var R, G, B : LongWord;
 begin
@@ -1724,7 +1737,9 @@ var
         for Channel := 0 to SampleCnt-1 do
         begin
           {$PUSH}{$Q-}
-          Inc(ChannelValues[Channel],Swap(Word(Run^)));
+          //Inc(ChannelValues[Channel],Swap(Word(Run^)));   original
+          LastChannelValues[Channel] := LastChannelValues[Channel]+Swap(Word(Run^));
+          ChannelValues[Channel] :=LastChannelValues[Channel];
           {$POP}
           inc(Run, 2);
         end;
@@ -1743,7 +1758,9 @@ var
         for Channel := 0 to SampleCnt-1 do
         begin
           {$PUSH}{$Q-}
-          Inc(ChannelValues[Channel],Word(Run^));
+          //Inc(ChannelValues[Channel],Word(Run^)); original
+          LastChannelValues[Channel] := (LastChannelValues[Channel]+Word(Run^));
+          ChannelValues[Channel] :=LastChannelValues[Channel];
           {$POP}
           inc(Run, 2);
         end;
@@ -1852,6 +1869,7 @@ var
   var PaletteIndex: LongWord;
     GrayValue: Word;
     lab: TLabA;
+    cmyk: TStdCMYK;
   begin
     if IFD.PhotoMetricInterpretation >= 8 then
     begin
@@ -1892,7 +1910,11 @@ var
     //4 Mask/holdout mask (obsolete by TIFF 6.0 specification)
 
     5: // CMYK plus optional alpha
-      FPColorValue:=CMYKToFPColor(ChannelValues[0],ChannelValues[1],ChannelValues[2],ChannelValues[3]);
+      begin
+        //FPColorValue:=CMYKToFPColor(ChannelValues[0],ChannelValues[1],ChannelValues[2],ChannelValues[3]); test the differences
+        cmyk :=TStdCMYK.New(ChannelValues[0]/$ffff, ChannelValues[1]/$ffff, ChannelValues[2]/$ffff, ChannelValues[3]/$ffff);
+        FPColorValue :=cmyk.ToExpandedPixel.ToFPColor(true); //MaxM: in Future we can use GammaCompression
+      end;
 
      //6: YCBCR: CCIR 601
     else
@@ -2903,6 +2925,720 @@ begin
   else Result :=1;
   end;
 end;
+
+{$ELSE}
+
+procedure TBGRAReaderTiff.LoadImageFromStream(IFD: TTiffIFD);
+var
+  SampleCnt: SizeUInt;
+  SampleBits: PWord;
+  ChannelValues, LastChannelValues: array of word;
+  All8Bit, All16Bit: boolean;
+
+  procedure CheckBitCount;
+  var
+    Channel: LongWord;
+  begin
+    All8Bit := true;
+    All16Bit := true;
+    for Channel := 0 to SampleCnt-1 do
+    begin
+      if SampleBits[Channel] <> 8 then All8Bit:= false;
+      if SampleBits[Channel] <> 16 then All16Bit:= false;
+    end;
+  end;
+
+var
+  PaletteCnt,PaletteStride: SizeUInt;
+  PaletteValues: PWord;
+
+  AlphaChannel: integer;
+  PremultipliedAlpha: boolean;
+
+  procedure InitColor;
+  var Channel: LongWord;
+  begin
+    SetLength(ChannelValues, SampleCnt);
+    SetLength(LastChannelValues, SampleCnt);
+    for Channel := 0 to SampleCnt-1 do
+      LastChannelValues[Channel] := 0;
+  end;
+
+  procedure ReadNext16BitData(var Run: Pointer);
+  var Channel: PtrUInt;
+  begin
+    if ReverseEndian then
+    begin
+      if IFD.Predictor=2 then
+      begin
+        for Channel := 0 to SampleCnt-1 do
+        begin
+          {$PUSH}{$Q-}
+          //Inc(ChannelValues[Channel],Swap(Word(Run^)));   original
+          LastChannelValues[Channel] := LastChannelValues[Channel]+Swap(Word(Run^));
+          ChannelValues[Channel] :=LastChannelValues[Channel];
+          {$POP}
+          inc(Run, 2);
+        end;
+      end else
+      begin
+        for Channel := 0 to SampleCnt-1 do
+        begin
+          ChannelValues[Channel] := Swap(Word(Run^));
+          inc(Run, 2);
+        end;
+      end;
+    end else
+    begin
+      if IFD.Predictor=2 then
+      begin
+        for Channel := 0 to SampleCnt-1 do
+        begin
+          {$PUSH}{$Q-}
+          //Inc(ChannelValues[Channel],Word(Run^)); original
+          LastChannelValues[Channel] := (LastChannelValues[Channel]+Word(Run^));
+          ChannelValues[Channel] :=LastChannelValues[Channel];
+          {$POP}
+          inc(Run, 2);
+        end;
+      end else
+      begin
+        for Channel := 0 to SampleCnt-1 do
+        begin
+          ChannelValues[Channel] := Word(Run^);
+          inc(Run, 2);
+        end;
+      end;
+    end;
+  end;
+
+  procedure ReadNext8BitData(var Run: Pointer);
+  var Channel: PtrUInt;
+  begin
+    if IFD.Predictor=2 then
+    begin
+      for Channel := 0 to SampleCnt-1 do
+      begin
+        {$PUSH}{$Q-}
+        LastChannelValues[Channel] := (LastChannelValues[Channel]+Byte(Run^)) and $ff;
+        ChannelValues[Channel] := LastChannelValues[Channel]+(LastChannelValues[Channel] shl 8);
+        {$POP}
+        inc(Run);
+      end;
+    end else
+    begin
+      for Channel := 0 to SampleCnt-1 do
+      begin
+        ChannelValues[Channel] := Byte(Run^)+(Byte(Run^) shl 8);
+        inc(Run);
+      end;
+    end;
+  end;
+
+  procedure ReadNextPixelData(var Run: Pointer; var BitPos: byte);
+  var Channel: LongWord;
+  begin
+    for Channel := 0 to SampleCnt-1 do
+      ReadImgValue(SampleBits[Channel], Run,BitPos,IFD.FillOrder,
+                   IFD.Predictor,LastChannelValues[Channel],
+                   ChannelValues[Channel]);
+  end;
+
+  procedure GetPixelAsLab(out lab: TLabA);
+  begin
+    lab.L := 0;
+    lab.a := 0;
+    lab.b := 0;
+    lab.alpha := 1;
+
+    case IFD.PhotoMetricInterpretation of
+    8: begin
+         case IFD.GrayBits of
+           8,16: lab.L := ChannelValues[0]*(100/65535);
+           0:begin
+               lab.L := ChannelValues[0]*(100/65535);
+               case IFD.RedBits of
+                 16: lab.a := SmallInt(ChannelValues[1])/256;
+                 8: lab.a := ShortInt(ChannelValues[1] shr 8);
+               end;
+               case IFD.BlueBits of
+                 16: lab.b := SmallInt(ChannelValues[2])/256;
+                 8: lab.b := ShortInt(ChannelValues[2] shr 8);
+               end;
+             end;
+         end;
+       end;
+    9: begin
+         case IFD.GrayBits of
+           16: lab.L := ChannelValues[0]*(100/65280);
+           8: lab.L := ChannelValues[0]*(100/65535);
+           0:begin
+               case IFD.GreenBits of
+                 16: lab.L := ChannelValues[0]*(100/65280);
+                 8: lab.L := ChannelValues[0]*(100/65535);
+               end;
+               case IFD.RedBits of
+                 16: lab.a := (ChannelValues[1]-32768)/256;
+                 8: lab.a := (ChannelValues[1] shr 8)-128;
+               end;
+               case IFD.BlueBits of
+                 16: lab.b := (ChannelValues[2]-32768)/256;
+                 8: lab.b := (ChannelValues[2] shr 8)-128;
+               end;
+             end;
+         end;
+       end;
+     //10: ITULAB: ITU L*a*b*
+     //32844: LOGL: CIE Log2(L)
+     //32845: LOGLUV: CIE Log2(L) (u',v')
+    else
+      TiffError('PhotometricInterpretation='+IntToStr(IFD.PhotoMetricInterpretation)+' not supported');
+    end;
+
+    if AlphaChannel >= 0 then
+      lab.alpha:= ChannelValues[AlphaChannel]/65535;
+  end;
+
+var
+  FPColorValue: TFPColor;
+
+  procedure GetPixelAsFPColor;
+  var PaletteIndex: LongWord;
+    GrayValue: Word;
+    lab: TLabA;
+    cmyk: TStdCMYK;
+  begin
+    if IFD.PhotoMetricInterpretation >= 8 then
+    begin
+      GetPixelAsLab(lab);
+      FPColorValue.FromLabA(lab);
+      exit;
+    end;
+
+    case IFD.PhotoMetricInterpretation of
+    0,1: // 0:bilevel grayscale 0 is white; 1:0 is black
+      begin
+        GrayValue := ChannelValues[0];
+        if IFD.PhotoMetricInterpretation=0 then
+          GrayValue:=$ffff-GrayValue;
+        FPColorValue.red  := GrayValue;
+        FPColorValue.green:= GrayValue;
+        FPColorValue.blue := GrayValue;
+        FPColorValue.alpha := alphaOpaque;
+      end;
+
+    2: // RGB(A)
+      begin
+        FPColorValue.red  := ChannelValues[0];
+        FPColorValue.green:= ChannelValues[1];
+        FPColorValue.blue := ChannelValues[2];
+        FPColorValue.alpha := alphaOpaque;
+      end;
+
+    3: //3 Palette/color map indexed
+      begin
+        PaletteIndex := ChannelValues[0] shr (16 - SampleBits[0]);
+        FPColorValue.red  := PaletteValues[PaletteIndex];
+        FPColorValue.green:= PaletteValues[PaletteIndex+PaletteStride];
+        FPColorValue.blue := PaletteValues[PaletteIndex+2*PaletteStride];
+        FPColorValue.alpha := alphaOpaque;
+      end;
+
+    //4 Mask/holdout mask (obsolete by TIFF 6.0 specification)
+
+    5: // CMYK plus optional alpha
+      begin
+        cmyk :=TStdCMYK.New(ChannelValues[0]/$ffff, ChannelValues[1]/$ffff, ChannelValues[2]/$ffff, ChannelValues[3]/$ffff);
+        FPColorValue :=cmyk.ToExpandedPixel.ToFPColor(true); //MaxM: in Future we can use GammaCompression
+      end;
+
+     //6: YCBCR: CCIR 601
+    else
+      TiffError('PhotometricInterpretation='+IntToStr(IFD.PhotoMetricInterpretation)+' not supported');
+    end;
+
+    if AlphaChannel >= 0 then
+    begin
+      FPColorValue.alpha:= ChannelValues[AlphaChannel];
+      if PremultipliedAlpha and (FPColorValue.alpha <> alphaOpaque) and (FPColorValue.alpha <> 0) then
+      begin
+        FPColorValue.red := (FPColorValue.red * alphaOpaque + FPColorValue.alpha div 2) div FPColorValue.alpha;
+        FPColorValue.green := (FPColorValue.green * alphaOpaque + FPColorValue.alpha div 2) div FPColorValue.alpha;
+        FPColorValue.blue := (FPColorValue.blue * alphaOpaque + FPColorValue.alpha div 2) div FPColorValue.alpha;
+      end;
+    end;
+  end;
+
+var
+  ChunkOffsets: Pointer;
+  ChunkByteCounts: PDWord;
+  Chunk: PByte;
+  ChunkCount: DWord;
+  ChunkIndex: DWord;
+  CurCount: SizeUInt;
+  CurOffset: SizeUInt;
+  CurByteCnt: PtrInt;
+  Run: PByte;
+  BitPos: Byte;
+  x, y, cx, cy, dx1,dy1, dx2,dy2, sx, sy: integer;
+  SampleBitsPerPixel: DWord;
+  CurFPImg: TFPCustomImage;
+  aContinue, ConvertFromLab: Boolean;
+  ExpectedChunkLength: PtrInt;
+  ChunkType: TTiffChunkType;
+  TilesAcross, TilesDown: DWord;
+  ChunkLeft, ChunkTop, ChunkWidth, ChunkHeight: DWord;
+  ChunkBytesPerLine: DWord;
+
+  LabArray: array of TLabA;
+  ConversionFromLab: TBridgedConversion;
+  DestStride: PtrInt;
+  PDest: PByte;
+  CurPixelValue: TBGRAPixel;
+
+  procedure ComputeDestStride;
+  begin
+    DestStride := dy1*TCustomUniversalBitmap(CurFPImg).RowSize;
+    if TCustomUniversalBitmap(CurFPImg).LineOrder = riloBottomToTop then
+      DestStride := -DestStride;
+    inc(DestStride, dx1*PtrInt(TCustomUniversalBitmap(CurFPImg).Colorspace.GetSize));
+  end;
+
+  procedure ReadResolutionValues;
+  begin
+    {$IF FPC_FULLVERSION<30301}
+    if (CurFPImg is TCustomUniversalBitmap) then
+    with TCustomUniversalBitmap(CurFPImg) do
+    {$ELSE}
+    with CurFPImg do
+    {$ENDIF}
+    begin
+        ResolutionUnit :=TifResolutionUnitToResolutionUnit(IFD.ResolutionUnit);
+        ResolutionX :=IFD.XResolution.Numerator/IFD.XResolution.Denominator;
+        ResolutionY :=IFD.YResolution.Numerator/IFD.YResolution.Denominator;
+     end;
+  end;
+
+begin
+  if (IFD.ImageWidth=0) or (IFD.ImageHeight=0) then
+    exit;
+
+  if IFD.PhotoMetricInterpretation=High(IFD.PhotoMetricInterpretation) then
+    TiffError('missing PhotometricInterpretation');
+  if IFD.BitsPerSample=0 then
+    TiffError('missing BitsPerSample');
+  if IFD.TileWidth>0 then begin
+    ChunkType:=tctTile;
+    if IFD.TileLength=0 then
+      TiffError('missing TileLength');
+    if IFD.TileOffsets=0 then
+      TiffError('missing TileOffsets');
+    if IFD.TileByteCounts=0 then
+      TiffError('missing TileByteCounts');
+  end else begin
+    ChunkType:=tctStrip;
+    if IFD.RowsPerStrip=0 then
+      TiffError('missing RowsPerStrip');
+    if IFD.StripOffsets=0 then
+      TiffError('missing StripOffsets');
+    if IFD.StripByteCounts=0 then
+      TiffError('missing StripByteCounts');
+  end;
+
+  if IFD.PlanarConfiguration > 1 then
+     TiffError('Planar configuration not handled');
+
+  {$ifdef FPC_Debug_Image}
+  if Debug then
+    writeln('TBGRAReaderTiff.LoadImageFromStream reading ...');
+  {$endif}
+
+  ChunkOffsets:=nil;
+  ChunkByteCounts:=nil;
+  Chunk:=nil;
+  SampleBits:=nil;
+  try
+    // read chunk starts and sizes
+    if ChunkType=tctTile then begin
+      TilesAcross:=(IFD.ImageWidth+IFD.TileWidth-1) div IFD.TileWidth;
+      TilesDown:=(IFD.ImageHeight+IFD.TileLength-1) div IFD.TileLength;
+      {$ifdef FPC_Debug_Image}
+      if Debug then
+        writeln('TBGRAReaderTiff.LoadImageFromStream TilesAcross=',TilesAcross,' TilesDown=',TilesDown);
+      {$endif}
+      ChunkCount := TilesAcross * TilesDown;
+      ReadShortOrLongValues(IFD.TileOffsets,ChunkOffsets,CurCount);
+      if CurCount<ChunkCount then
+        TiffError('number of TileCounts is wrong');
+      ReadShortOrLongValues(IFD.TileByteCounts,ChunkByteCounts,CurCount);
+      if CurCount<ChunkCount then
+        TiffError('number of TileByteCounts is wrong');
+    end else begin //strip
+      ChunkCount:=((IFD.ImageHeight-1) div IFD.RowsPerStrip)+1;
+      ReadShortOrLongValues(IFD.StripOffsets,ChunkOffsets,CurCount);
+      if CurCount<ChunkCount then
+        TiffError('number of StripOffsets is wrong');
+      ReadShortOrLongValues(IFD.StripByteCounts,ChunkByteCounts,CurCount);
+      if CurCount<ChunkCount then
+        TiffError('number of StripByteCounts is wrong');
+    end;
+
+    // read image sample structure
+    ReadImageSampleProperties(IFD, AlphaChannel, PremultipliedAlpha,
+      SampleCnt, SampleBits, SampleBitsPerPixel,
+      PaletteCnt, PaletteValues);
+
+    PaletteStride := PaletteCnt div 3;
+
+  (*  if BigTiff  //MaxM: WorkAround ReadNextXXBitData fail to get colors correctly
+    then begin
+           All8Bit:=False;
+           All16Bit:=False;
+         end
+    else*) CheckBitCount;
+
+    // create FPimage
+    DoCreateImage(IFD);
+    if IFD.Img=nil then
+    begin
+      IFD.Img := BGRABitmapFactory.Create;
+      IFD.FreeImg := true;
+    end;
+    CurFPImg:=IFD.Img;
+    if CurFPImg=nil then exit;
+
+    //Resolution
+    ReadResolutionValues;
+
+    SetFPImgExtras(CurFPImg, IFD);
+
+    case IFD.Orientation of
+    0,1..4: CurFPImg.SetSize(IFD.ImageWidth,IFD.ImageHeight);
+    5..8: CurFPImg.SetSize(IFD.ImageHeight,IFD.ImageWidth);
+    end;
+
+    {$ifdef FPC_Debug_Image}
+    if Debug then
+      writeln('TBGRAReaderTiff.LoadImageFromStream SampleBitsPerPixel=',SampleBitsPerPixel);
+    {$endif}
+
+    LabArray := nil;
+    if (IFD.PhotoMetricInterpretation >= 8) and
+       (CurFPImg is TCustomUniversalBitmap) then
+    begin
+      ConvertFromLab := true;
+      ConversionFromLab := TLabAColorspace.GetBridgedConversion(TCustomUniversalBitmap(CurFPImg).Colorspace)
+    end else
+      ConvertFromLab := false;
+
+    // read chunks
+    for ChunkIndex:=0 to ChunkCount-1 do begin
+      if BigTiff
+      then CurOffset:=PSizeUInt(ChunkOffsets)[ChunkIndex]
+      else CurOffset:=PDWord(ChunkOffsets)[ChunkIndex];
+
+      CurByteCnt:=ChunkByteCounts[ChunkIndex];
+
+      //writeln('TBGRAReaderTiff.LoadImageFromStream CurOffset=',CurOffset,' CurByteCnt=',CurByteCnt);
+      if CurByteCnt<=0 then continue;
+      ReAllocMem(Chunk,CurByteCnt);
+      SetStreamPos(CurOffset);
+      ReadBuffer(Chunk^,CurByteCnt);
+
+      // decompress
+      if ChunkType=tctTile then
+        ExpectedChunkLength:=(SampleBitsPerPixel*IFD.TileWidth+7) div 8*IFD.TileLength
+      else
+        ExpectedChunkLength:=((SampleBitsPerPixel*IFD.ImageWidth+7) div 8)*IFD.RowsPerStrip;
+      case IFD.Compression of
+      TiffCompressionNone: ;
+      TiffCompressionPackBits: DecodePackBits(Chunk,CurByteCnt);
+      TiffCompressionLZW: DecodeLZW(Chunk,CurByteCnt);
+      TiffCompressionDeflateAdobe,
+      TiffCompressionDeflateZLib: DecodeDeflate(Chunk,CurByteCnt,ExpectedChunkLength);
+      else
+        TiffError('compression '+TiffCompressionName(IFD.Compression)+' not supported yet');
+      end;
+      if CurByteCnt<=0 then continue;
+
+      // compute current chunk area
+      if ChunkType=tctTile then begin
+        ChunkLeft:=(ChunkIndex mod TilesAcross)*IFD.TileWidth;
+        ChunkTop:=(ChunkIndex div TilesAcross)*IFD.TileLength;
+        ChunkWidth:=Min(IFD.TileWidth,IFD.ImageWidth-ChunkLeft);
+        ChunkHeight:=Min(IFD.TileLength,IFD.ImageHeight-ChunkTop);
+        ChunkBytesPerLine:=(SampleBitsPerPixel*ChunkWidth+7) div 8;
+        ExpectedChunkLength:=ChunkBytesPerLine*ChunkHeight;
+        if CurByteCnt<ExpectedChunkLength then begin
+          //writeln('TBGRAReaderTiff.LoadImageFromStream SampleBitsPerPixel=',SampleBitsPerPixel,' IFD.ImageWidth=',IFD.ImageWidth,' IFD.ImageHeight=',IFD.ImageHeight,' y=',y,' IFD.TileWidth=',IFD.TileWidth,' IFD.TileLength=',IFD.TileLength,' ExpectedChunkLength=',ExpectedChunkLength,' CurByteCnt=',CurByteCnt);
+          TiffError('TBGRAReaderTiff.LoadImageFromStream Tile too short ByteCnt='+IntToStr(CurByteCnt)+' ChunkWidth='+IntToStr(ChunkWidth)+' ChunkHeight='+IntToStr(ChunkHeight)+' expected='+IntToStr(ExpectedChunkLength));
+        end else if CurByteCnt>ExpectedChunkLength then begin
+          // boundary tiles have padding
+          ChunkBytesPerLine:=(SampleBitsPerPixel*IFD.TileWidth+7) div 8;
+        end;
+      end else begin //tctStrip
+        ChunkLeft:=0;
+        ChunkTop:=IFD.RowsPerStrip*ChunkIndex;
+        ChunkWidth:=IFD.ImageWidth;
+        ChunkHeight:=Min(IFD.RowsPerStrip,IFD.ImageHeight-ChunkTop);
+        ChunkBytesPerLine:=(SampleBitsPerPixel*ChunkWidth+7) div 8;
+        ExpectedChunkLength:=ChunkBytesPerLine*ChunkHeight;
+        //writeln('TBGRAReaderTiff.LoadImageFromStream SampleBitsPerPixel=',SampleBitsPerPixel,' IFD.ImageWidth=',IFD.ImageWidth,' IFD.ImageHeight=',IFD.ImageHeight,' y=',y,' IFD.RowsPerStrip=',IFD.RowsPerStrip,' ExpectedChunkLength=',ExpectedChunkLength,' CurByteCnt=',CurByteCnt);
+        if CurByteCnt<ExpectedChunkLength then
+          TiffError('TBGRAReaderTiff.LoadImageFromStream Strip too short ByteCnt='+IntToStr(CurByteCnt)+' ChunkWidth='+IntToStr(ChunkWidth)+' ChunkHeight='+IntToStr(ChunkHeight)+' expected='+IntToStr(ExpectedChunkLength));
+      end;
+
+      // progress
+      aContinue:=true;
+      Progress(psRunning, 0, false, Rect(0,0,IFD.ImageWidth,ChunkTop), '', aContinue);
+      if not aContinue then break;
+
+      // Orientation
+      if IFD.Orientation in [1..4] then begin
+        sx:=ChunkLeft; sy:=ChunkTop;
+        dy1 := 0; dx2 := 0;
+        case IFD.Orientation of
+        1: begin dx1:=1; dy2:=1; end;// 0,0 is left, top
+        2: begin sx:=IFD.ImageWidth-sx-1; dx1:=-1; dy2:=1; end;// 0,0 is right, top
+        3: begin sx:=IFD.ImageWidth-sx-1; dx1:=-1; sy:=IFD.ImageHeight-sy-1; dy2:=-1; end;// 0,0 is right, bottom
+        4: begin dx1:=1; sy:=IFD.ImageHeight-sy-1; dy2:=-1; end;// 0,0 is left, bottom
+        end;
+      end else begin
+        // rotated
+        sx:=ChunkTop; sy:=ChunkLeft;
+        dx1 := 0; dy2 := 0;
+        case IFD.Orientation of
+        5: begin dy1:=1; dx2:=1; end;// 0,0 is top, left (rotated)
+        6: begin dy1:=1; sx:=IFD.ImageWidth-sx-1; dx2:=-1; end;// 0,0 is top, right (rotated)
+        7: begin sy:=IFD.ImageHeight-sy-1; dy1:=-1; sx:=IFD.ImageHeight-sx-1; dx2:=-1; end;// 0,0 is bottom, right (rotated)
+        8: begin sy:=IFD.ImageHeight-sy-1; dy1:=-1; dx2:=1; end;// 0,0 is bottom, left (rotated)
+        end;
+      end;
+
+      //writeln('TBGRAReaderTiff.LoadImageFromStream Chunk ',ChunkIndex,' ChunkLeft=',ChunkLeft,' ChunkTop=',ChunkTop,' IFD.ImageWidth=',IFD.ImageWidth,' IFD.ImageHeight=',IFD.ImageHeight,' ChunkWidth=',ChunkWidth,' ChunkHeight=',ChunkHeight,' PaddingRight=',PaddingRight);
+      for cy:=0 to ChunkHeight-1 do begin
+        Run:=Chunk+ChunkBytesPerLine*cy;
+        BitPos := 0;
+        InitColor;
+        //writeln('TBGRAReaderTiff.LoadImageFromStream (x,y)=(',sx,',',sy,')');
+
+        if ConvertFromLab then
+        begin
+          if length(LabArray)<ChunkWidth then setlength(LabArray, ChunkWidth);
+
+          if All16Bit then
+          begin
+            for cx:=0 to ChunkWidth-1 do begin
+              ReadNext16BitData(Run);
+              GetPixelAsLab(LabArray[cx]);
+            end;
+          end else
+          if All8Bit then
+          begin
+            for cx:=0 to ChunkWidth-1 do begin
+              ReadNext8BitData(Run);
+              GetPixelAsLab(LabArray[cx]);
+            end;
+          end else
+          begin
+            for cx:=0 to ChunkWidth-1 do begin
+              ReadNextPixelData(Run,BitPos);
+              GetPixelAsLab(LabArray[cx]);
+            end;
+          end;
+
+          ComputeDestStride;
+          ConversionFromLab.Convert(@LabArray[0], TCustomUniversalBitmap(CurFPImg).GetPixelAddress(sx,sy),
+                                    ChunkWidth, sizeof(TLabA), DestStride, nil);
+        end else
+        begin
+          x:= sx;
+          y:= sy;
+          if All16Bit then
+          begin
+            if (CurFPImg is TBGRACustomBitmap) and (IFD.Predictor <> 2) then
+            begin
+              ComputeDestStride;
+              PDest := TBGRACustomBitmap(CurFPImg).GetPixelAddress(sx,sy);
+              if (IFD.PhotoMetricInterpretation = 0) and (SampleCnt = 1) then
+              begin
+                for cx:=0 to ChunkWidth-1 do begin
+                  PBGRAPixel(PDest)^.red:= FastRoundDiv257(not (PWord(Run)^));
+                  PBGRAPixel(PDest)^.green:= PBGRAPixel(PDest)^.red;
+                  PBGRAPixel(PDest)^.blue:= PBGRAPixel(PDest)^.red;
+                  PBGRAPixel(PDest)^.alpha:= 255;
+                  inc(Run, 2);
+                  inc(PDest, DestStride);
+                end;
+              end else
+              if (IFD.PhotoMetricInterpretation = 1) and (SampleCnt = 1) then
+              begin
+                for cx:=0 to ChunkWidth-1 do begin
+                  PBGRAPixel(PDest)^.red:= FastRoundDiv257(PWord(Run)^);
+                  PBGRAPixel(PDest)^.green:= PBGRAPixel(PDest)^.red;
+                  PBGRAPixel(PDest)^.blue:= PBGRAPixel(PDest)^.red;
+                  PBGRAPixel(PDest)^.alpha:= 255;
+                  inc(Run, 2);
+                  inc(PDest, DestStride);
+                end;
+              end else
+              if (IFD.PhotoMetricInterpretation = 2) and (SampleCnt = 3) then
+              begin
+                for cx:=0 to ChunkWidth-1 do begin
+                  PBGRAPixel(PDest)^.red:= FastRoundDiv257(PWord(Run)^);
+                  PBGRAPixel(PDest)^.green:= FastRoundDiv257(PWord(Run+2)^);
+                  PBGRAPixel(PDest)^.blue:= FastRoundDiv257(PWord(Run+4)^);
+                  PBGRAPixel(PDest)^.alpha:= 255;
+                  inc(Run, 6);
+                  inc(PDest, DestStride);
+                end;
+              end else
+              for cx:=0 to ChunkWidth-1 do begin
+                 ReadNext16BitData(Run);
+                 GetPixelAsFPColor;
+                 PBGRAPixel(PDest)^.red:= FastRoundDiv257(FPColorValue.red);
+                 PBGRAPixel(PDest)^.green:= FastRoundDiv257(FPColorValue.green);
+                 PBGRAPixel(PDest)^.blue:= FastRoundDiv257(FPColorValue.blue);
+                 PBGRAPixel(PDest)^.alpha:= FastRoundDiv257(FPColorValue.alpha);
+                 inc(PDest, DestStride);
+               end;
+            end else
+              for cx:=0 to ChunkWidth-1 do begin
+                ReadNext16BitData(Run);
+                GetPixelAsFPColor;
+                CurFPImg.Colors[x,y]:= FPColorValue;
+                // next column
+                inc(x,dx1);
+                inc(y,dy1);
+              end;
+          end else
+          if All8Bit then
+          begin
+            if CurFPImg is TBGRACustomBitmap then
+            begin
+              ComputeDestStride;
+              PDest := TBGRACustomBitmap(CurFPImg).GetPixelAddress(sx,sy);
+              if (IFD.PhotoMetricInterpretation = 0) and (SampleCnt = 1) then
+              begin
+                if IFD.Predictor = 2 then
+                begin
+                  CurPixelValue := BGRAPixelTransparent;
+                  for cx:=0 to ChunkWidth-1 do begin
+                    {$PUSH}{$R-}inc(CurPixelValue.green, run^);{$POP}
+                    PBGRAPixel(PDest)^.red:= not CurPixelValue.green;
+                    PBGRAPixel(PDest)^.green:= not CurPixelValue.green;
+                    PBGRAPixel(PDest)^.blue:= not CurPixelValue.green;
+                    PBGRAPixel(PDest)^.alpha:= 255;
+                    inc(Run);
+                    inc(PDest, DestStride);
+                  end;
+                end else
+                for cx:=0 to ChunkWidth-1 do begin
+                  PBGRAPixel(PDest)^.red:= not (Run^);
+                  PBGRAPixel(PDest)^.green:= not (Run^);
+                  PBGRAPixel(PDest)^.blue:= not (Run^);
+                  PBGRAPixel(PDest)^.alpha:= 255;
+                  inc(Run);
+                  inc(PDest, DestStride);
+                end;
+              end else
+              if (IFD.PhotoMetricInterpretation = 1) and (SampleCnt = 1) then
+              begin
+                if IFD.Predictor = 2 then
+                begin
+                  CurPixelValue := BGRAPixelTransparent;
+                  for cx:=0 to ChunkWidth-1 do begin
+                    {$PUSH}{$R-}inc(CurPixelValue.green, run^);{$POP}
+                    PBGRAPixel(PDest)^.red:= CurPixelValue.green;
+                    PBGRAPixel(PDest)^.green:= CurPixelValue.green;
+                    PBGRAPixel(PDest)^.blue:= CurPixelValue.green;
+                    PBGRAPixel(PDest)^.alpha:= 255;
+                    inc(Run);
+                    inc(PDest, DestStride);
+                  end;
+                end else
+                for cx:=0 to ChunkWidth-1 do begin
+                  PBGRAPixel(PDest)^.red:= Run^;
+                  PBGRAPixel(PDest)^.green:= Run^;
+                  PBGRAPixel(PDest)^.blue:= Run^;
+                  PBGRAPixel(PDest)^.alpha:= 255;
+                  inc(Run);
+                  inc(PDest, DestStride);
+                end;
+              end else
+              if (IFD.PhotoMetricInterpretation = 2) and (SampleCnt = 3) then
+              begin
+                if IFD.Predictor = 2 then
+                begin
+                  CurPixelValue := BGRAPixelTransparent;
+                  for cx:=0 to ChunkWidth-1 do begin
+                    {$PUSH}{$R-}inc(CurPixelValue.red, run^);{$POP}
+                    {$PUSH}{$R-}inc(CurPixelValue.green, (run+1)^);{$POP}
+                    {$PUSH}{$R-}inc(CurPixelValue.blue, (run+2)^);{$POP}
+                    PBGRAPixel(PDest)^.red:= CurPixelValue.red;
+                    PBGRAPixel(PDest)^.green:= CurPixelValue.green;
+                    PBGRAPixel(PDest)^.blue:= CurPixelValue.blue;
+                    PBGRAPixel(PDest)^.alpha:= 255;
+                    inc(Run,3);
+                    inc(PDest, DestStride);
+                  end;
+                end else
+                for cx:=0 to ChunkWidth-1 do begin
+                  PBGRAPixel(PDest)^.red:= Run^;
+                  PBGRAPixel(PDest)^.green:= (Run+1)^;
+                  PBGRAPixel(PDest)^.blue:= (Run+2)^;
+                  PBGRAPixel(PDest)^.alpha:= 255;
+                  inc(Run,3);
+                  inc(PDest, DestStride);
+                end;
+              end else
+              for cx:=0 to ChunkWidth-1 do begin
+                 ReadNext8BitData(Run);
+                 GetPixelAsFPColor;
+                 PBGRAPixel(PDest)^.red:= FPColorValue.red shr 8;
+                 PBGRAPixel(PDest)^.green:= FPColorValue.green shr 8;
+                 PBGRAPixel(PDest)^.blue:= FPColorValue.blue shr 8;
+                 PBGRAPixel(PDest)^.alpha:= FPColorValue.alpha shr 8;
+                 inc(PDest, DestStride);
+               end;
+            end else
+              for cx:=0 to ChunkWidth-1 do begin
+                ReadNext8BitData(Run);
+                GetPixelAsFPColor;
+                CurFPImg.Colors[x,y]:= FPColorValue;
+                // next column
+                inc(x,dx1);
+                inc(y,dy1);
+              end;
+          end else
+          begin
+            for cx:=0 to ChunkWidth-1 do begin
+              ReadNextPixelData(Run,BitPos);
+              GetPixelAsFPColor;
+              CurFPImg.Colors[x,y]:= FPColorValue;
+              // next column
+              inc(x,dx1);
+              inc(y,dy1);
+            end;
+          end;
+        end;
+
+        // next line
+        inc(sx,dx2);
+        inc(sy,dy2);
+      end;
+      // next chunk
+    end;
+  finally
+    ReAllocMem(SampleBits,0);
+    ReAllocMem(ChunkOffsets,0);
+    ReAllocMem(ChunkByteCounts,0);
+    ReAllocMem(Chunk,0);
+    ReAllocMem(PaletteValues,0);
+  end;
+end;
+
+{$ENDIF}
 
 initialization
   DefaultBGRAImageReader[ifTiff] := TBGRAReaderTiff;

--- a/bgrabitmap/bgrareadtiff.pas
+++ b/bgrabitmap/bgrareadtiff.pas
@@ -50,7 +50,7 @@ interface
 
 uses
   Math, BGRAClasses, SysUtils, ctypes, zinflate, zbase, FPimage, FPTiffCmn,
-  BGRABitmapTypes {$IF FPC_FULLVERSION>=30301}, FPColorSpace, FPReadTiff{$ENDIF};
+  BGRABitmapTypes {$IF FPC_FULLVERSION>=30301}, FPReadTiff{$ENDIF};
 
 type
   {$IF FPC_FULLVERSION<30301}

--- a/bgrabitmap/extendedcolorspace.inc
+++ b/bgrabitmap/extendedcolorspace.inc
@@ -10,6 +10,12 @@ type
     W,Y: Single;
   end;
 
+  TYCbCrSTD = (YCbCr_601, YCbCr_709, YCbCr_2020, YCbCr_JPG);
+  TYCbCrSTD_Factor= packed record
+    a, b, c, d, e :single;
+  end;
+
+
 {$I spectraldata.inc}
 
 type

--- a/bgrabitmap/generatedcolorspace.inc
+++ b/bgrabitmap/generatedcolorspace.inc
@@ -557,6 +557,9 @@ type
     function ToWordXYZA(const AReferenceWhite: TXYZReferenceWhite): TWordXYZA;overload;
     function ToLabA: TLabA;
     function ToLChA: TLChA;
+    {** SamplePrecision = 2^(YCbCrSamplePrecision-1) }
+    function ToYCbCr(const AStd:TYCbCrSTD=YCbCr_JPG; ASamplePrecision:Single=0.5): TYCbCr; overload;
+    function ToYCbCr(LumaRed:Single=0.299; LumaGreen:Single=0.587; LumaBlue:Single=0.114): TYCbCr; overload;
     procedure FromColor(AValue: TColor);
     procedure FromBGRAPixel(AValue: TBGRAPixel);
     procedure FromFPColor(AValue: TFPColor);
@@ -871,9 +874,6 @@ type
     function ToWordXYZA(const AReferenceWhite: TXYZReferenceWhite): TWordXYZA;overload;
     function ToLabA: TLabA;
     function ToLChA: TLChA;
-    {** SamplePrecision = 2^(YCbCrSamplePrecision-1) }
-    function ToYCbCr(const AStd:TYCbCrSTD=YCbCr_JPG; ASamplePrecision:Single=0.5): TYCbCr; overload;
-    function ToYCbCr(LumaRed:Single=0.299; LumaGreen:Single=0.587; LumaBlue:Single=0.114): TYCbCr; overload;
     procedure FromColor(AValue: TColor);
     procedure FromBGRAPixel(AValue: TBGRAPixel);
     procedure FromFPColor(AValue: TFPColor);
@@ -1188,8 +1188,8 @@ type
 
   TYCbCrHelper = record helper for TYCbCr
     {** SamplePrecision = 2^(YCbCrSamplePrecision-1) }
-    function ToLinearRGBA(const AStd:TYCbCrSTD=YCbCr_JPG; ASamplePrecision:Single=0.5): TLinearRGBA; overload;
-    function ToLinearRGBA(LumaRed:Single=0.299; LumaGreen:Single=0.587; LumaBlue:Single=0.114): TLinearRGBA; overload;
+    function ToStdRGBA(const AStd:TYCbCrSTD=YCbCr_601; ASamplePrecision:Single=0.5): TStdRGBA; overload;
+    function ToStdRGBA(LumaRed:Single=0.299; LumaGreen:Single=0.587; LumaBlue:Single=0.114): TStdRGBA; overload;
   end;
 
 
@@ -4496,6 +4496,26 @@ begin Result := ExpandedPixelToLabA(StdRGBAToExpandedPixel(Self)) end;
 function TStdRGBAHelper.ToLChA: TLChA;
 begin Result := ExpandedPixelToLChA(StdRGBAToExpandedPixel(Self)) end;
 
+function TStdRGBAHelper.ToYCbCr(const AStd: TYCbCrSTD; ASamplePrecision: Single): TYCbCr;
+begin
+  with self, YCbCrSTD_Factors[AStd]  do
+  begin
+    result.Y := a * red + b * green + c * blue;
+    result.Cb := ((blue - result.Y) / d)+ASamplePrecision;
+    result.Cr := ((red - result.Y) / e)+ASamplePrecision;
+  end;
+end;
+
+function TStdRGBAHelper.ToYCbCr(LumaRed: Single; LumaGreen: Single; LumaBlue: Single): TYCbCr;
+begin
+  with self  do
+  begin
+    result.Y :=  ( LumaRed * red + LumaGreen * green + LumaBlue * blue );
+    result.Cb := ( blue - result.Y ) / ( 2 - 2 * LumaBlue );
+    result.Cr := ( red - result.Y ) / ( 2 - 2 * LumaRed );
+  end;
+end;
+
 procedure TStdRGBAHelper.FromColor(AValue: TColor);
 begin Self := ColorToStdRGBA(AValue) end;
 
@@ -5408,26 +5428,6 @@ begin Result := LinearRGBAToLabA(Self) end;
 function TLinearRGBAHelper.ToLChA: TLChA;
 begin Result := LinearRGBAToLChA(Self) end;
 
-function TLinearRGBAHelper.ToYCbCr(const AStd: TYCbCrSTD; ASamplePrecision: Single): TYCbCr;
-begin
-  with self, YCbCrSTD_Factors[AStd]  do
-  begin
-    result.Y := a * red + b * green + c * blue;
-    result.Cb := ((blue - result.Y) / d)+ASamplePrecision;
-    result.Cr := ((red - result.Y) / e)+ASamplePrecision;
-  end;
-end;
-
-function TLinearRGBAHelper.ToYCbCr(LumaRed: Single; LumaGreen: Single; LumaBlue: Single): TYCbCr;
-begin
-  with self  do
-  begin
-    result.Y :=  ( LumaRed * red + LumaGreen * green + LumaBlue * blue );
-    result.Cb := ( blue - result.Y ) / ( 2 - 2 * LumaBlue );
-    result.Cr := ( red - result.Y ) / ( 2 - 2 * LumaRed );
-  end;
-end;
-
 procedure TLinearRGBAHelper.FromColor(AValue: TColor);
 begin Self := ExpandedPixelToLinearRGBA(ColorToExpandedPixel(AValue)) end;
 
@@ -6296,7 +6296,7 @@ begin Self := LabAToLChA(AValue) end;
 
 { TYCbCrHelper }
 
-function TYCbCrHelper.ToLinearRGBA(const AStd: TYCbCrSTD; ASamplePrecision: Single): TLinearRGBA;
+function TYCbCrHelper.ToStdRGBA(const AStd: TYCbCrSTD; ASamplePrecision: Single): TStdRGBA;
 begin
   with self, YCbCrSTD_Factors[AStd]  do
   begin
@@ -6306,7 +6306,7 @@ begin
   end;
 end;
 
-function TYCbCrHelper.ToLinearRGBA(LumaRed: Single; LumaGreen: Single; LumaBlue: Single): TLinearRGBA;
+function TYCbCrHelper.ToStdRGBA(LumaRed: Single; LumaGreen: Single; LumaBlue: Single): TStdRGBA;
 begin
   with self  do
   begin

--- a/bgrabitmap/generatedcolorspace.inc
+++ b/bgrabitmap/generatedcolorspace.inc
@@ -101,6 +101,15 @@ type
     class function New(const ALightness,AChroma,AHue:single): TLChA;overload;static;
   end;
 
+  { TYCbCr }
+
+  PYCbCr = ^TYCbCr;
+  TYCbCr = packed record
+    Y,Cb,Cr: single;
+    class function New(const AY, ACb, ACr:single): TYCbCr; static;
+  end;
+
+
   { TColorColorspace }
 
   TColorColorspace = class(TCustomColorspace)
@@ -862,6 +871,9 @@ type
     function ToWordXYZA(const AReferenceWhite: TXYZReferenceWhite): TWordXYZA;overload;
     function ToLabA: TLabA;
     function ToLChA: TLChA;
+    {** SamplePrecision = 2^(YCbCrSamplePrecision-1) }
+    function ToYCbCr(const AStd:TYCbCrSTD=YCbCr_JPG; ASamplePrecision:Single=0.5): TYCbCr; overload;
+    function ToYCbCr(LumaRed:Single=0.299; LumaGreen:Single=0.587; LumaBlue:Single=0.114): TYCbCr; overload;
     procedure FromColor(AValue: TColor);
     procedure FromBGRAPixel(AValue: TBGRAPixel);
     procedure FromFPColor(AValue: TFPColor);
@@ -1171,6 +1183,15 @@ type
     procedure FromWordXYZA(AValue: TWordXYZA; const AReferenceWhite: TXYZReferenceWhite); overload;
     procedure FromLabA(AValue: TLabA);
   end;
+
+  { TYCbCrHelper }
+
+  TYCbCrHelper = record helper for TYCbCr
+    {** SamplePrecision = 2^(YCbCrSamplePrecision-1) }
+    function ToLinearRGBA(const AStd:TYCbCrSTD=YCbCr_JPG; ASamplePrecision:Single=0.5): TLinearRGBA; overload;
+    function ToLinearRGBA(LumaRed:Single=0.299; LumaGreen:Single=0.587; LumaBlue:Single=0.114): TLinearRGBA; overload;
+  end;
+
 
 operator := (const AValue: TColor): TStdRGBA;
 operator := (const AValue: TColor): TAdobeRGBA;
@@ -2626,6 +2647,15 @@ begin
   Result.C := AChroma;
   Result.h := AHue;
   Result.alpha := 1;
+end;
+
+{ TYCbCr }
+
+class function TYCbCr.New(const AY, ACb, ACr: single): TYCbCr;
+begin
+  Result.Y := AY;
+  Result.Cb := ACb;
+  Result.Cr := ACr;
 end;
 
 { TColorColorspace }
@@ -5378,6 +5408,26 @@ begin Result := LinearRGBAToLabA(Self) end;
 function TLinearRGBAHelper.ToLChA: TLChA;
 begin Result := LinearRGBAToLChA(Self) end;
 
+function TLinearRGBAHelper.ToYCbCr(const AStd: TYCbCrSTD; ASamplePrecision: Single): TYCbCr;
+begin
+  with self, YCbCrSTD_Factors[AStd]  do
+  begin
+    result.Y := a * red + b * green + c * blue;
+    result.Cb := ((blue - result.Y) / d)+ASamplePrecision;
+    result.Cr := ((red - result.Y) / e)+ASamplePrecision;
+  end;
+end;
+
+function TLinearRGBAHelper.ToYCbCr(LumaRed: Single; LumaGreen: Single; LumaBlue: Single): TYCbCr;
+begin
+  with self  do
+  begin
+    result.Y :=  ( LumaRed * red + LumaGreen * green + LumaBlue * blue );
+    result.Cb := ( blue - result.Y ) / ( 2 - 2 * LumaBlue );
+    result.Cr := ( red - result.Y ) / ( 2 - 2 * LumaRed );
+  end;
+end;
+
 procedure TLinearRGBAHelper.FromColor(AValue: TColor);
 begin Self := ExpandedPixelToLinearRGBA(ColorToExpandedPixel(AValue)) end;
 
@@ -6243,6 +6293,28 @@ begin Self := WordXYZAToLChA(AValue,AReferenceWhite) end;
 
 procedure TLChAHelper.FromLabA(AValue: TLabA);
 begin Self := LabAToLChA(AValue) end;
+
+{ TYCbCrHelper }
+
+function TYCbCrHelper.ToLinearRGBA(const AStd: TYCbCrSTD; ASamplePrecision: Single): TLinearRGBA;
+begin
+  with self, YCbCrSTD_Factors[AStd]  do
+  begin
+    result.red := Y + e * (Cr-ASamplePrecision);
+    result.green := Y - (a * e / b) * (Cr-ASamplePrecision) - (c * d / b) * (Cb-ASamplePrecision);
+    result.blue := Y + d * (Cb-ASamplePrecision);
+  end;
+end;
+
+function TYCbCrHelper.ToLinearRGBA(LumaRed: Single; LumaGreen: Single; LumaBlue: Single): TLinearRGBA;
+begin
+  with self  do
+  begin
+    result.red := Cr * ( 2 - 2 * LumaRed ) + Y;
+    result.blue := Cb * ( 2 - 2 * LumaBlue ) + Y;
+    result.green :=  ( Y - LumaBlue * result.blue - LumaRed * result.red ) / LumaGreen;
+  end;
+end;
 
 {Operators}
 

--- a/bgrabitmap/spectraldata.inc
+++ b/bgrabitmap/spectraldata.inc
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-linking-exception
-const //horseshoe shape of visible colors at 2° (illuminant E)
+const
+  //horseshoe shape of visible colors at 2° (illuminant E)
   SpectralLocus: array[0..94] of TSpectralLocusPoint =
  ((W:360; X:0.0001299; Y:0.000003917; Z:0.0006061),
   (W:365; X:0.0002321; Y:0.000006965; Z:0.001086),
@@ -97,7 +98,7 @@ const //horseshoe shape of visible colors at 2° (illuminant E)
   (W:825; X:1.776509E-06; Y:6.4153E-07; Z:0),
   (W:830; X:1.251141E-06; Y:4.5181E-07; Z:0));
 
-const //D65 illuminant
+  //D65 illuminant
   IlluminantSpectrumD65: array[0..94] of TIlluminantSpectrumPoint =
  ((W:360; Y:46.6383),
   (W:365; Y:49.3637),
@@ -194,4 +195,12 @@ const //D65 illuminant
   (W:820; Y:57.4406),
   (W:825; Y:58.8765),
   (W:830; Y:60.3125));
+
+  //YcbCr to From RGB Factors
+  YCbCrSTD_Factors : array [TYCbCrSTD] of TYCbCrSTD_Factor = (
+  (a:0.299; b:0.587; c:0.114; d:1.772; e:1.402),        //BT.601
+  (a:0.2126; b:0.7152; c:0.0722; d:1.8556; e:1.5748),   //BT.709
+  (a:0.2627; b:0.6780; c:0.0593; d:1.8814; e:1.4746),   //BT.2020
+  (a:0.299; b:0.587; c:0.114; d:1.772; e:1.402)         //JPG Same Factor of 601?
+  );
 


### PR DESCRIPTION
added BigTif (only from fpc 3.3.1),
solved Read 16 bit data with predictor fails,
conditional compilation for 3.3.1 (now the class is derived from TFPReaderTiff)
Added YCbCr colorspace support
