### PR TITLE
Improved libavif wrapper. Adds support for image sequences (animation…

### DIFF
--- a/bgrabitmap/avifbgra.pas
+++ b/bgrabitmap/avifbgra.pas
@@ -14,9 +14,107 @@ uses
 type
   EAvifException = class(Exception);
   avifPixelFormat = libavif.avifPixelFormat;
+  avifCodecChoice = libavif.avifCodecChoice;
 
 const
-  AVIF_DEFAULT_QUALITY = 30;
+  DEFAULT_TIMESCALE = 30;
+  DEFAULT_ENCODER = AVIF_CODEC_CHOICE_AUTO;
+  DEFAULT_QUALITY = 30;
+  DEFAULT_QUALITY_ALPHA = 50;
+
+type
+  { To read one or more images }
+
+  TAvifReader = class
+  protected
+    FDecoder: PavifDecoder;
+    FDecoderWrap: TObject; //TDecoderBase;
+    FStream: TStream;
+    FImageIndex: integer;
+    FImageCount: uint32;
+    FImageDurationSeconds: double;
+    FImageDurationTimescales: uint64;
+    FSequenceDuration: double;
+    FRepetitionCount: integer;
+    FInitOk: boolean;
+    FWidth: uint32;
+    FHeight: uint32;
+    FTimescale: uint64;   // if all images have 1 timescale of duration is the same as FPS.
+    procedure Init(AStream: TStream);
+  public
+    constructor Create(AFileName: string); virtual; overload;
+    constructor Create(AStream: TStream); virtual; overload;
+    destructor Destroy; override;
+    //WARNING: Before unload the libavif we MUST close or Free all readers.
+    procedure Close;
+
+    function GetNextImage(AOutBitmap: TBGRACustomBitmap): boolean;
+    function GetNthImage(AOutBitmap: TBGRACustomBitmap; AImageIndex: uint32): boolean;
+    procedure SetDecoder(ACodec: avifCodecChoice);
+    property ImageIndex: integer read FImageIndex;
+    property ImageCount: uint32 read FImageCount;
+    property ImageDurationSeconds: double read FImageDurationSeconds;
+    property ImageDurationTimescales: uint64 read FImageDurationTimescales;
+    property SequenceDuration: double read FSequenceDuration;
+    property RepetitionCount: integer read FRepetitionCount;
+    property InitOk: boolean read FInitOk;
+    property Width: uint32 read FWidth;
+    property Height: uint32 read FHeight;
+    property Timescale: uint64 read FTimescale;
+  end;
+
+
+  { To encode one or more images in a sequence }
+
+  TAvifWriter = class
+  protected
+    FEncoder: PAvifEncoder;
+    FEncoderWrap: TObject; //TEncoderBase;
+    FInitOk: boolean;
+    FQuality0to100: integer;
+    FPixelFormat: avifPixelFormat;
+    FIgnoreAlpha: boolean;
+    FTimescale: uint64;
+    FAvifOutput: avifRWData;
+    FOnlyOneImage: boolean;
+    FImagesCount: uint32;
+    procedure EncoderFinish;
+    procedure SetMaxThreads(AMT: integer);
+    procedure SetMinQuantizer(AMinQ: integer);
+    procedure SetMaxQuantizer(AMaxQ: integer);
+    procedure SetMinQuantizerAlpha(AMinQ: integer);
+    procedure SetMaxQuantizerAlpha(AMaxQ: integer);
+    procedure SetIgnoreAlpha(AValue: boolean);
+    function GetMaxThreads: integer;
+    function GetMinQuantizer: integer;
+    function GetMaxQuantizer: integer;
+    function GetMinQuantizerAlpha: integer;
+    function GetMaxQuantizerAlpha: integer;
+  public
+    constructor Create(AQuality0to100: integer = DEFAULT_QUALITY; ASpeed0to10: integer = AVIF_SPEED_DEFAULT; APixelFormat: avifPixelFormat = AVIF_PIXEL_FORMAT_YUV420;
+      AIgnoreAlpha: boolean = False;ACodec:avifCodecChoice=AVIF_CODEC_CHOICE_AUTO); virtual; overload;
+    procedure Close;
+    destructor Destroy; override;
+    procedure AddImage(ABitmap: TBGRACustomBitmap; ADurationMs: cardinal=0);
+    function SaveToFile(AFileName: string): NativeUInt;
+    function SaveToStream(AStream: TStream): NativeUInt;
+    function SaveToMemory(AData: Pointer; ASize: NativeUInt): NativeUInt;
+    function GetOutputSize: NativeUInt;
+    procedure SetEncoder(ACodec: avifCodecChoice);
+    procedure SetTimeScale(ATimeScale: uint64);
+    procedure SetQuality(AValue: integer);
+    procedure SetQualityAlpha(AValue: integer);
+    property InitOk: boolean read FInitOk;
+    property OnlyOneImage: boolean read FOnlyOneImage write FOnlyOneImage;
+    property MaxThreads: integer read GetMaxThreads write SetMaxThreads;
+    property MinQuantizer: integer read GetMinQuantizer write SetMinQuantizer;
+    property MaxQuantizer: integer read GetMaxQuantizer write SetMaxQuantizer;
+    property MinQuantizerAlpha: integer read GetMinQuantizerAlpha write SetMinQuantizerAlpha;
+    property MaxQuantizerAlpha: integer read GetMaxQuantizerAlpha write SetMaxQuantizerAlpha;
+    property TimeScale: uint64 read FTimeScale write SetTimeScale;
+    property IgnoreAlpha: boolean read FIgnoreAlpha write SetIgnoreAlpha;
+  end;
+
 
 procedure AvifLoadFromStream(AStream: TStream; aBitmap: TBGRACustomBitmap);
 procedure AvifLoadFromFile(const AFilename: string; aBitmap: TBGRACustomBitmap);
@@ -27,6 +125,17 @@ function AvifSaveToStream(aBitmap: TBGRACustomBitmap; AStream: TStream; aQuality
 function AvifSaveToFile(aBitmap: TBGRACustomBitmap; const AFilename: string; aQuality0to100: integer = 30;aSpeed0to10:integer=AVIF_SPEED_DEFAULT;aPixelFormat:avifPixelFormat=AVIF_PIXEL_FORMAT_YUV420;aIgnoreAlpha:boolean=false): NativeUInt;
 //returns size of the resulting bitmap.
 function AvifSaveToMemory(aBitmap: TBGRACustomBitmap; AData: Pointer; ASize: cardinal; aQuality0to100: integer = 30;aSpeed0to10:integer=AVIF_SPEED_DEFAULT;aPixelFormat:avifPixelFormat=AVIF_PIXEL_FORMAT_YUV420;aIgnoreAlpha:boolean=false): NativeUInt;
+
+function AvifSaveToStream(ABitmap: TBGRACustomBitmap; AStream: TStream; AIgnoreAlpha: boolean = False;
+  AQuality0to100: integer = DEFAULT_QUALITY; AQualityAlpha0to100: integer = DEFAULT_QUALITY_ALPHA; APixelFormat: avifPixelFormat = AVIF_PIXEL_FORMAT_YUV420;
+  ACodec: avifCodecChoice = DEFAULT_ENCODER; ASpeed0to10: integer = AVIF_SPEED_DEFAULT): nativeuint; overload;
+function AvifSaveToFile(ABitmap: TBGRACustomBitmap; const AFilename: string; AIgnoreAlpha: boolean = False;
+  AQuality0to100: integer = DEFAULT_QUALITY; AQualityAlpha0to100: integer = DEFAULT_QUALITY_ALPHA; APixelFormat: avifPixelFormat = AVIF_PIXEL_FORMAT_YUV420;
+  ACodec: avifCodecChoice = DEFAULT_ENCODER; ASpeed0to10: integer = AVIF_SPEED_DEFAULT): nativeuint; overload;
+function AvifSaveToMemory(ABitmap: TBGRACustomBitmap; AData: Pointer; ASize: nativeuint; AIgnoreAlpha: boolean = False;
+  AQuality0to100: integer = DEFAULT_QUALITY; AQualityAlpha0to100: integer = DEFAULT_QUALITY_ALPHA; APixelFormat: avifPixelFormat = AVIF_PIXEL_FORMAT_YUV420;
+  ACodec: avifCodecChoice = DEFAULT_ENCODER; ASpeed0to10: integer = AVIF_SPEED_DEFAULT): nativeuint; overload;
+
 //aBuffer  12 first bytes of file.
 function AvifValidateHeaderSignature(aBuffer: Pointer): boolean;
 
@@ -79,6 +188,13 @@ type
     function GetImage: PavifImage; virtual; abstract;
     function GetIo:PavifIO; virtual; abstract;
     function GetDecoder:PavifDecoder; virtual; abstract;
+    function GetSequenceDuration: double; virtual; abstract;
+    function GetImageCount: longint; virtual; abstract;
+    function GetImageIndex: longint; virtual; abstract;
+    function GetImageDurationSeconds: double; virtual; abstract;
+    function GetImageDurationTimescales: UInt64;virtual; abstract;
+    function GetTimescale: UInt64; virtual; abstract;
+    procedure SetCodecChoice(ACodec:avifCodecChoice); virtual; abstract;
   end;
 
   generic TDecoder<T> = class(TDecoderBase)
@@ -90,6 +206,13 @@ type
     function GetImage: PavifImage; override;
     function GetIo:PavifIO; override;
     function GetDecoder:PavifDecoder; override;
+    function GetSequenceDuration: double; override;
+    function GetImageCount: longint; override;
+    function GetImageIndex: longint; override;
+    function GetImageDurationSeconds: double; override;
+    function GetImageDurationTimescales: UInt64;override;
+    function GetTimescale: UInt64; override;
+    procedure SetCodecChoice(ACodec:avifCodecChoice); override;
   end;
 
   TEncoderBase = class
@@ -102,6 +225,12 @@ type
     procedure SetMinQuantizerAlpha(AMinQ: integer); virtual; abstract;
     procedure SetMaxQuantizerAlpha(AMQ: integer); virtual; abstract;
     procedure SetCodecChoice(AMQ: avifCodecChoice); virtual; abstract;
+    procedure SetTimeScale(aValue:UInt64); virtual; abstract;
+    function GetMaxThreads: integer; virtual; abstract;
+    function GetMinQuantizer: integer; virtual; abstract;
+    function GetMaxQuantizer: integer; virtual; abstract;
+    function GetMinQuantizerAlpha: integer; virtual; abstract;
+    function GetMaxQuantizerAlpha: integer; virtual; abstract;
   end;
 
   generic TEncoder<T> = class(TEncoderBase)
@@ -117,6 +246,12 @@ type
     procedure SetMinQuantizerAlpha(AMinQ: integer); override;
     procedure SetMaxQuantizerAlpha(AMQ: integer); override;
     procedure SetCodecChoice(ACC: avifCodecChoice); override;
+    procedure SetTimeScale(aValue:UInt64); override;
+    function GetMaxThreads: integer; override;
+    function GetMinQuantizer: integer; override;
+    function GetMaxQuantizer: integer; override;
+    function GetMinQuantizerAlpha: integer; override;
+    function GetMaxQuantizerAlpha: integer; override;
   end;
 
   TAvifRGBImageBase = class
@@ -131,6 +266,7 @@ type
     procedure SetFormat(aFormat:avifRGBFormat); virtual; abstract;
     procedure SetRowBytes(aRowBytes : UInt32); virtual; abstract;
     procedure SetIgnoreAlpha(AIgnoreAlpha : avifBool); virtual; abstract;
+    procedure SetAlphaPremultiplied(aValue:avifBool);virtual; abstract;
   end;
 
   TAvifRGBImageField = record
@@ -159,6 +295,7 @@ type
     procedure SetFormat(aFormat:avifRGBFormat); override;
     procedure SetRowBytes(aRowBytes : UInt32); override;
     procedure SetIgnoreAlpha(AIgnoreAlpha : avifBool); override;
+    procedure SetAlphaPremultiplied(aValue:avifBool);override;
   end;
 
 function TAvifImageFactory(aImagePtr: Pointer): TAvifImageBase;
@@ -234,13 +371,48 @@ begin
   result := FDecoder;
 end;
 
+function TDecoder.GetImageIndex:longint;
+begin
+  result := FDecoder^.imageIndex;
+end;
+
+function TDecoder.GetImageDurationSeconds: double;
+begin
+  result := FDecoder^.imageTiming.duration;
+end;
+
+function TDecoder.GetImageDurationTimescales: UInt64;
+begin
+  result := FDecoder^.imageTiming.durationInTimescales;
+end;
+
+function TDecoder.GetTimescale: UInt64;
+begin
+  result := FDecoder^.timescale;
+end;
+
+procedure TDecoder.SetCodecChoice(ACodec: avifCodecChoice);
+begin
+  FDecoder^.codecChoice := ACodec;
+end;
+
+function TDecoder.GetImageCount:longint;
+begin
+  result := FDecoder^.imageCount;
+end;
+
+function TDecoder.GetSequenceDuration:double;
+begin
+  result := FDecoder^.duration;
+end;
+
 constructor TAvifRGBImage.Create;
 begin
   wrgb := Default(TAvifRGBImageField);
   FImage:= T(@wrgb);
 end;
 
-function TAvifRGBImage.GetRgbImage: Pointer;
+function TAvifRGBImage.GetRgbImage: PavifRGBImage;
 begin
   result := FImage;
 end;
@@ -290,6 +462,11 @@ begin
   FImage^.ignoreAlpha:=aIgnoreAlpha;
 end;
 
+procedure TAvifRGBImage.SetAlphaPremultiplied(aValue: avifBool);
+begin
+  FImage^.alphaPremultiplied:=aVAlue;
+end;
+
 constructor TEncoder.Create(aEncoderPtr: Pointer);
 begin
   Init(aEncoderPtr);
@@ -333,6 +510,36 @@ end;
 procedure TEncoder.SetCodecChoice(ACC: avifCodecChoice);
 begin
   FEncoder^.codecChoice := ACC;
+end;
+
+procedure TEncoder.SetTimeScale(aValue: UInt64);
+begin
+  FEncoder^.timescale:=aValue;
+end;
+
+function TEncoder.GetMaxThreads: integer;
+begin
+  result:=FEncoder^.maxThreads;
+end;
+
+function TEncoder.GetMinQuantizer: integer;
+begin
+  result:=FEncoder^.minQuantizer;
+end;
+
+function TEncoder.GetMaxQuantizer: integer;
+begin
+  result:=FEncoder^.maxQuantizer;
+end;
+
+function TEncoder.GetMinQuantizerAlpha: integer;
+begin
+  result:=FEncoder^.minQuantizerAlpha;
+end;
+
+function TEncoder.GetMaxQuantizerAlpha: integer;
+begin
+  result:=FEncoder^.maxQuantizerAlpha;
 end;
 
 constructor TAvifImage.Create(aImagePtr: Pointer);
@@ -472,57 +679,67 @@ begin
   exit(AVIF_RESULT_OK);
 end;
 
-procedure AvifDecode(decoderWrap: TDecoderBase; aBitmap: TBGRACustomBitmap);
+procedure AvifImageToBGRABitmap(aAvifImage:PAvifImage; aBitmap: TBGRACustomBitmap);
 var
   res: avifResult;
   imageWrap: TAvifImageBase;
   rgbImageWrap: TAvifRgbImageBase;
 begin
+  imageWrap:=nil;
+  rgbImageWrap:=nil;
+  try
+    rgbImageWrap:=TAvifRgbImageFactory();
+    imageWrap:=TAvifImageFactory(aAvifImage);
+    avifRGBImageSetDefaults(rgbImageWrap.GetRgbImage, aAvifImage);
+    //aBitmap.LineOrder:=riloTopToBottom;
+    aBitmap.SetSize(rgbImageWrap.GetWidth, rgbImageWrap.GetHeight);
+    rgbImageWrap.SetPixels(PUint8(aBitmap.databyte));
+    rgbImageWrap.SetDepth(8);
+    {$push}{$warn 6018 off}//unreachable code
+    if TBGRAPixel_RGBAOrder then
+      rgbImageWrap.SetFormat(AVIF_RGB_FORMAT_RGBA)
+    else
+      rgbImageWrap.SetFormat(AVIF_RGB_FORMAT_BGRA);
+    {$pop}
+    rgbImageWrap.SetRowBytes(rgbImageWrap.GetWidth * 4);
+    //if aBitmap.LineOrder<>riloTopToBottom then
+    //begin
+    //  decoder^.image^.transformFlags:=decoder^.image^.transformFlags + Uint32(AVIF_TRANSFORM_IMIR);
+    //  decoder^.image^.imir.mode:=0;
+    //end;
+    //decoder^.image^.imir.axis:=0; //vertical mirror
+    res := avifImageYUVToRGB(aAvifImage, rgbImageWrap.GetRgbImage);
+
+    if res <> AVIF_RESULT_OK then
+      raise EAvifException.Create('Avif Error: ' + avifResultToString(res));
+    if (aBitmap.LineOrder <> riloTopToBottom) and not
+      (( imageWrap.GetTransformFlags and longword(AVIF_TRANSFORM_IMIR) ) = longword(AVIF_TRANSFORM_IMIR) ) and
+      (imageWrap.GetImirMode = 0) then
+      aBitmap.VerticalFlip;
+    aBitmap.InvalidateBitmap;
+  finally
+     imageWrap.Free;
+     rgbImageWrap.Free;
+  end;
+end;
+
+procedure AvifDecode(decoderWrap: TDecoderBase; aBitmap: TBGRACustomBitmap);
+var
+  res: avifResult;
+  image:PAvifImage;
+begin
   res := avifDecoderParse(decoderWrap.GetDecoder);
   if res <> AVIF_RESULT_OK then
     raise EAvifException.Create('Avif Error: ' + avifResultToString(res));
   //  Memo1.Lines.Add(Format('Parsed AVIF: %ux%u (%ubpc)', [decoder^.image^.Width, decoder^.image^.Height, decoder^.image^.depth]));
-  if avifDecoderNextImage(decoderWrap.GetDecoder) = AVIF_RESULT_OK then
+  res := avifDecoderNextImage(decoderWrap.GetDecoder);
+  if res = AVIF_RESULT_OK then
   begin
-    if decoderWrap.GetImage = nil then
+    image := decoderWrap.GetImage;
+    if image = nil then
       raise EAvifException.Create('No image data recieved from AVIF library.');
-
-    imageWrap:=nil;
-    rgbImageWrap:=nil;
-    try
-      rgbImageWrap:=TAvifRgbImageFactory();
-      imageWrap:=TAvifImageFactory(decoderWrap.GetImage);
-      avifRGBImageSetDefaults(rgbImageWrap.GetRgbImage, decoderWrap.GetImage);
-      //aBitmap.LineOrder:=riloTopToBottom;
-      aBitmap.SetSize(rgbImageWrap.GetWidth, rgbImageWrap.GetHeight);
-      rgbImageWrap.SetPixels(PUint8(aBitmap.databyte));
-      rgbImageWrap.SetDepth(8);
-      {$push}{$warn 6018 off}//unreachable code
-      if TBGRAPixel_RGBAOrder then
-        rgbImageWrap.SetFormat(AVIF_RGB_FORMAT_RGBA)
-      else
-        rgbImageWrap.SetFormat(AVIF_RGB_FORMAT_BGRA);
-      {$pop}
-      rgbImageWrap.SetRowBytes(rgbImageWrap.GetWidth * 4);
-      //if aBitmap.LineOrder<>riloTopToBottom then
-      //begin
-      //  decoder^.image^.transformFlags:=decoder^.image^.transformFlags + Uint32(AVIF_TRANSFORM_IMIR);
-      //  decoder^.image^.imir.mode:=0;
-      //end;
-      //decoder^.image^.imir.axis:=0; //vertical mirror
-      res := avifImageYUVToRGB(decoderWrap.GetImage, rgbImageWrap.GetRgbImage);
-      if res <> AVIF_RESULT_OK then
-        raise EAvifException.Create('Avif Error: ' + avifResultToString(res));
-      if (aBitmap.LineOrder <> riloTopToBottom) and not
-        (( imageWrap.GetTransformFlags and longword(AVIF_TRANSFORM_IMIR) ) = longword(AVIF_TRANSFORM_IMIR) ) and
-        (imageWrap.GetImirMode = 0) then
-        aBitmap.VerticalFlip;
-      aBitmap.InvalidateBitmap;
-    finally
-      imageWrap.Free;
-      rgbImageWrap.Free;
-    end;
-  end
+    AvifImageToBGRABitmap(image,aBitmap);
+   end
   else
     raise EAvifException.Create('Avif Error: ' + avifResultToString(res));
 end;
@@ -638,26 +855,464 @@ end;
 //https://github.com/AOMediaCodec/libavif/issues/545
 //https://gitmemory.com/issue/AOMediaCodec/libavif/545/802934788
 // aQuality0to100   0 worst quality, 100 best quality ( lossless ).
-procedure AvifEncode(aBitmap: TBGRACustomBitmap; aQuality0to100: integer; aSpeed0to10:integer; var avifOutput: avifRWData;aPixelFormat:avifPixelFormat=AVIF_PIXEL_FORMAT_YUV420;aIgnoreAlpha:boolean=false);
+
+function AvifSaveToFile(aBitmap: TBGRACustomBitmap; const AFilename: string;
+  aQuality0to100: integer; aSpeed0to10: integer; aPixelFormat: avifPixelFormat;
+  aIgnoreAlpha: boolean): NativeUInt;
 var
-  encoder: PavifEncoder;
-  image: PavifImage;
-  imageWrap:TAvifImageBase;
-  encoderWrap:TEncoderBase;
-  convertResult, addImageResult, finishResult: avifResult;
+  writer: TAvifWriter;
+begin
+  Result := 0;
+  writer := TAvifWriter.Create( aQuality0to100, aSpeed0to10, aPixelFormat, aIgnoreAlpha);
+  try
+    writer.OnlyOneImage := True;
+    writer.AddImage(aBitmap, 0);
+    Result := writer.SaveToFile(AFileName);
+  finally
+    writer.Free;
+  end;
+end;
+
+function AvifSaveToStream(aBitmap: TBGRACustomBitmap; AStream: TStream;
+  aQuality0to100: integer; aSpeed0to10: integer; aPixelFormat: avifPixelFormat;
+  aIgnoreAlpha: boolean): NativeUInt;
+var
+  writer: TAvifWriter;
+begin
+  Result := 0;
+  writer := TAvifWriter.Create(aQuality0to100, aSpeed0to10, aPixelFormat, aIgnoreAlpha);
+  try
+    writer.OnlyOneImage := True;
+    writer.AddImage(aBitmap, 0);
+    Result := writer.SaveToStream(AStream);
+  finally
+    writer.Free;
+  end;
+end;
+//returns the size of the resulting bitmap.
+function AvifSaveToMemory(aBitmap: TBGRACustomBitmap; AData: Pointer; ASize: cardinal; aQuality0to100: integer;aSpeed0to10:integer;aPixelFormat:avifPixelFormat;aIgnoreAlpha:boolean): NativeUInt;
+var
+  writer:TAvifWriter;
+begin
+  result:=0;
+  writer:=TAvifWriter.Create(aQuality0to100,aSpeed0to10,aPixelFormat,aIgnoreAlpha);
+  try
+    writer.OnlyOneImage := True;
+    writer.AddImage(aBitmap,0);
+    result:=writer.SaveToMemory(AData,ASize);
+  finally
+    writer.Free;
+  end;
+end;
+
+
+function AvifSaveToStream(ABitmap: TBGRACustomBitmap; AStream: TStream;
+  AIgnoreAlpha: boolean; AQuality0to100: integer; AQualityAlpha0to100: integer;
+  APixelFormat: avifPixelFormat; ACodec: avifCodecChoice; ASpeed0to10: integer
+  ): nativeuint;
+var
+  writer: TAvifWriter;
+begin
+  Result := 0;
+  writer := TAvifWriter.Create( AQuality0to100, ASpeed0to10, APixelFormat, AIgnoreAlpha);
+  try
+    writer.SetEncoder(ACodec);
+    writer.OnlyOneImage := True;
+    writer.SetQuality(AQuality0to100);
+    writer.SetQualityAlpha(AQualityAlpha0to100);
+    writer.AddImage(aBitmap, 0);
+    Result := writer.SaveToStream(AStream);
+  finally
+    writer.Free;
+  end;
+end;
+
+function AvifSaveToFile(ABitmap: TBGRACustomBitmap; const AFilename: string;
+  AIgnoreAlpha: boolean; AQuality0to100: integer; AQualityAlpha0to100: integer;
+  APixelFormat: avifPixelFormat; ACodec: avifCodecChoice; ASpeed0to10: integer
+  ): nativeuint;
+var
+  writer: TAvifWriter;
+begin
+  Result := 0;
+  writer := TAvifWriter.Create( AQuality0to100, ASpeed0to10, APixelFormat, AIgnoreAlpha);
+  try
+    writer.SetEncoder(ACodec);
+    writer.MaxThreads := 16;
+    writer.OnlyOneImage := True;
+    writer.SetQuality(AQuality0to100);
+    writer.SetQualityAlpha(AQualityAlpha0to100);
+    writer.AddImage(ABitmap, 0);
+    Result := writer.SaveToFile(AFileName);
+  finally
+    writer.Free;
+  end;
+end;
+
+function AvifSaveToMemory(ABitmap: TBGRACustomBitmap; AData: Pointer;
+  ASize: nativeuint; AIgnoreAlpha: boolean; AQuality0to100: integer;
+  AQualityAlpha0to100: integer; APixelFormat: avifPixelFormat;
+  ACodec: avifCodecChoice; ASpeed0to10: integer): nativeuint;
+var
+  writer: TAvifWriter;
+begin
+  Result := 0;
+  writer := TAvifWriter.Create( AQuality0to100, ASpeed0to10, APixelFormat, AIgnoreAlpha);
+  try
+    writer.SetEncoder(ACodec);
+    writer.OnlyOneImage := True;
+    writer.SetQuality(AQuality0to100);
+    writer.SetQualityAlpha(AQualityAlpha0to100);
+    writer.AddImage(ABitmap, 0);
+    Result := writer.SaveToMemory(AData,ASize);
+  finally
+    writer.Free;
+  end;
+end;
+
+{ TAvifReader }
+
+constructor TAvifReader.Create(AFileName: string);
+begin
+  FStream := TFileStream.Create(AFileName, fmOpenRead or fmShareDenyWrite);
+  Init(FStream);
+end;
+
+constructor TAvifReader.Create(AStream: TStream);
+begin
+  Init(AStream);
+end;
+
+procedure TAvifReader.Init(AStream: TStream);
+var
+  res: avifResult;
+  DecoderWrap:TDecoderBase;
+begin
+  FDecoder := avifDecoderCreate();
+  if FDecoder = nil then
+    Exit;
+  DecoderWrap:=TDecoderFactory(FDecoder);
+  FDecoderWrap:=DecoderWrap;
+  res := avifDecoderSetIOStream(DecoderWrap, AStream);
+  if res = AVIF_RESULT_OK then
+    res := avifDecoderParse(DecoderWrap.GetDecoder);
+  if res <> AVIF_RESULT_OK then
+      raise EAvifException.Create('Avif Error: ' + avifResultToString(res));
+  FImageCount:=DecoderWrap.GetImageCount;
+  FImageIndex:=DecoderWrap.GetImageIndex;
+  FSequenceDuration := DecoderWrap.GetSequenceDuration;
+  FTimescale := DecoderWrap.GetTimescale;
+  FInitOk:=True;
+end;
+
+procedure TAvifReader.Close;
+begin
+  //WARNING: if the user unload libavif before clossing the reader then Access violation.
+  if (FDecoder <> nil) and LibAvifLoaded then
+  begin
+    //avifDecoderReset(FDecoder);
+    avifDecoderDestroy(FDecoder);
+    FDecoder := nil;
+  end;
+  FreeAndNil(FDecoderWrap);
+  FreeAndNil(FStream);
+end;
+
+destructor TAvifReader.Destroy;
+begin
+  Close;
+  inherited Destroy;
+end;
+
+function TAvifReader.GetNextImage(AOutBitmap: TBGRACustomBitmap): boolean;
+var
+  image: PAvifImage;
+  res: avifResult;
+begin
+  Result := False;
+  FImageDurationSeconds := -1;
+  FImageDurationTimescales := 0;
+  if (not InitOk) or (AOutBitmap = nil) or (FImageIndex >= (FImageCount - 1)) then
+    Exit;
+  res := avifDecoderNextImage(TDecoderBase(FDecoderWrap).GetDecoder);
+  if res = AVIF_RESULT_OK then
+  begin
+    image := TDecoderBase(FDecoderWrap).GetImage;
+    if image = nil then
+      raise EAvifException.Create('No image data recieved from AVIF library.');
+    AvifImageToBGRABitmap(image, aOutBitmap);
+    FImageIndex := TDecoderBase(FDecoderWrap).GetImageIndex;
+    FImageDurationSeconds := TDecoderBase(FDecoderWrap).GetImageDurationSeconds;
+    FImageDurationTimescales := TDecoderBase(FDecoderWrap).GetImageDurationTimescales;
+    if FImageIndex = 0 then
+    begin
+      FWidth := aOutBitmap.Width;
+      FHeight := aOutBitmap.Height;
+    end;
+    Result := True;
+  end
+  else
+    raise EAvifException.Create('Avif Error: ' + avifResultToString(res));
+end;
+
+function TAvifReader.GetNthImage(AOutBitmap: TBGRACustomBitmap;
+  AImageIndex: uint32): boolean;
+var
+  image: PAvifImage;
+  res: avifResult;
+begin
+  Result := False;
+  FImageDurationSeconds := -1;
+  if (not InitOk) or (AOutBitmap = nil) or (aImageIndex >= FImageCount) then
+    Exit;
+  res := avifDecoderNthImage(TDecoderBase(FDecoderWrap).GetDecoder, aImageIndex);
+  if res = AVIF_RESULT_OK then
+  begin
+    image := TDecoderBase(FDecoderWrap).GetImage;
+    if image = nil then
+      raise EAvifException.Create('No image data recieved from AVIF library.');
+    AvifImageToBGRABitmap(image, aOutBitmap);
+    FImageIndex := TDecoderBase(FDecoderWrap).GetImageIndex;
+    FImageDurationSeconds := TDecoderBase(FDecoderWrap).GetImageDurationSeconds;
+    if FImageIndex = 0 then
+    begin
+      FWidth := aOutBitmap.Width;
+      FHeight := aOutBitmap.Height;
+    end;
+    Result := True;
+  end
+  else
+    raise EAvifException.Create('Avif Error: ' + avifResultToString(res));
+end;
+
+procedure TAvifReader.SetDecoder(ACodec: avifCodecChoice);
+var
+  lDecoderWrap:TDecoderBase;
+begin
+  lDecoderWrap := TDecoderBase(FDecoderWrap);
+  lDecoderWrap.SetCodecChoice(ACodec);
+end;
+
+{ TAvifWriter }
+
+constructor TAvifWriter.Create(AQuality0to100: integer; ASpeed0to10: integer;
+  APixelFormat: avifPixelFormat; AIgnoreAlpha: boolean; ACodec: avifCodecChoice
+  );
+var
   alpha_quantizer, min_quantizer, max_quantizer: integer;
   quality: integer;
-  rgbImageWrap:TAvifRgbImageBase;
+  lEncoderWrap: TEncoderBase;
 const
   LOSS_LESS_IMAGE_QUALITY = 100;
 begin
-  encoder := nil;
-  rgbImageWrap:=nil;
+  FAvifOutput := AVIF_DATA_EMPTY;
+  FEncoder := avifEncoderCreate();
+  if FEncoder = nil then
+    raise EAvifException.Create('Avif Error: creating encoder');
+  FEncoderWrap := TEncoderFactory(FEncoder);
+  lEncoderWrap := TEncoderBase(FEncoderWrap);
+  FPixelFormat := APixelFormat;
+  FIgnoreAlpha := AIgnoreAlpha;
+  FTimescale := DEFAULT_TIMESCALE;
+  lEncoderWrap.SetTimeScale(FTimescale);
+
+  // Configure your encoder here (see avif/avif.h):
+  // * maxThreads
+  // * minQuantizer
+  // * maxQuantizer
+  // * minQuantizerAlpha
+  // * maxQuantizerAlpha
+  // * tileRowsLog2
+  // * tileColsLog2
+  // * speed
+  // * keyframeInterval
+  // * timescale
+
+  FQuality0to100 := clamp(AQuality0to100, 0, 100);
+  if aSpeed0to10 <> AVIF_SPEED_DEFAULT then
+    aSpeed0to10 := clamp(ASpeed0to10, AVIF_SPEED_SLOWEST, AVIF_SPEED_FASTEST);
+
+  lEncoderWrap.SetMaxThreads(2);
+  lEncoderWrap.SetSpeed(ASpeed0to10);
+  if FQuality0to100 = LOSS_LESS_IMAGE_QUALITY then
+  begin
+    // Set defaults, and warn later on if anything looks incorrect
+    //input.requestedFormat = AVIF_PIXEL_FORMAT_YUV444; // don't subsample when using AVIF_MATRIX_COEFFICIENTS_IDENTITY
+    lEncoderWrap.SetMinQuantizer(AVIF_QUANTIZER_LOSSLESS);
+    lEncoderWrap.SetMaxQuantizer(AVIF_QUANTIZER_LOSSLESS);
+    lEncoderWrap.SetMinQuantizerAlpha(AVIF_QUANTIZER_LOSSLESS);
+    lEncoderWrap.SetMaxQuantizerAlpha(AVIF_QUANTIZER_LOSSLESS);
+    lEncoderWrap.SetCodecChoice(AVIF_CODEC_CHOICE_AOM);              // rav1e doesn't support lossless transform yet:
+  end
+  else
+  begin
+    // CONVERT 0..100  TO 63..0
+    quality := Trunc(interpolate(AQuality0to100, 0, 100, AVIF_QUANTIZER_WORST_QUALITY, AVIF_QUANTIZER_BEST_QUALITY));
+    max_quantizer := quality;
+    min_quantizer := 0;
+    alpha_quantizer := 0;
+    if (max_quantizer > 20) then
+    begin
+      min_quantizer := max_quantizer - 20;
+      if (max_quantizer > 40) then
+        alpha_quantizer := max_quantizer - 40;
+    end;
+    lEncoderWrap.SetMinQuantizer(min_quantizer);
+    lEncoderWrap.SetMaxQuantizer(max_quantizer);
+    lEncoderWrap.SetMinQuantizerAlpha(0);
+    lEncoderWrap.SetMaxQuantizerAlpha(alpha_quantizer);
+    //lEncoderWrap.SetCodecChoice(aCodec);
+  end;
+  FInitOk := True;
+end;
+
+procedure TAvifWriter.Close;
+begin
+  EncoderFinish;
+end;
+
+procedure TAvifWriter.EncoderFinish;
+var
+  finishResult: avifResult;
+begin
+  if (FEncoder <> nil) and LibAvifLoaded then
+  begin
+    try
+      if FInitOk and (FImagesCount > 0) then
+      begin
+        finishResult := avifEncoderFinish(FEncoder, @FAvifOutput);
+        if finishResult <> AVIF_RESULT_OK then
+          raise EAvifException.Create('Failed to finish encode: ' + avifResultToString(finishResult));
+      end;
+    finally
+      avifEncoderDestroy(FEncoder);
+      FreeAndNil(FEncoderWrap);
+      FEncoder := nil;
+    end;
+  end;
+end;
+
+procedure TAvifWriter.SetMaxThreads(AMT: integer);
+var
+  lEncoderWrap:TEncoderBase;
+begin
+  lEncoderWrap := TEncoderBase(FEncoderWrap);
+  lEncoderWrap.SetMaxThreads(AMT);
+end;
+
+procedure TAvifWriter.SetMinQuantizer(AMinQ: integer);
+var
+  lEncoderWrap:TEncoderBase;
+begin
+  lEncoderWrap := TEncoderBase(FEncoderWrap);
+  lEncoderWrap.SetMinQuantizer(AMinQ);
+end;
+
+procedure TAvifWriter.SetMaxQuantizer(AMaxQ: integer);
+var
+  lEncoderWrap:TEncoderBase;
+begin
+  lEncoderWrap := TEncoderBase(FEncoderWrap);
+  lEncoderWrap.SetMaxQuantizer(AMaxQ);
+end;
+
+procedure TAvifWriter.SetMinQuantizerAlpha(AMinQ: integer);
+var
+  lEncoderWrap:TEncoderBase;
+begin
+  lEncoderWrap := TEncoderBase(FEncoderWrap);
+  lEncoderWrap.SetMinQuantizerAlpha(AMinQ);
+end;
+
+procedure TAvifWriter.SetMaxQuantizerAlpha(AMaxQ: integer);
+var
+  lEncoderWrap:TEncoderBase;
+begin
+  lEncoderWrap := TEncoderBase(FEncoderWrap);
+  lEncoderWrap.SetMaxQuantizerAlpha(AMaxQ);
+end;
+
+procedure TAvifWriter.SetIgnoreAlpha(AValue: boolean);
+begin
+  FIgnoreAlpha := AValue;
+end;
+
+function TAvifWriter.GetMaxThreads: integer;
+var
+  lEncoderWrap:TEncoderBase;
+begin
+  lEncoderWrap := TEncoderBase(FEncoderWrap);
+  result:=lEncoderWrap.GetMaxThreads;
+end;
+
+function TAvifWriter.GetMinQuantizer: integer;
+var
+  lEncoderWrap:TEncoderBase;
+begin
+  lEncoderWrap := TEncoderBase(FEncoderWrap);
+  result:=lEncoderWrap.GetMinQuantizer;
+end;
+
+function TAvifWriter.GetMaxQuantizer: integer;
+var
+  lEncoderWrap:TEncoderBase;
+begin
+  lEncoderWrap := TEncoderBase(FEncoderWrap);
+  result:=lEncoderWrap.GetMaxQuantizer;
+end;
+
+function TAvifWriter.GetMinQuantizerAlpha: integer;
+var
+  lEncoderWrap:TEncoderBase;
+begin
+  lEncoderWrap := TEncoderBase(FEncoderWrap);
+  result:=lEncoderWrap.GetMinQuantizerAlpha;
+end;
+
+function TAvifWriter.GetMaxQuantizerAlpha: integer;
+var
+  lEncoderWrap:TEncoderBase;
+begin
+  lEncoderWrap := TEncoderBase(FEncoderWrap);
+  result:=lEncoderWrap.GetMaxQuantizerAlpha;
+end;
+
+destructor TAvifWriter.Destroy;
+begin
+  if LibAvifLoaded then
+  begin
+    try
+      EncoderFinish;
+    finally
+      avifRWDataFree(@FAvifOutput);
+    end;
+  end;
+  inherited Destroy;
+end;
+
+procedure TAvifWriter.AddImage(ABitmap: TBGRACustomBitmap; ADurationMs: cardinal
+  );
+var
+  image: PavifImage;
+  imageWrap: TAvifImageBase;
+  rgbImageWrap: TAvifRgbImageBase;
+  convertResult, addImageResult: avifResult;
+  durationTimescales: uint64;
+  imageFlags: uint32;
+const
+  LOSS_LESS_IMAGE_QUALITY = 100;
+begin
+  if (not FInitOk) or (FEncoder = nil) then
+    Exit;
+  if (FImagesCount > 0) and FOnlyOneImage then
+    raise EAvifException.Create('Only one image is allowed. ');
+  rgbImageWrap := nil;
+  imageWrap := nil;
   try
-    if aQuality0to100 = LOSS_LESS_IMAGE_QUALITY then
-      image := avifImageCreate(aBitmap.Width, aBitmap.Height, 8, AVIF_PIXEL_FORMAT_YUV444)
+    if FQuality0to100 = LOSS_LESS_IMAGE_QUALITY then
+      image := avifImageCreate(ABitmap.Width, ABitmap.Height, 8, AVIF_PIXEL_FORMAT_YUV444)
     else
-      image := avifImageCreate(aBitmap.Width, aBitmap.Height, 8, aPixelFormat{AVIF_PIXEL_FORMAT_YUV420}{AVIF_PIXEL_FORMAT_YUV444});
+      image := avifImageCreate(ABitmap.Width, ABitmap.Height, 8, FPixelFormat{AVIF_PIXEL_FORMAT_YUV420}{AVIF_PIXEL_FORMAT_YUV444});
     imageWrap := TAvifImageFactory(image);
     // these values dictate what goes into the final AVIF
     // Configure image here: (see avif/avif.h)
@@ -678,172 +1333,165 @@ begin
     // Override RGB(A)->YUV(A) defaults here: depth, format, chromaUpsampling, ignoreAlpha, alphaPremultiplied, libYUVUsage, etc
     // Alternative: set rgb.pixels and rgb.rowBytes yourself, which should match your chosen rgb.format
     // Be sure to use uint16_t* instead of uint8_t* for rgb.pixels/rgb.rowBytes if (rgb.depth > 8)
-    rgbImageWrap:=TAvifRgbImageFactory();
-    imageWrap:=TAvifImageFactory(image);
+    rgbImageWrap := TAvifRgbImageFactory();
     // If you have RGB(A) data you want to encode, use this path
     avifRGBImageSetDefaults(rgbImageWrap.GetRgbImage, image);
-    rgbImageWrap.SetWidth(aBitmap.Width);
-    rgbImageWrap.SetHeight(aBitmap.Height);
+    rgbImageWrap.SetWidth(ABitmap.Width);
+    rgbImageWrap.SetHeight(ABitmap.Height);
     {$push}{$warn 6018 off}//unreachable code
     if TBGRAPixel_RGBAOrder then
       rgbImageWrap.SetFormat(AVIF_RGB_FORMAT_RGBA)
     else
       rgbImageWrap.SetFormat(AVIF_RGB_FORMAT_BGRA);
     {$pop}
-    if aIgnoreAlpha then
+    if FIgnoreAlpha then
       rgbImageWrap.SetIgnoreAlpha(AVIF_TRUE)
     else
       rgbImageWrap.SetIgnoreAlpha(AVIF_FALSE);
-    rgbImageWrap.SetPixels(aBitmap.DataByte);
-    rgbImageWrap.SetRowBytes(aBitmap.Width * 4);
-    if aQuality0to100 = LOSS_LESS_IMAGE_QUALITY then
+    rgbImageWrap.SetPixels(ABitmap.DataByte);
+    rgbImageWrap.SetRowBytes(ABitmap.Width * 4);
+    if FQuality0to100 = LOSS_LESS_IMAGE_QUALITY then
     begin
-      imageWrap.SetYuvRange(AVIF_RANGE_FULL);
+      // https://github.com/xiph/rav1e/issues/151
+      imageWrap.SetYuvRange(AVIF_RANGE_FULL); // avoid limited range
       imageWrap.SetMatrixCoefficients(AVIF_MATRIX_COEFFICIENTS_IDENTITY); // this is key for lossless
+    end;
+    if aBitmap.LineOrder <> riloTopToBottom then   //vertical mirror.
+    begin
+      imageWrap.SetTransformFlags(imageWrap.GetTransformFlags + uint32(AVIF_TRANSFORM_IMIR));
+      imageWrap.SetImirMode(0);
     end;
     convertResult := avifImageRGBToYUV(image, rgbImageWrap.GetRgbImage);
     if convertResult <> AVIF_RESULT_OK then
       raise EAvifException.Create('Failed to convert to YUV(A): ' + avifResultToString(convertResult));
-    encoder := avifEncoderCreate();
-    encoderWrap := TEncoderFactory(encoder);
 
-    // Configure your encoder here (see avif/avif.h):
-    // * maxThreads
-    // * minQuantizer
-    // * maxQuantizer
-    // * minQuantizerAlpha
-    // * maxQuantizerAlpha
-    // * tileRowsLog2
-    // * tileColsLog2
-    // * speed
-    // * keyframeInterval
-    // * timescale
-
-    aQuality0to100:=clamp(aQuality0to100,0,100);
-    if aSpeed0to10<>AVIF_SPEED_DEFAULT then
-      aSpeed0to10:=clamp(aSpeed0to10,AVIF_SPEED_SLOWEST,AVIF_SPEED_FASTEST);
-
-    encoderWrap.SetMaxThreads(2);
-    encoderWrap.SetSpeed(aSpeed0to10);
-    if aQuality0to100 = LOSS_LESS_IMAGE_QUALITY then
-    begin
-      // Set defaults, and warn later on if anything looks incorrect
-      //input.requestedFormat = AVIF_PIXEL_FORMAT_YUV444; // don't subsample when using AVIF_MATRIX_COEFFICIENTS_IDENTITY
-      encoderWrap.SetMinQuantizer(AVIF_QUANTIZER_LOSSLESS);
-      encoderWrap.SetMaxQuantizer(AVIF_QUANTIZER_LOSSLESS);
-      encoderWrap.SetMinQuantizerAlpha(AVIF_QUANTIZER_LOSSLESS);
-      encoderWrap.SetMaxQuantizerAlpha(AVIF_QUANTIZER_LOSSLESS);
-      encoderWrap.SetCodecChoice(AVIF_CODEC_CHOICE_AOM);              // rav1e doesn't support lossless transform yet:
-      // https://github.com/xiph/rav1e/issues/151
-      imageWrap.SetYuvRange(AVIF_RANGE_FULL); // avoid limited range
-      imageWrap.SetMatrixCoefficients(AVIF_MATRIX_COEFFICIENTS_IDENTITY); // this is key for lossless
-    end
+    if FTimesCale <> 0 then
+      durationTimescales := Trunc(((ADurationMs / 1000) * FTimescale) + 0.5)
     else
-    begin
-      // CONVERT 0..100  TO 63..0
-      quality := Trunc(interpolate(aQuality0to100, 0, 100, AVIF_QUANTIZER_WORST_QUALITY, AVIF_QUANTIZER_BEST_QUALITY));
-      max_quantizer := quality;
-      min_quantizer := 0;
-      alpha_quantizer := 0;
-      if (max_quantizer > 20) then
-      begin
-        min_quantizer := max_quantizer - 20;
-        if (max_quantizer > 40) then
-          alpha_quantizer := max_quantizer - 40;
-      end;
-      encoderWrap.SetMinQuantizer(min_quantizer);
-      encoderWrap.SetMaxQuantizer(max_quantizer);
-      encoderWrap.SetMinQuantizerAlpha(0);
-      encoderWrap.SetMaxQuantizerAlpha(alpha_quantizer);
-    end;
+      durationTimescales := 1;
+    if durationTimesCales < 1 then
+      durationTimescales := 1;
 
-    if aBitmap.LineOrder <> riloTopToBottom then   //vertical mirror.
-    begin
-      imageWrap.SetTransformFlags(imageWrap.GetTransformFlags + uint32(AVIF_TRANSFORM_IMIR));
-      imageWrap.SetImirMode( 0 );
-    end;
-
-    // Call avifEncoderAddImage() for each image in your sequence
-    // Only set AVIF_ADD_IMAGE_FLAG_SINGLE if you're not encoding a sequence
-    // Use avifEncoderAddImageGrid() instead with an array of avifImage* to make a grid image
-    addImageResult := avifEncoderAddImage(encoder, image, 1, uint32(AVIF_ADD_IMAGE_FLAG_SINGLE));
+    imageFlags := uint32(AVIF_ADD_IMAGE_FLAG_NONE);
+    if FOnlyOneImage then
+      imageFlags := uint32(AVIF_ADD_IMAGE_FLAG_SINGLE);
+    addImageResult := avifEncoderAddImage(FEncoder, image, durationTimescales, imageFlags);
     if addImageResult <> AVIF_RESULT_OK then
       raise EAvifException.Create('Failed to add image to encoder: ' + avifResultToString(addImageResult));
-    finishResult := avifEncoderFinish(encoder, @avifOutput);
-    if finishResult <> AVIF_RESULT_OK then
-      raise EAvifException.Create('Failed to finish encode: ' + avifResultToString(finishResult));
-    //Memo1.Lines.Add('Encode success, total bytes: ' + IntToStr(avifOutput.size));
+    Inc(FImagesCount);
   finally
     if image <> nil then
       avifImageDestroy(image);
-    if encoder <> nil then
-      avifEncoderDestroy(encoder);
     imageWrap.Free;
-    encoderWrap.Free;
     rgbImageWrap.Free;
   end;
 end;
 
-function AvifSaveToFile(aBitmap: TBGRACustomBitmap; const AFilename: string; aQuality0to100: integer;aSpeed0to10:integer;aPixelFormat:avifPixelFormat;aIgnoreAlpha:boolean): NativeUInt;
+function TAvifWriter.SaveToFile(AFileName: string): NativeUInt;
 var
-  Stream: TFileStream;
+  lStream: TFileStream;
 begin
-  Stream := TFileStream.Create(AFileName, fmCreate);
+  Result := 0;
+  if not InitOk then
+    Exit;
+  lStream := TFileStream.Create(AFileName, fmCreate or fmShareExclusive);
   try
-    Result := AvifSaveToStream(aBitmap, Stream, aQuality0to100, aSpeed0to10,aPixelFormat,aIgnoreAlpha);
+    Result := SaveToStream(lStream);
   finally
-    Stream.Free;
+    lSTream.Free;
   end;
 end;
 
-function AvifSaveToStream(aBitmap: TBGRACustomBitmap; AStream: TStream; aQuality0to100: integer;aSpeed0to10:integer;aPixelFormat:avifPixelFormat;aIgnoreAlpha:boolean): NativeUInt;
+function TAvifWriter.SaveToStream(AStream: TStream): NativeUInt;
 var
-  avifOutput: avifRWData;
-  p:PByte;
-  remain,toWrite:LongWord;
+  p: pbyte;
+  remain, toWrite: longword;
 const
-  CopySize=65535;
+  CopySize = 65535;
 begin
-  try
-    avifOutput := AVIF_DATA_EMPTY;
-    AvifEncode(aBitmap, aQuality0to100,aSpeed0to10, avifOutput,aPixelFormat,aIgnoreAlpha);
-    Result := avifOutput.size;
-    if avifOutput.Data <> nil then
+  Result := 0;
+  if not InitOk then
+    Exit;
+  EncoderFinish;
+  Result := FAvifOutput.Size;
+  if FAvifOutput.Data <> nil then
+  begin
+    //AStream.WriteBuffer(avifOutput.Data^, avifOutput.size)
+    remain := FAvifOutput.size;
+    p := FAvifOutput.Data;
+    while remain > 0 do
     begin
-      //AStream.WriteBuffer(avifOutput.Data^, avifOutput.size)
-      remain := avifOutput.size;
-      p := avifOutput.Data;
-      while remain > 0 do
-      begin
-        if remain > CopySize then
-          toWrite := CopySize
-        else
-          toWrite := remain;
-        AStream.WriteBuffer(p^, toWrite);
-        inc(p, toWrite);
-        dec(remain, toWrite);
-      end;
-    end
-    else
-      Result := 0;
-  finally
-    avifRWDataFree(@avifOutput);
+      if remain > CopySize then
+        toWrite := CopySize
+      else
+        toWrite := remain;
+      aStream.WriteBuffer(p^, toWrite);
+      Inc(p, toWrite);
+      Dec(remain, toWrite);
+    end;
   end;
 end;
 
 //returns the size of the resulting bitmap.
-function AvifSaveToMemory(aBitmap: TBGRACustomBitmap; AData: Pointer; ASize: cardinal; aQuality0to100: integer;aSpeed0to10:integer;aPixelFormat:avifPixelFormat;aIgnoreAlpha:boolean): NativeUInt;
-var
-  avifOutput: avifRWData;
+function TAvifWriter.SaveToMemory(AData: Pointer; ASize: NativeUInt
+  ): NativeUInt;
 begin
-  try
-    avifOutput := AVIF_DATA_EMPTY;
-    AvifEncode(aBitmap, aQuality0to100, aSpeed0to10, avifOutput,aPixelFormat,aIgnoreAlpha);
-    Result := avifOutput.size;
-    if avifOutput.Data <> nil then
-      Move(avifOutput.Data^, aData^, min(ASize, avifOutput.size));
-  finally
-    avifRWDataFree(@avifOutput);
+  Result := 0;
+  if not InitOk then
+    Exit;
+  EncoderFinish;
+  Result := FAvifOutput.size;
+  if FAvifOutput.Data <> nil then
+    Move(FAvifOutput.Data^, AData^, min(ASize, FAvifOutput.size));
+end;
+
+function TAvifWriter.GetOutputSize: NativeUInt;
+begin
+  EncoderFinish;
+  Result := FAvifOutput.Size;
+end;
+
+procedure TAvifWriter.SetEncoder(ACodec: avifCodecChoice);
+var
+  lEncoderWrap:TEncoderBase;
+begin
+  lEncoderWrap := TEncoderBase(FEncoderWrap);
+  lEncoderWrap.SetCodecChoice(ACodec);
+end;
+
+procedure TAvifWriter.SetTimeScale(ATimeScale: uint64);
+begin
+  FTimeScale := ATimeScale;
+  TEncoderBase(FEncoderWrap).SetTimeScale(FTimescale);
+end;
+
+procedure TAvifWriter.SetQuality(AValue: integer);
+var
+  QV:integer;
+begin
+  if AVIF_VERSION >= AVIF_VERSION_1_0_0 then
+    PavifEncoder1_0_0(FEncoder)^.quality:=clamp(AValue,AVIF_QUALITY_WORST,AVIF_QUALITY_BEST)
+  else
+  begin
+    //0..100 -> 63..0
+    QV:=Trunc(Interpolate(AValue,AVIF_QUALITY_WORST,AVIF_QUALITY_BEST,AVIF_QUANTIZER_WORST_QUALITY,AVIF_QUANTIZER_BEST_QUALITY));
+    SetMinQuantizer(QV);
+    SetMaxQuantizer(QV);
+  end;
+end;
+
+procedure TAvifWriter.SetQualityAlpha(AValue: integer);
+var
+  QV:integer;
+begin
+  if AVIF_VERSION >= AVIF_VERSION_1_0_0 then
+    PavifEncoder1_0_0(FEncoder)^.qualityAlpha:=clamp(AValue,AVIF_QUALITY_WORST,AVIF_QUALITY_BEST)
+  else
+  begin
+    //0..100 -> 63..0
+    QV:=Trunc(Interpolate(AValue,AVIF_QUALITY_WORST,AVIF_QUALITY_BEST,AVIF_QUANTIZER_WORST_QUALITY,AVIF_QUANTIZER_BEST_QUALITY));
+    SetMinQuantizerAlpha(QV);
+    SetMaxQuantizerAlpha(QV);
   end;
 end;
 


### PR DESCRIPTION
HI circular, 

This merge request improves the libavif wraper 

Adds one reader that can read animated Avifs.  like [butterfly.avif](https://ezgif.com/images/format-demo/butterfly.avif)
[link to see the animated image](https://ezgif.com/help/alternative-animated-image-formats) github don't support avifs now.

Adds one writer that allows more fine grained control of the encoding options and also allows generate animations.

I have added 3 functions with more options for compressing alpha channel and choosing encoder.

I refactored the decoder extracting the function
procedure AvifImageToBGRABitmap(aAvifImage:PAvifImage; aBitmap: TBGRACustomBitmap); 
to be able to use it in the TAvifReader.

```pascal
function AvifSaveToStream(ABitmap: TBGRACustomBitmap; AStream: TStream; AIgnoreAlpha: boolean = False;
  AQuality0to100: integer = DEFAULT_QUALITY; AQualityAlpha0to100: integer = DEFAULT_QUALITY_ALPHA; APixelFormat: avifPixelFormat = AVIF_PIXEL_FORMAT_YUV420;
  ACodec: avifCodecChoice = DEFAULT_ENCODER; ASpeed0to10: integer = AVIF_SPEED_DEFAULT): nativeuint; overload;
function AvifSaveToFile(ABitmap: TBGRACustomBitmap; const AFilename: string; AIgnoreAlpha: boolean = False;
  AQuality0to100: integer = DEFAULT_QUALITY; AQualityAlpha0to100: integer = DEFAULT_QUALITY_ALPHA; APixelFormat: avifPixelFormat = AVIF_PIXEL_FORMAT_YUV420;
  ACodec: avifCodecChoice = DEFAULT_ENCODER; ASpeed0to10: integer = AVIF_SPEED_DEFAULT): nativeuint; overload;
function AvifSaveToMemory(ABitmap: TBGRACustomBitmap; AData: Pointer; ASize: nativeuint; AIgnoreAlpha: boolean = False;
  AQuality0to100: integer = DEFAULT_QUALITY; AQualityAlpha0to100: integer = DEFAULT_QUALITY_ALPHA; APixelFormat: avifPixelFormat = AVIF_PIXEL_FORMAT_YUV420;
  ACodec: avifCodecChoice = DEFAULT_ENCODER; ASpeed0to10: integer = AVIF_SPEED_DEFAULT): nativeuint; overload;
```
Now the functions for saving images are just wrappers for the TAvifWriter.

I have seen yor the suggestion in the forum to use a record to pass the parameters to the enhanced functions, but I think it is more comfortable to use overloaded functions with default parameters and if the user needs a better control he can use TAvifWriter. 
Of course the changes are backwards compatible.



quick and dirty animation code 

```pascal
procedure TForm1.btnPlayClick(Sender: TObject);
var
  wBack: TBGRABitmap;
  wBitmap: TBGRABitmap;
  wReader: TAvifReader;
begin
  wBitmap := nil;
  wBack := nil;
  wReader := TAvifReader.Create('butterfly.avif');
  try
    if wReader.ImageCount <= 0 then
      Exit;
    wBitmap:=TBGRABitmap.Create;
    wReader.GetNthImage(wBitmap, 0);
    wBack:=TBGRABitmap.Create(wReader.Width,wReader.Height);
    repeat
      wBack.Fill(BGRA(255, 255, 255));
      wBack.PutImage(0, 0, wBitmap, dmLinearBlend);
      wBack.Draw(Canvas, 10, 10);
      Sleep(Trunc(wReader.ImageDurationSeconds * 1000));
      if wReader.ImageIndex >= wReader.ImageCount - 1 then
        break;
      wReader.GetNextImage(wBitmap);
    until False;
  finally
    wBitmap.Free;
    wBack.Free;
    wReader.Free;
  end;
end;   
```
Sample code to generate an animated avif.

```pascal
procedure TForm1.btnGenerateClick(Sender: TObject);
var
  wAvifWriter:TAvifWriter;
  wBitmap:TBGRABitmap;
  wI:integer;
begin
  wAvifWriter:=nil;
  wBitmap:=nil;
  try
    wBitmap:=TBGRABitmap.Create(100,100,BGRA(255,255,255));
    wBitmap.LineOrder:=riloTopToBottom;
    //wBitmap.LineOrder:=riloBottomToTop;
    wAvifWriter:=TAvifWriter.Create();
    for wI:=1 to 10 do
    begin
      wBitmap.Fill(BGRA(255,255,255,0));
      wBitmap.FillRect(15, 3*wI, 25, 25+3*wI, BGRA(0,0,255));
      wBitmap.TextOut(10+6*wI,50,IntToSTr(wI),BGRA(255,0,0));
      wAvifWriter.AddImage(wBitmap,100+wI*60);
    end;
    wAvifWriter.SaveToFile('testwriter.avif');
  finally
     wAvifWriter.Free;
     wBitmap.Free;
  end;
end;

```

My encoder speed tests on windows 64 and 32 bit give the AVIF_CODEC_CHOICE_RAV1E codec as the fastest but differ from those of forum user r.lukasiak on linux which give AVIF_CODEC_CHOICE_AOM as the best so I don't dare to suggest any default codec and leave the decision to libavif (AVIF_CODEC_CHOICE_AUTO).  

Regards 
Domingo