### PR TITLE
BigTif ;  Read 16 bit predictor fails; YCbCr601ToStdRGBA user Params

### DIFF
--- a/bgrabitmap/bgradefaultbitmap.pas
+++ b/bgrabitmap/bgradefaultbitmap.pas
@@ -1162,6 +1162,12 @@ begin
   begin
     DiscardBitmapChange;
     SetSize(TBGRACustomBitmap(Source).Width, TBGRACustomBitmap(Source).Height);
+
+    //Resolution
+    ResolutionUnit:=TBGRACustomBitmap(Source).ResolutionUnit;
+    ResolutionX:=TBGRACustomBitmap(Source).ResolutionX;
+    ResolutionY:=TBGRACustomBitmap(Source).ResolutionY;
+
     PutImage(0, 0, TBGRACustomBitmap(Source), dmSet);
     if Source is TBGRADefaultBitmap then
     begin
@@ -1180,6 +1186,14 @@ begin
   begin
     DiscardBitmapChange;
     SetSize(TFPCustomImage(Source).Width, TFPCustomImage(Source).Height);
+
+    {$IF FPC_FULLVERSION>=30301}
+    //Resolution
+    ResolutionUnit:=TFPCustomImage(Source).ResolutionUnit;
+    ResolutionX:=TFPCustomImage(Source).ResolutionX;
+    ResolutionY:=TFPCustomImage(Source).ResolutionY;
+    {$ENDIF}
+
     for y := 0 to TFPCustomImage(Source).Height-1 do
     begin
       pdest := ScanLine[y];

--- a/bgrabitmap/bgrareadjpeg.pas
+++ b/bgrabitmap/bgrareadjpeg.pas
@@ -12,8 +12,10 @@ unit BGRAReadJpeg;
 interface
 
 uses
-  BGRAClasses, BGRABitmapTypes, Classes, Types, SysUtils, FPReadJPEG, FPImage,
-  JPEGLib, JdAPImin, JDataSrc, JdAPIstd, JmoreCfg;
+  {$IF FPC_FULLVERSION<30301}
+   JPEGLib, JdAPImin, JDataSrc, JdAPIstd, JmoreCfg,
+  {$ENDIF}
+  BGRABitmapTypes, Classes, SysUtils, FPReadJPEG, FPImage;
 
 type
   TJPEGScale = FPReadJPEG.TJPEGScale;

--- a/bgrabitmap/extendedcolorspace.inc
+++ b/bgrabitmap/extendedcolorspace.inc
@@ -146,7 +146,8 @@ function StdCMYKToStdRGBA(const AStdCMYK: TStdCMYK; AAlpha: Single = 1): TStdRGB
 procedure StdRGBToYCbCr(const R, G, B: single; const AParameters: TYCbCrStdParameters; out Y, Cb, Cr: Single); inline;
 procedure YCbCrToStdRGB(const Y, Cb, Cr: Single; const AParameters: TYCbCrStdParameters; out R, G, B: Single); inline;
 function StdRGBAToYCbCr601(const AStdRGBA: TStdRGBA): TYCbCr601;
-function YCbCr601ToStdRGBA(const AYCbCr: TYCbCr601; AAlpha: Single = 1): TStdRGBA;
+function YCbCr601ToStdRGBA(const AYCbCr: TYCbCr601; AAlpha: Single = 1): TStdRGBA; overload;
+function YCbCr601ToStdRGBA(const AYCbCr: TYCbCr601; ALumaRed, ALumaGreen, ALumaBlue, AAlpha: Single): TStdRGBA; overload;
 function StdRGBAToYCbCr709(const AStdRGBA: TStdRGBA): TYCbCr709;
 function YCbCr709ToStdRGBA(const AYCbCr: TYCbCr709; AAlpha: Single = 1): TStdRGBA;
 function StdRGBAToYCbCr601JPEG(const AStdRGBA: TStdRGBA): TYCbCr601JPEG;
@@ -1211,6 +1212,25 @@ begin
   With AYCbCr, result do
   begin
     YCbCrToStdRGB(Y, Cb, Cr, YCbCrStdParameters[ITUR601], red, green, blue);
+    alpha:= AAlpha;
+    with YCbCrStdParameters[ITUR601] do
+      HandleLinearRGBAOverflow(PLinearRGBA(@result)^, LumaRed, LumaGreen, LumaBlue);
+  end;
+end;
+
+function YCbCr601ToStdRGBA(const AYCbCr: TYCbCr601; ALumaRed, ALumaGreen, ALumaBlue, AAlpha: Single): TStdRGBA;
+var
+   userParams :TYCbCrStdParameters;
+
+begin
+  userParams :=YCbCrStdParameters[ITUR601];
+  userParams.LumaRed:=ALumaRed;
+  userParams.LumaGreen:=ALumaGreen;
+  userParams.LumaBlue:=ALumaBlue;
+
+  With AYCbCr, result do
+  begin
+    YCbCrToStdRGB(Y, Cb, Cr, userParams, red, green, blue);
     alpha:= AAlpha;
     with YCbCrStdParameters[ITUR601] do
       HandleLinearRGBAOverflow(PLinearRGBA(@result)^, LumaRed, LumaGreen, LumaBlue);


### PR DESCRIPTION
ReadTiff
  added BigTif (only from fpc 3.3.1);
  solved Read 16 bit data with predictor fails;
  conditional compilation for 3.3.1 (now the class is derived from TFPReaderTiff)
  Colorspace YCbCr601ToStdRGBA overload with user Params
TBGRADefaultBitmap.Assign Resolution