### PR TITLE
Dev bgrabitmap v9.0.2

### DIFF
--- a/.github/workflows/make.pas
+++ b/.github/workflows/make.pas
@@ -27,18 +27,22 @@ type
   procedure OutLog(Knd: TLog; Msg: string);
   begin
     case Knd of
-        error: Writeln(stderr, #27'[31m', Msg, #27'[0m');
+        error: Writeln(stderr, #27'[91m', Msg, #27'[0m');
         info:  Writeln(stderr, #27'[32m', Msg, #27'[0m');
         audit: Writeln(stderr, #27'[33m', Msg, #27'[0m');
     end;
   end;
 
   function CheckModules: Output;
+  var Line: string;
   begin
     if FileExists('.gitmodules') then
       if RunCommand('git', ['submodule', 'update', '--init', '--recursive',
         '--force', '--remote'], Result.Output) then
-        OutLog(info, Result.Output);
+      begin
+        for Line in SplitString(Result.Output, LineEnding) do
+          OutLog(info, Line);
+      end;
   end;
 
   function AddPackage(Path: string): Output;
@@ -54,7 +58,7 @@ type
       ;
       if not Exec(Path) and RunCommand('lazbuild', ['--add-package-link', Path],
         Result.Output) then
-        OutLog(audit, 'added ' + Path);
+        OutLog(info, 'added ' + Path);
       Free;
     end;
   end;
@@ -82,18 +86,18 @@ type
         ExitCode += 1;
         with TRegExpr.Create do
         begin
-          Expression := '(Fatal|Error|/ld):';
+          Expression := '(Fatal|Error|/ld(\.[a-z]+)?):';
           for Line in SplitString(Result.Output, LineEnding) do
           begin
             if Exec(Line) then
-              OutLog(error, #10 + Line);
+              OutLog(error, Line);
           end;
           Free;
         end;
       end;
     except
       on E: Exception do
-        OutLog(error, E.ClassName + #13#10 + E.Message);
+        OutLog(error, E.ClassName + LineEnding + E.Message);
     end;
   end;
 
@@ -112,7 +116,7 @@ type
           end;
         except
           on E: Exception do
-            OutLog(error, E.ClassName + #13#10 + E.Message);
+            OutLog(error, E.ClassName + LineEnding + E.Message);
         end;
   end;
 
@@ -199,9 +203,9 @@ type
       List.Free;
     end;
     if ExitCode <> 0 then
-      OutLog(error, #10 + 'Errors: ' + IntToStr(ExitCode))
+      OutLog(error, LineEnding + 'Errors: ' + IntToStr(ExitCode))
     else
-      OutLog(info, #10 + 'Errors: ' + IntToStr(ExitCode));
+      OutLog(info, LineEnding + 'Errors: ' + IntToStr(ExitCode));
   end;
 
 begin

--- a/.github/workflows/make.pas
+++ b/.github/workflows/make.pas
@@ -80,14 +80,16 @@ type
       else
       begin
         ExitCode += 1;
-        for Line in SplitString(Result.Output, LineEnding) do
-          with TRegExpr.Create do
+        with TRegExpr.Create do
+        begin
+          Expression := '(Fatal|Error|/ld):';
+          for Line in SplitString(Result.Output, LineEnding) do
           begin
-            Expression := '(Fatal|Error):';
             if Exec(Line) then
               OutLog(error, #10 + Line);
-            Free;
           end;
+          Free;
+        end;
       end;
     except
       on E: Exception do

--- a/.github/workflows/make.pas
+++ b/.github/workflows/make.pas
@@ -41,7 +41,8 @@ type
         '--force', '--remote'], Result.Output) then
       begin
         for Line in SplitString(Result.Output, LineEnding) do
-          OutLog(info, Line);
+          if Line <> '' then
+            OutLog(info, Line);
       end;
   end;
 
@@ -202,10 +203,12 @@ type
     finally
       List.Free;
     end;
+    OutLog(audit,   '------------');
     if ExitCode <> 0 then
-      OutLog(error, LineEnding + 'Errors: ' + IntToStr(ExitCode))
+      OutLog(error, 'Errors: ' + IntToStr(ExitCode))
     else
-      OutLog(info, LineEnding + 'Errors: ' + IntToStr(ExitCode));
+      OutLog(info,  'No Errors 😊');
+    OutLog(audit,   '------------');  
   end;
 
 begin

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -36,7 +36,7 @@ jobs:
       shell: bash
       run: |
         set -xeuo pipefail
-        sudo bash -c 'apt-get update; apt-get install -y lazarus' >/dev/null
+        sudo bash -c 'apt-get update; apt-get install -y lazarus libxtst-dev' >/dev/null
         instantfpc -Fu/usr/lib/lazarus/*/components/lazutils .github/workflows/make.pas
         delp -r "${PWD}"
 

--- a/bgrabitmap/bgrabitmap.pas
+++ b/bgrabitmap/bgrabitmap.pas
@@ -78,6 +78,9 @@ type
     {$IFDEF BGRABITMAP_USE_LCL}
       {$IFDEF LCLwin32}
         {* Import version for Windows }
+
+        { TBGRABitmap }
+
         TBGRABitmap = class(TBGRAWinBitmap)
       {$ELSE}
         {$IFDEF LCLgtk}
@@ -135,7 +138,9 @@ type
     function CreateBrushTexture(ABrushStyle: TBrushStyle; APatternColor, ABackgroundColor: TBGRAPixel;
                 AWidth: integer = 8; AHeight: integer = 8; APenWidth: single = 1): TBGRABitmap; override;
     function Resample(newWidth, newHeight: integer;
-      mode: TResampleMode = rmFineResample; ACopyProperties: Boolean=False): TBGRABitmap; override;
+      mode: TResampleMode = rmFineResample; ACopyProperties: Boolean=False): TBGRABitmap; overload; override;
+    function Resample(newResolutionUnit: TResolutionUnit; NewWidth, NewHeight: Single;
+      mode: TResampleMode = rmFineResample; ACopyProperties: Boolean=True): TBGRABitmap; overload; override;
     function RotateCW(ACopyProperties: Boolean=False): TBGRABitmap; override;
     function RotateCCW(ACopyProperties: Boolean=False): TBGRABitmap; override;
     function RotateUD(ACopyProperties: Boolean=False): TBGRABitmap; override;
@@ -321,6 +326,12 @@ end;
 function TBGRABitmap.Resample(newWidth, newHeight: integer; mode: TResampleMode; ACopyProperties: Boolean=False): TBGRABitmap;
 begin
   Result:=inherited Resample(newWidth, newHeight, mode, ACopyProperties) as TBGRABitmap;
+end;
+
+function TBGRABitmap.Resample(newResolutionUnit: TResolutionUnit; NewWidth, NewHeight: Single;
+  mode: TResampleMode; ACopyProperties: Boolean): TBGRABitmap;
+begin
+  Result:=inherited Resample(newResolutionUnit, NewWidth, NewHeight, mode, ACopyProperties) as TBGRABitmap;
 end;
 
 function TBGRABitmap.RotateCW(ACopyProperties: Boolean=False): TBGRABitmap;

--- a/bgrabitmap/bgrabitmappack.lpk
+++ b/bgrabitmap/bgrabitmappack.lpk
@@ -25,7 +25,7 @@
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
     <Version Major="11" Minor="6" Release="4"/>
-    <Files Count="153">
+    <Files Count="154">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>
         <UnitName Value="BGRAAnimatedGif"/>
@@ -640,6 +640,10 @@
         <Filename Value="bgracustomtextfx.pas"/>
         <UnitName Value="BGRACustomTextFX"/>
       </Item153>
+      <Item154>
+        <Filename Value="bgrapdf.pas"/>
+        <UnitName Value="BGRAPDF"/>
+      </Item154>
     </Files>
     <CompatibilityMode Value="True"/>
     <RequiredPkgs Count="2">

--- a/bgrabitmap/bgrabitmappack.lpk
+++ b/bgrabitmap/bgrabitmappack.lpk
@@ -24,7 +24,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="11" Minor="6" Release="4"/>
+    <Version Major="11" Minor="6" Release="5"/>
     <Files Count="154">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack.pas
+++ b/bgrabitmap/bgrabitmappack.pas
@@ -31,7 +31,7 @@ uses
   XYZABitmap, BGRAWriteTiff, WordXYZABitmap, ExpandedBitmap, libwebp, 
   linuxlib, BGRAReadWebP, BGRAWriteWebP, BGRAClasses, avifbgra, libavif, 
   BGRAWriteAvif, BGRAReadAvif, darwinlib, BGRAWriteJpeg, BGRAWriteBMP, 
-  BGRAWritePCX, BGRAPapers, BGRAPNGComn, BGRACustomTextFX;
+  BGRAWritePCX, BGRAPapers, BGRAPNGComn, BGRACustomTextFX, BGRAPDF;
 
 implementation
 

--- a/bgrabitmap/bgrabitmappack4android.lpk
+++ b/bgrabitmap/bgrabitmappack4android.lpk
@@ -35,7 +35,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="11" Minor="6" Release="4"/>
+    <Version Major="11" Minor="6" Release="5"/>
     <Files Count="106">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack4android_freetype.lpk
+++ b/bgrabitmap/bgrabitmappack4android_freetype.lpk
@@ -27,15 +27,12 @@
         </Debugging>
       </Linking>
       <Other>
-        <ConfigFile>
-          <WriteConfigFilePath Value="$(PkgOutDir)\fpclaz.cfg"/>
-        </ConfigFile>
         <CustomOptions Value="-dBGRABITMAP_DONT_USE_LCL"/>
       </Other>
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="11" Minor="5" Release="8"/>
+    <Version Major="11" Minor="6" Release="4"/>
     <Files Count="107">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack4android_freetype.lpk
+++ b/bgrabitmap/bgrabitmappack4android_freetype.lpk
@@ -32,7 +32,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="11" Minor="6" Release="4"/>
+    <Version Major="11" Minor="6" Release="5"/>
     <Files Count="107">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack4fpgui.lpk
+++ b/bgrabitmap/bgrabitmappack4fpgui.lpk
@@ -33,7 +33,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="11" Minor="6" Release="4"/>
+    <Version Major="11" Minor="6" Release="5"/>
     <Files Count="105">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack4nogui.lpk
+++ b/bgrabitmap/bgrabitmappack4nogui.lpk
@@ -35,7 +35,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="11" Minor="6" Release="4"/>
+    <Version Major="11" Minor="6" Release="5"/>
     <Files Count="109">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack4nogui.lpk
+++ b/bgrabitmap/bgrabitmappack4nogui.lpk
@@ -36,7 +36,7 @@
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
     <Version Major="11" Minor="6" Release="4"/>
-    <Files Count="108">
+    <Files Count="109">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>
         <UnitName Value="BGRAAnimatedGif"/>
@@ -469,6 +469,10 @@
         <Filename Value="generatedutf8.inc"/>
         <Type Value="Include"/>
       </Item108>
+      <Item109>
+        <Filename Value="bgrapdf.pas"/>
+        <UnitName Value="BGRAPDF"/>
+      </Item109>
     </Files>
     <CompatibilityMode Value="True"/>
     <RequiredPkgs Count="2">

--- a/bgrabitmap/bgrabitmappack4nogui.pas
+++ b/bgrabitmap/bgrabitmappack4nogui.pas
@@ -24,7 +24,7 @@ uses
   BGRANoGUIBitmap, BGRASceneTypes, BGRARenderer3D, BGRAWriteBmpMioMap, 
   BGRASpriteGL, BGRAOpenGLType, BGRAOpenGL, BGRACanvasGL, BGRAPhoxo, 
   BGRAFilterScanner, BGRAFilterType, BGRAFilterBlur, BGRAMultiFileType, 
-  BGRAWinResource, BGRAUnicode, BGRAClasses;
+  BGRAWinResource, BGRAUnicode, BGRAClasses, BGRAPDF;
 
 implementation
 

--- a/bgrabitmap/bgrabitmappack4nolcl.lpk
+++ b/bgrabitmap/bgrabitmappack4nolcl.lpk
@@ -22,15 +22,12 @@
         </Optimizations>
       </CodeGeneration>
       <Other>
-        <ConfigFile>
-          <WriteConfigFilePath Value="$(PkgOutDir)\fpclaz.cfg"/>
-        </ConfigFile>
         <CustomOptions Value="-dBGRABITMAP_DONT_USE_LCL -dBGRABITMAP_DONT_USE_LAZFREETYPE"/>
       </Other>
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="11" Minor="5" Release="5"/>
+    <Version Major="11" Minor="6" Release="4"/>
     <Files Count="147">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack4nolcl.lpk
+++ b/bgrabitmap/bgrabitmappack4nolcl.lpk
@@ -27,7 +27,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="11" Minor="6" Release="4"/>
+    <Version Major="11" Minor="6" Release="5"/>
     <Files Count="148">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack4nolcl.lpk
+++ b/bgrabitmap/bgrabitmappack4nolcl.lpk
@@ -28,7 +28,7 @@
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
     <Version Major="11" Minor="6" Release="4"/>
-    <Files Count="147">
+    <Files Count="148">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>
         <UnitName Value="BGRAAnimatedGif"/>
@@ -619,6 +619,10 @@
         <Filename Value="bgrawritepcx.pas"/>
         <UnitName Value="BGRAWritePCX"/>
       </Item147>
+      <Item148>
+        <Filename Value="bgrapdf.pas"/>
+        <UnitName Value="BGRAPDF"/>
+      </Item148>
     </Files>
     <CompatibilityMode Value="True"/>
     <RequiredPkgs Count="1">

--- a/bgrabitmap/bgrabitmappack4nolcl.pas
+++ b/bgrabitmap/bgrabitmappack4nolcl.pas
@@ -30,7 +30,7 @@ uses
   UniversalDrawer, LinearRGBABitmap, XYZABitmap, BGRAWriteTiff, 
   WordXYZABitmap, ExpandedBitmap, libwebp, linuxlib, BGRAReadWebP, 
   BGRAWriteWebP, BGRAClasses, avifbgra, libavif, BGRAWriteAvif, BGRAReadAvif, 
-  darwinlib, BGRAWriteJpeg, BGRAWriteBMP, BGRAWritePCX;
+  darwinlib, BGRAWriteJpeg, BGRAWriteBMP, BGRAWritePCX, BGRAPDF;
 
 implementation
 

--- a/bgrabitmap/bgrabitmappack4nolcl_freetype.lpk
+++ b/bgrabitmap/bgrabitmappack4nolcl_freetype.lpk
@@ -27,7 +27,7 @@
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="11" Minor="6" Release="4"/>
+    <Version Major="11" Minor="6" Release="5"/>
     <Files Count="149">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack4nolcl_freetype.lpk
+++ b/bgrabitmap/bgrabitmappack4nolcl_freetype.lpk
@@ -28,7 +28,7 @@
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
     <Version Major="11" Minor="6" Release="4"/>
-    <Files Count="148">
+    <Files Count="149">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>
         <UnitName Value="BGRAAnimatedGif"/>
@@ -623,6 +623,10 @@
         <Filename Value="bgrafreetype.pas"/>
         <UnitName Value="BGRAFreeType"/>
       </Item148>
+      <Item149>
+        <Filename Value="bgrapdf.pas"/>
+        <UnitName Value="BGRAPDF"/>
+      </Item149>
     </Files>
     <CompatibilityMode Value="True"/>
     <RequiredPkgs Count="2">

--- a/bgrabitmap/bgrabitmappack4nolcl_freetype.lpk
+++ b/bgrabitmap/bgrabitmappack4nolcl_freetype.lpk
@@ -22,15 +22,12 @@
         </Optimizations>
       </CodeGeneration>
       <Other>
-        <ConfigFile>
-          <WriteConfigFilePath Value="$(PkgOutDir)\fpclaz.cfg"/>
-        </ConfigFile>
         <CustomOptions Value="-dBGRABITMAP_DONT_USE_LCL"/>
       </Other>
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
-    <Version Major="11" Minor="5" Release="5"/>
+    <Version Major="11" Minor="6" Release="4"/>
     <Files Count="148">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>

--- a/bgrabitmap/bgrabitmappack4nolcl_freetype.pas
+++ b/bgrabitmap/bgrabitmappack4nolcl_freetype.pas
@@ -30,7 +30,7 @@ uses
   UniversalDrawer, LinearRGBABitmap, XYZABitmap, BGRAWriteTiff, 
   WordXYZABitmap, ExpandedBitmap, libwebp, linuxlib, BGRAReadWebP, 
   BGRAWriteWebP, BGRAClasses, avifbgra, libavif, BGRAWriteAvif, BGRAReadAvif, 
-  darwinlib, BGRAWriteJpeg, BGRAWriteBMP, BGRAWritePCX, BGRAFreeType;
+  darwinlib, BGRAWriteJpeg, BGRAWriteBMP, BGRAWritePCX, BGRAFreeType, BGRAPDF;
 
 implementation
 

--- a/bgrabitmap/bgrabitmaptypes.pas
+++ b/bgrabitmap/bgrabitmaptypes.pas
@@ -188,10 +188,13 @@ var
     AReader: TFPCustomImageReaderClass; AWriter: TFPCustomImageWriterClass;
     AddFPCHandlers: Boolean; const ATypeName: String; const AExtensions: String);
 
-  {** Get Registered Readers Extensions To Use in Masks List}
-  function BGRARegisteredImageReadersExtensions: String;
-  {** Get Registered Writers Extensions To Use in Masks List}
-  function BGRARegisteredImageWritersExtensions: String;
+  {** Get Registered Readers Extensions to use in Masks List}
+  function BGRARegisteredImageReaderExtension: String; overload;
+  function BGRARegisteredImageReaderExtension(AFormat: TBGRAImageFormat): String; overload;
+
+  {** Get Registered Writers Extensions to use in Masks List}
+  function BGRARegisteredImageWriterExtension: String;
+  function BGRARegisteredImageWriterExtension(AFormat: TBGRAImageFormat): String; overload;
 
 type
   {* Possible options when loading an image }
@@ -1604,34 +1607,50 @@ begin
   BGRARegisterImageWriter(AFormat, AWriter, AddFPCHandlers);
 end;
 
-function BGRARegisteredImageReadersExtensions: String;
+function BGRARegisteredImageReaderExtension: String;
 var
    iFormat: TBGRAImageFormat;
 
 begin
   Result:= '';
-  for iFormat:=Low(TBGRAImageFormat) to High(TBGRAImageFormat) do
+  for iFormat:=ifJpeg to High(TBGRAImageFormat) do
     if (DefaultBGRAImageReader[iFormat] <> nil)
     then if (Result = '')
-         then Result:= '*.'+BGRAImageFormat[iFormat].Extensions
+         then Result:= '*'+ExtensionSeparator+BGRAImageFormat[iFormat].Extensions
          else Result:= Result+';'+BGRAImageFormat[iFormat].Extensions;
 
-  Result := StringReplace(Result, ';', ';*.', [rfReplaceAll]);
+  Result:= StringReplace(Result, ';', ';*'+ExtensionSeparator, [rfReplaceAll]);
 end;
 
-function BGRARegisteredImageWritersExtensions: String;
+function BGRARegisteredImageReaderExtension(AFormat: TBGRAImageFormat): String;
+begin
+  Result:= '';
+  if (DefaultBGRAImageReader[AFormat] <> nil)
+  then Result:= StringReplace('*'+ExtensionSeparator+BGRAImageFormat[AFormat].Extensions,
+                              ';', ';*'+ExtensionSeparator, [rfReplaceAll]);
+end;
+
+function BGRARegisteredImageWriterExtension: String;
 var
    iFormat: TBGRAImageFormat;
 
 begin
   Result:= '';
-  for iFormat:=Low(TBGRAImageFormat) to High(TBGRAImageFormat) do
+  for iFormat:=ifJpeg to High(TBGRAImageFormat) do
     if (DefaultBGRAImageWriter[iFormat] <> nil)
     then if (Result = '')
-         then Result:= '*.'+BGRAImageFormat[iFormat].Extensions
+         then Result:= '*'+ExtensionSeparator+BGRAImageFormat[iFormat].Extensions
          else Result:= Result+';'+BGRAImageFormat[iFormat].Extensions;
 
-  Result := StringReplace(Result, ';', ';*.', [rfReplaceAll]);
+  Result:= StringReplace(Result, ';', ';*'+ExtensionSeparator, [rfReplaceAll]);
+end;
+
+function BGRARegisteredImageWriterExtension(AFormat: TBGRAImageFormat): String;
+begin
+  Result:= '';
+  if (DefaultBGRAImageWriter[AFormat] <> nil)
+  then Result:= StringReplace('*'+ExtensionSeparator+BGRAImageFormat[AFormat].Extensions,
+                              ';', ';*'+ExtensionSeparator, [rfReplaceAll]);
 end;
 
 function ResourceFile(AFilename: string): string;

--- a/bgrabitmap/bgrabitmaptypes.pas
+++ b/bgrabitmap/bgrabitmaptypes.pas
@@ -188,6 +188,11 @@ var
     AReader: TFPCustomImageReaderClass; AWriter: TFPCustomImageWriterClass;
     AddFPCHandlers: Boolean; const ATypeName: String; const AExtensions: String);
 
+  {** Get Registered Readers Extensions To Use in Masks List}
+  function BGRARegisteredImageReadersExtensions: String;
+  {** Get Registered Writers Extensions To Use in Masks List}
+  function BGRARegisteredImageWritersExtensions: String;
+
 type
   {* Possible options when loading an image }
   TBGRALoadingOption = (
@@ -1597,6 +1602,36 @@ begin
   BGRARegisterImageFormat(AFormat, ATypeName, AExtensions);
   BGRARegisterImageReader(AFormat, AReader, AddFPCHandlers);
   BGRARegisterImageWriter(AFormat, AWriter, AddFPCHandlers);
+end;
+
+function BGRARegisteredImageReadersExtensions: String;
+var
+   iFormat: TBGRAImageFormat;
+
+begin
+  Result:= '';
+  for iFormat:=Low(TBGRAImageFormat) to High(TBGRAImageFormat) do
+    if (DefaultBGRAImageReader[iFormat] <> nil)
+    then if (Result = '')
+         then Result:= '*.'+BGRAImageFormat[iFormat].Extensions
+         else Result:= Result+';'+BGRAImageFormat[iFormat].Extensions;
+
+  Result := StringReplace(Result, ';', ';*.', [rfReplaceAll]);
+end;
+
+function BGRARegisteredImageWritersExtensions: String;
+var
+   iFormat: TBGRAImageFormat;
+
+begin
+  Result:= '';
+  for iFormat:=Low(TBGRAImageFormat) to High(TBGRAImageFormat) do
+    if (DefaultBGRAImageWriter[iFormat] <> nil)
+    then if (Result = '')
+         then Result:= '*.'+BGRAImageFormat[iFormat].Extensions
+         else Result:= Result+';'+BGRAImageFormat[iFormat].Extensions;
+
+  Result := StringReplace(Result, ';', ';*.', [rfReplaceAll]);
 end;
 
 function ResourceFile(AFilename: string): string;

--- a/bgrabitmap/bgrabitmaptypes.pas
+++ b/bgrabitmap/bgrabitmaptypes.pas
@@ -1544,14 +1544,18 @@ procedure BGRARegisterImageReader(AFormat: TBGRAImageFormat; AReader: TFPCustomI
   AddFPCReader: Boolean);
 var
   typeName: String;
+
 begin
   DefaultBGRAImageReader[AFormat] := AReader;
   typeName := BGRAImageFormat[AFormat].TypeName;
 
-  { #note -oMaxM : we can't replace the Handler, only add it (doesn't make much sense) }
-  if AddFPCReader and (typeName <> '') and (ImageHandlers.ImageReader[typeName] = nil)
-    and (BGRAImageFormat[AFormat].Extensions <> '') then
+  if AddFPCReader and (typeName <> '') and (BGRAImageFormat[AFormat].Extensions <> '') then
+  begin
+    if (ImageHandlers.ImageReader[typeName] <> nil)
+    then ImageHandlers.UnregisterImageHandlers(typeName, True, False);
+
     ImageHandlers.RegisterImageReader(typeName, BGRAImageFormat[AFormat].Extensions, AReader);
+  end;
 end;
 
 procedure BGRARegisterImageReader(AFormat: TBGRAImageFormat; AReader: TFPCustomImageReaderClass;
@@ -1561,19 +1565,22 @@ begin
   BGRARegisterImageReader(AFormat, AReader, AddFPCReader);
 end;
 
-// registering FPC writer works only if the
 procedure BGRARegisterImageWriter(AFormat: TBGRAImageFormat; AWriter: TFPCustomImageWriterClass;
   AddFPCWriter: Boolean);
 var
   typeName: String;
+
 begin
   DefaultBGRAImageWriter[AFormat] := AWriter;
   typeName := BGRAImageFormat[AFormat].TypeName;
 
-  { #note -oMaxM : we can't replace the Handler, only add it (doesn't make much sense) }
-  if addFPCWriter and (typeName <> '') and (ImageHandlers.ImageWriter[typeName] = nil)
-    and (BGRAImageFormat[AFormat].Extensions <> '') then
+  if addFPCWriter and (typeName <> '') and (BGRAImageFormat[AFormat].Extensions <> '') then
+  begin
+    if (ImageHandlers.ImageWriter[typeName] <> nil)
+    then ImageHandlers.UnregisterImageHandlers(typeName, False, True);
+
     ImageHandlers.RegisterImageWriter(typeName, BGRAImageFormat[AFormat].Extensions, AWriter);
+  end;
 end;
 
 procedure BGRARegisterImageWriter(AFormat: TBGRAImageFormat; AWriter: TFPCustomImageWriterClass;

--- a/bgrabitmap/bgrabitmaptypes.pas
+++ b/bgrabitmap/bgrabitmaptypes.pas
@@ -27,7 +27,7 @@ uses
 {=== Miscellaneous types ===}
 
   {* Current version expressed as an integer with each part multiplied by 100 }
-  const BGRABitmapVersion = 11060400;
+  const BGRABitmapVersion = 11060500;
 
   {* String representation of the version, numbers separated by dots }
   function BGRABitmapVersionStr: string;

--- a/bgrabitmap/bgracustombitmap.inc
+++ b/bgrabitmap/bgracustombitmap.inc
@@ -836,6 +836,7 @@ end;
      procedure InplaceNormalize(ABounds: TRect; AEachChannel: boolean = True); overload; virtual; abstract;
      procedure ConvertToLinearRGB; virtual; abstract;
      procedure ConvertFromLinearRGB; virtual; abstract;
+     procedure ConvertToPaletteGrayscale; virtual; abstract;
      procedure SwapRedBlue; overload; virtual; abstract;
      procedure SwapRedBlue(ARect: TRect); overload; virtual; abstract;
      procedure GrayscaleToAlpha; virtual; abstract;

--- a/bgrabitmap/bgracustombitmap.inc
+++ b/bgrabitmap/bgracustombitmap.inc
@@ -814,6 +814,8 @@ end;
      procedure BlendImageOver(ADest: TRect; ASource: IBGRAScanner; AOffsetX, AOffsetY: integer; AOperation: TBlendOperation; AOpacity: byte = 255; ALinearBlend: boolean = false); overload; virtual; abstract;
      function Resample(newWidth, newHeight: integer;
        mode: TResampleMode = rmFineResample; ACopyProperties: Boolean=False): TBGRACustomBitmap; virtual; abstract;
+     function Resample(newResolutionUnit: TResolutionUnit; newWidth, newHeight: Single;
+       mode: TResampleMode = rmFineResample; ACopyProperties: Boolean=True): TBGRACustomBitmap; virtual; abstract;
 
      //masks
      procedure FillMask(x,y: integer; AMask: TCustomUniversalBitmap; ATexture: IBGRAScanner; ADrawMode: TDrawMode); overload; override;

--- a/bgrabitmap/bgradefaultbitmap.pas
+++ b/bgrabitmap/bgradefaultbitmap.pas
@@ -109,8 +109,12 @@ type
     function GetInternalPixel(x, y: integer): integer; override;
 
     {Image functions}
-    function FineResample(NewWidth, NewHeight: integer): TBGRACustomBitmap;
-    function SimpleStretch(NewWidth, NewHeight: integer): TBGRACustomBitmap;
+    function FineResample(NewWidth, NewHeight: integer): TBGRACustomBitmap; overload;
+    function FineResample(NewResolutionUnit: TResolutionUnit; NewWidth, NewHeight: Single): TBGRACustomBitmap; overload;
+
+    function SimpleStretch(NewWidth, NewHeight: integer): TBGRACustomBitmap; overload;
+    function SimpleStretch(NewResolutionUnit: TResolutionUnit; NewWidth, NewHeight: Single): TBGRACustomBitmap; overload;
+
     function CheckEmpty: boolean; override;
     function GetHasTransparentPixels: boolean; override;
     function GetHasSemiTransparentPixels: boolean; override;
@@ -601,7 +605,9 @@ type
     function MakeBitmapCopy(BackgroundColor: TColor; AMasked: boolean = False): TBitmap; override;
 
     function Resample(newWidth, newHeight: integer;
-      mode: TResampleMode = rmFineResample; ACopyProperties: Boolean=False): TBGRADefaultBitmap; override;
+      mode: TResampleMode = rmFineResample; ACopyProperties: Boolean=False): TBGRADefaultBitmap; overload; override;
+    function Resample(newResolutionUnit: TResolutionUnit; newWidth, newHeight: Single;
+      mode: TResampleMode = rmFineResample; ACopyProperties: Boolean=True): TBGRADefaultBitmap; overload; override;
     procedure Negative; override;
     procedure NegativeRect(ABounds: TRect); override;
     procedure LinearNegative; override;
@@ -4391,10 +4397,20 @@ begin
   Result := BGRAResample.FineResample(self, NewWidth, NewHeight, ResampleFilter);
 end;
 
-function TBGRADefaultBitmap.SimpleStretch(NewWidth, NewHeight: integer):
-TBGRACustomBitmap;
+function TBGRADefaultBitmap.FineResample(NewResolutionUnit: TResolutionUnit;
+  NewWidth, NewHeight: Single): TBGRACustomBitmap;
+begin
+  Result := BGRAResample.FineResample(self, NewResolutionUnit, NewWidth, NewHeight, ResampleFilter);
+end;
+
+function TBGRADefaultBitmap.SimpleStretch(NewWidth, NewHeight: integer): TBGRACustomBitmap;
 begin
   Result := BGRAResample.SimpleStretch(self, NewWidth, NewHeight);
+end;
+
+function TBGRADefaultBitmap.SimpleStretch(NewResolutionUnit: TResolutionUnit; NewWidth, NewHeight: Single): TBGRACustomBitmap;
+begin
+  Result := BGRAResample.SimpleStretch(self, NewResolutionUnit, NewWidth, NewHeight);
 end;
 
 function TBGRADefaultBitmap.Resample(newWidth, newHeight: integer;
@@ -4403,8 +4419,16 @@ begin
   case mode of
     rmFineResample: Result  := FineResample(newWidth, newHeight) as TBGRADefaultBitmap;
     rmSimpleStretch: Result := SimpleStretch(newWidth, newHeight) as TBGRADefaultBitmap;
-    else
-      Result := nil;
+  end;
+  if ACopyProperties and (Result<>nil) then CopyPropertiesTo(Result);
+end;
+
+function TBGRADefaultBitmap.Resample(newResolutionUnit: TResolutionUnit; newWidth, newHeight: Single;
+  mode: TResampleMode; ACopyProperties: Boolean=True): TBGRADefaultBitmap;
+begin
+  case mode of
+    rmFineResample: Result  := FineResample(newResolutionUnit, newWidth, newHeight) as TBGRADefaultBitmap;
+    rmSimpleStretch: Result := SimpleStretch(newResolutionUnit, newWidth, newHeight) as TBGRADefaultBitmap;
   end;
   if ACopyProperties and (Result<>nil) then CopyPropertiesTo(Result);
 end;

--- a/bgrabitmap/bgradefaultbitmap.pas
+++ b/bgrabitmap/bgradefaultbitmap.pas
@@ -30,6 +30,9 @@ type
     It implements most function to the exception from implementations specific to the
     widgetset.
   }
+
+  { TBGRADefaultBitmap }
+
   TBGRADefaultBitmap = class(TBGRACustomBitmap)
   private
     { Bounds checking which are shared by drawing functions. These functions check
@@ -615,6 +618,7 @@ type
     {$IFNDEF BGRABITMAP_CORE}function GetGrayscaleMaskFromAlpha: TGrayscaleMask;{$ENDIF}
     procedure ConvertToLinearRGB; override;
     procedure ConvertFromLinearRGB; override;
+    procedure ConvertToPaletteGrayscale; override;
 
     {Filters}
     {$IFNDEF BGRABITMAP_CORE}
@@ -4584,6 +4588,22 @@ begin
     p^.green := GammaCompressionTab[p^.green shl 8 + p^.green];
     p^.blue := GammaCompressionTab[p^.blue shl 8 + p^.blue];
     inc(p);
+  end;
+end;
+
+procedure TBGRADefaultBitmap.ConvertToPaletteGrayscale;
+var
+   newPal: TFPPalette;
+
+begin
+  try
+     newPal:= CreateGrayScalePalette;
+     UsePalette:= True;
+     Palette.Copy(newPal);
+     InplaceGrayscale(True);
+
+  finally
+     newPal.Free;
   end;
 end;
 

--- a/bgrabitmap/bgrapdf.pas
+++ b/bgrabitmap/bgrapdf.pas
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: LGPL-3.0-linking-exception
+{*******************************************************************************
+
+ (c) 2025 - Massimo Magnano
+
+********************************************************************************
+
+ PDF Document that allows you to specify ColorSpace and BitPerComponent of an image
+}
+
+unit BGRAPDF;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses Classes, SysUtils, fpPDF;
+
+type
+  TPDFColorSpace = (
+    csDeviceCMYK, //Device-dependent names
+    csDeviceGray,
+    csDeviceN,
+    csDeviceRGB,
+    csCalGray,     //Device-independent names
+    csCalRGB,
+    csLab,
+    csICCBased,
+    csIndexed,     //Special names
+    csPattern,
+    csSeparation);
+
+  { TBGRAPDFImageItem }
+
+  TBGRAPDFImageItem = class(TPDFImageItem)
+  private
+    FBitsPerComponent: Integer;
+    FColorSpace: TPDFColorSpace;
+  public
+    constructor Create(ACollection: TCollection); override;
+
+    property ColorSpace: TPDFColorSpace read FColorSpace write FColorSpace;
+    property BitsPerComponent: Integer read FBitsPerComponent write FBitsPerComponent;
+  end;
+
+  { TBGRAPDFDocument }
+
+  TBGRAPDFDocument = class(TPDFDocument)
+  protected
+    function CreatePDFImages: TPDFImages; override;
+    procedure CreateImageEntry(ImgWidth, ImgHeight, NumImg: integer;
+                               out ImageDict: TPDFDictionary); override;
+
+  end;
+
+const
+  PDFColorSpace : array[TPDFColorSpace] of String = (
+      'DeviceCMYK', //Device-dependent names
+      'DeviceGray',
+      'DeviceN',
+      'DeviceRGB',
+      'CalGray',     //Device-independent names
+      'CalRGB',
+      'Lab',
+      'ICCBased',
+      'Indexed',     //Special names
+      'Pattern',
+      'Separation');
+
+
+implementation
+
+type
+    //MaxM: Only to have access to protected methods,
+    //      What's the point of making Add methods protected remains a mystery?
+    TBGRAPDFDictionary = class(TPDFDictionary)
+    end;
+
+{ TBGRAPDFImageItem }
+
+constructor TBGRAPDFImageItem.Create(ACollection: TCollection);
+begin
+  inherited Create(ACollection);
+
+  FColorSpace:= csDeviceRGB;
+  FBitsPerComponent:= 8;
+end;
+
+{ TBGRAPDFDocument }
+
+function TBGRAPDFDocument.CreatePDFImages: TPDFImages;
+begin
+  Result:=TPDFImages.Create(Self, TBGRAPDFImageItem);
+end;
+
+procedure TBGRAPDFDocument.CreateImageEntry(ImgWidth, ImgHeight, NumImg: integer;
+                                            out ImageDict: TPDFDictionary);
+var
+  N: TPDFName;
+  ADict: TPDFDictionary;
+  i: integer;
+  lXRef: integer;
+  curImg: TBGRAPDFImageItem;
+
+begin
+  //MaxM: There is no way to Replace ColorSpace Dictionary Item, the Name property is readonly for no reason
+  //      So we copy the entire code from fpc source
+
+  curImg:= TBGRAPDFImageItem(Images[NumImg]);
+
+  lXRef := GlobalXRefCount; // reference to be used later
+
+  ImageDict:=CreateGlobalXRef.Dict;
+  TBGRAPDFDictionary(ImageDict).AddName('Type','XObject');
+  TBGRAPDFDictionary(ImageDict).AddName('Subtype','Image');
+  TBGRAPDFDictionary(ImageDict).AddInteger('Width',ImgWidth);
+  TBGRAPDFDictionary(ImageDict).AddInteger('Height',ImgHeight);
+
+  if (curImg <> nil)
+  then begin
+         TBGRAPDFDictionary(ImageDict).AddName('ColorSpace', PDFColorSpace[curImg.FColorSpace]);
+         TBGRAPDFDictionary(ImageDict).AddInteger('BitsPerComponent', curImg.BitsPerComponent);
+       end
+  else begin
+         TBGRAPDFDictionary(ImageDict).AddName('ColorSpace','DeviceRGB');
+         TBGRAPDFDictionary(ImageDict).AddInteger('BitsPerComponent',8);
+       end;
+
+  N:=CreateName('I'+IntToStr(NumImg)); // Needed later
+  TBGRAPDFDictionary(ImageDict).AddElement('Name',N);
+
+  // now find where we must add the image xref - we are looking for "Resources"
+  for i := 1 to GlobalXRefCount-1 do
+  begin
+    ADict:=GlobalXRefs[i].Dict;
+    if ADict.ElementCount > 0 then
+    begin
+      if (ADict.Values[0] is TPDFName) and ((ADict.Values[0] as TPDFName).Name='Page') then
+      begin
+        ADict:=ADict.ValueByName('Resources') as TPDFDictionary;
+        ADict:=TPDFDictionary(ADict.FindValue('XObject'));
+        if Assigned(ADict) then
+        begin
+          TBGRAPDFDictionary(ADict).AddReference(N.Name, lXRef);
+        end;
+      end;
+    end;
+  end;
+end;
+
+
+end.
+

--- a/bgrabitmap/bgrapdf.pas
+++ b/bgrabitmap/bgrapdf.pas
@@ -119,7 +119,7 @@ begin
   if (curImg <> nil)
   then begin
          TBGRAPDFDictionary(ImageDict).AddName('ColorSpace', PDFColorSpace[curImg.FColorSpace]);
-         TBGRAPDFDictionary(ImageDict).AddInteger('BitsPerComponent', curImg.BitsPerComponent);
+         TBGRAPDFDictionary(ImageDict).AddInteger('BitsPerComponent', curImg.FBitsPerComponent);
        end
   else begin
          TBGRAPDFDictionary(ImageDict).AddName('ColorSpace','DeviceRGB');

--- a/bgrabitmap/bgrareadjpeg.pas
+++ b/bgrabitmap/bgrareadjpeg.pas
@@ -46,6 +46,17 @@ type
     {$ENDIF}
 
     function InternalCheck(Str: TStream): boolean; override;
+
+  published
+    //property CompressInfo : jpeg_decompress_struct; rw
+    property Orientation; //: TExifOrientation; r
+    property ProgressiveEncoding; //: boolean;  r
+    property GrayScale;           //: boolean;  r
+    property Smoothing;           //: boolean;  rw
+    property Performance;         //: TJPEGReadPerformance; rw
+    property Scale;               //: TJPEGScale; rw
+    property MinWidth;            //: integer rw
+    property MinHeight;           //: integer rw
   end;
 
 implementation

--- a/bgrabitmap/bgrareadjpeg.pas
+++ b/bgrabitmap/bgrareadjpeg.pas
@@ -49,7 +49,9 @@ type
 
   published
     //property CompressInfo : jpeg_decompress_struct; rw
-    property Orientation; //: TExifOrientation; r
+    {$IF FPC_FULLVERSION>=30301}
+    property Orientation;         //: TExifOrientation; r
+    {$ENDIF}
     property ProgressiveEncoding; //: boolean;  r
     property GrayScale;           //: boolean;  r
     property Smoothing;           //: boolean;  rw

--- a/bgrabitmap/bgrareadpcx.pas
+++ b/bgrabitmap/bgrareadpcx.pas
@@ -22,11 +22,17 @@ uses FPImage, BGRAClasses, SysUtils, FPReadPCX;
 
 type
   { Reader for PCX image format }
+
+  { TBGRAReaderPCX }
+
   TBGRAReaderPCX = class(TFPReaderPCX)
   protected
     FBuffer: packed array of byte;
     FBufferPos, FBufferSize: integer;
     FBufferStream: TStream;
+
+    function GetBitsPerPixel: byte;
+    function GetGrayScale: Boolean;
     function InternalCheck(Stream: TStream): boolean; override;
     procedure ReadResolutionValues(Img: TFPCustomImage);
     procedure InternalRead(Stream: TStream; Img: TFPCustomImage); override;
@@ -35,6 +41,11 @@ type
     procedure InitReadBuffer(AStream: TStream; ASize: integer);
     procedure CloseReadBuffer;
     function GetNextBufferByte: byte;
+
+  published
+    property GrayScale: Boolean read GetGrayScale;
+    property BitsPerPixel: byte read GetBitsPerPixel; // [1, 4, 8, 24]
+    property Compressed;  //: boolean r;
   end;
 
 implementation
@@ -234,6 +245,16 @@ begin
     end else
       result := 0;
   end;
+end;
+
+function TBGRAReaderPCX.GetBitsPerPixel: byte;
+begin
+  Result:= Header.BitsPerPixel;
+end;
+
+function TBGRAReaderPCX.GetGrayScale: Boolean;
+begin
+  Result:= (Header.PaletteType = 2);
 end;
 
 function TBGRAReaderPCX.InternalCheck({%H-}Stream: TStream): boolean;

--- a/bgrabitmap/bgrareadtga.pas
+++ b/bgrabitmap/bgrareadtga.pas
@@ -30,10 +30,12 @@ type
     function GetBitsPerPixel: byte;
     function GetCompressed: boolean;
     function GetGrayScale: Boolean;
+
   protected
     FBuffer: packed array of byte;
     FBufferPos, FBufferSize: integer;
     FBufferStream: TStream;
+
     procedure ReadScanLine({%H-}Row: Integer; Stream: TStream); override;
     procedure WriteScanLine(Row : Integer; Img : TFPCustomImage); override;
     procedure InitReadBuffer(AStream: TStream; ASize: integer);
@@ -50,6 +52,11 @@ Implementation
 
 uses BGRABitmapTypes, targacmn;
 
+type
+  //Workaround to access the inherited Compressed variable with the same name of property
+  TFPReaderTarga_Access = class(TFPReaderTarga)
+  end;
+
 function TBGRAReaderTarga.GetBitsPerPixel: byte;
 begin
   Result:= BytesPerPixel; //MaxM: I think there is an error in var name 32byte for pixel it's not realistic
@@ -57,7 +64,7 @@ end;
 
 function TBGRAReaderTarga.GetCompressed: boolean;
 begin
-  Result:= TFPReaderTarga(Self).Compressed;
+  Result:= TFPReaderTarga_Access(Self).Compressed;
 end;
 
 function TBGRAReaderTarga.GetGrayScale: Boolean;

--- a/bgrabitmap/bgrareadtga.pas
+++ b/bgrabitmap/bgrareadtga.pas
@@ -22,7 +22,14 @@ uses FPReadTGA, FPimage, BGRAClasses;
 
 type
   { Reader for TGA image format }
+
+  { TBGRAReaderTarga }
+
   TBGRAReaderTarga = class (TFPReaderTarga)
+  private
+    function GetBitsPerPixel: byte;
+    function GetCompressed: boolean;
+    function GetGrayScale: Boolean;
   protected
     FBuffer: packed array of byte;
     FBufferPos, FBufferSize: integer;
@@ -32,11 +39,31 @@ type
     procedure InitReadBuffer(AStream: TStream; ASize: integer);
     procedure CloseReadBuffer;
     function GetNextBufferByte: byte;
+
+  published
+    property GrayScale: Boolean read GetGrayScale;
+    property BitsPerPixel: byte read GetBitsPerPixel; // [8, 16, 24, 32]
+    property Compressed: boolean read GetCompressed;
   end;
 
 Implementation
 
 uses BGRABitmapTypes, targacmn;
+
+function TBGRAReaderTarga.GetBitsPerPixel: byte;
+begin
+  Result:= BytesPerPixel; //MaxM: I think there is an error in var name 32byte for pixel it's not realistic
+end;
+
+function TBGRAReaderTarga.GetCompressed: boolean;
+begin
+  Result:= TFPReaderTarga(Self).Compressed;
+end;
+
+function TBGRAReaderTarga.GetGrayScale: Boolean;
+begin
+  Result:= (Header.ImgType = TARGA_GRAY_IMAGE);
+end;
 
 procedure TBGRAReaderTarga.ReadScanLine(Row: Integer; Stream: TStream);
 Var
@@ -84,7 +111,7 @@ begin
   end;
 end;
 
-Procedure TBGRAReaderTarga.WriteScanLine(Row : Integer; Img : TFPCustomImage);
+procedure TBGRAReaderTarga.WriteScanLine(Row: Integer; Img: TFPCustomImage);
 Var
   Col : Integer;
   Value   : UInt32or64;

--- a/bgrabitmap/bgraresample.pas
+++ b/bgrabitmap/bgraresample.pas
@@ -136,7 +136,7 @@ begin
   if (NewResolutionUnit = ruNone)
   then Result:= SimpleStretch(bmp, Trunc(NewWidth), Trunc(NewHeight))
   else begin
-         ResolutionUnitConvert(NewResolutionUnit, bmp.ResolutionUnit,
+         ResolutionConvertSize(NewResolutionUnit, bmp.ResolutionUnit,
                                NewWidth, newHeight, bmp.ResolutionX, bmp.ResolutionY);
          pixelWidth:= Round(NewWidth*bmp.ResolutionX);
          pixelHeight:= Round(NewHeight*bmp.ResolutionY);
@@ -1350,7 +1350,7 @@ begin
   if (NewResolutionUnit = ruNone)
   then Result:= FineResample(bmp, Trunc(NewWidth), Trunc(NewHeight), ResampleFilter)
   else begin
-         ResolutionUnitConvert(NewResolutionUnit, bmp.ResolutionUnit,
+         ResolutionConvertSize(NewResolutionUnit, bmp.ResolutionUnit,
                                NewWidth, newHeight, bmp.ResolutionX, bmp.ResolutionY);
          pixelWidth:= Round(NewWidth*bmp.ResolutionX);
          pixelHeight:= Round(NewHeight*bmp.ResolutionY);

--- a/bgrabitmap/bgrasvgtype.pas
+++ b/bgrabitmap/bgrasvgtype.pas
@@ -2611,7 +2611,7 @@ end;
 procedure TSVGElement.SetVisible(AValue: boolean);
 begin
   if AValue <> Visible then
-    Style['display'] := 'inline';
+    Style['display'] := BoolToStr(AValue, 'inline', 'none');
   FDomElem.RemoveAttribute('display');
 end;
 

--- a/bgrabitmap/bgrathumbnail.pas
+++ b/bgrabitmap/bgrathumbnail.pas
@@ -174,6 +174,8 @@ begin
         reader := nil;
         try
           reader := CreateBGRAImageReader(ff);
+          if reader is TBGRAReaderBMP then
+            TBGRAReaderBMP(reader).TransparencyOption:= toAuto;
           result := GetStreamThumbnail(AStream, reader, AWidth, AHeight, ABackColor, ACheckers, ADest);
         finally
           reader.Free;

--- a/bgrabitmap/bgrawritebmp.pas
+++ b/bgrabitmap/bgrawritebmp.pas
@@ -14,21 +14,43 @@ interface
 
 uses SysUtils, Classes, FPImage, FPWriteBMP, BGRABitmapTypes;
 
+const
+   BMP_BitsValidValues: array[0..6] of byte = (1,4,8,15,16,24,32);
+
 type
-  {* Extends the TFPWriterBMP to save resolution }
+  { TBGRAWriterBMP }
+
   TBGRAWriterBMP = class (TFPWriterBMP)
   protected
-    {$IF FPC_FULLVERSION<30203}
+    FGrayScale: boolean;
+
+    procedure SetGrayScale(AValue: boolean); virtual;
+
     function SaveHeader(Stream:TStream; Img: TFPCustomImage):boolean; override;
-    {$ENDIF}
+    procedure InternalWrite(Stream:TStream; Img: TFPCustomImage); override;
+
+  public
+    constructor Create; override;
+
+  published
+    property GrayScale: boolean read FGrayscale write SetGrayScale;
+    property BitsPerPixel;  //: byte rw [1,4,8,15,16,24,32];
+    property RLECompress;   //: boolean rw;
   end;
 
 
 implementation
 
-{$IF FPC_FULLVERSION<30203}
+procedure TBGRAWriterBMP.SetGrayScale(AValue: boolean);
+begin
+  if FGrayscale=AValue then Exit;
+  FGrayscale:=AValue;
+  BitsPerPixel:= 8;
+end;
+
 function TBGRAWriterBMP.SaveHeader(Stream:TStream; Img : TFPCustomImage):boolean;
 begin
+  {$IF FPC_FULLVERSION<30203}
   if (Img is TCustomUniversalBitmap) then
   with TCustomUniversalBitmap(Img) do
   begin
@@ -36,10 +58,37 @@ begin
     Self.XPelsPerMeter :=Trunc(ResolutionX*100);
     Self.YPelsPerMeter :=Trunc(ResolutionY*100);
   end;
+  {$ENDIF}
 
-  Result:=Inherited SaveHeader(Stream, Img);
+  Result:= inherited SaveHeader(Stream, Img);
 end;
-{$ENDIF}
+
+procedure TBGRAWriterBMP.InternalWrite(Stream: TStream; Img: TFPCustomImage);
+var
+   newPal: TFPPalette;
+
+begin
+  if FGrayscale then
+  begin
+    try
+       newPal:= CreateGrayScalePalette;
+       Img.UsePalette:= True;
+       Img.Palette.Copy(newPal);
+       newPal.Free;
+    except
+       newPal.Free;
+    end;
+  end;
+
+  inherited InternalWrite(Stream, Img);
+end;
+
+constructor TBGRAWriterBMP.Create;
+begin
+  inherited Create;
+
+  FGrayScale:= False;
+end;
 
 initialization
   BGRARegisterImageWriter(ifBMP, TBGRAWriterBMP, True, 'BMP Format', 'bmp');

--- a/bgrabitmap/bgrawritejpeg.pas
+++ b/bgrabitmap/bgrawritejpeg.pas
@@ -31,6 +31,12 @@ type
     procedure WriteResolutionValues(Img: TFPCustomImage); virtual;
     procedure InternalWrite(Str: TStream; Img: TFPCustomImage); override;
     {$ENDIF}
+
+  published
+    //property CompressInfo : jpeg_compress_struct; rw
+    property CompressionQuality;  //: TFPJPEGCompressionQuality; rw
+    property ProgressiveEncoding; //: boolean; rw
+    property GrayScale;           //: boolean; rw
   end;
 
 implementation

--- a/bgrabitmap/bgrawritepcx.pas
+++ b/bgrabitmap/bgrawritepcx.pas
@@ -21,6 +21,13 @@ type
     {$IF FPC_FULLVERSION<30203}
     function SaveHeader(Stream: TStream; Img: TFPCustomImage): boolean; override;
     {$ENDIF}
+
+  published
+    // MaxM: TO-DO TFPWriterPCX alway write at 8 BitsPerPixel
+    //             It might be useful to write the other modes
+    //property GrayScale: Boolean
+    //property BitsPerPixel: byte // [1, 4, 8, 24]
+    property Compressed;  //: boolean rw;
   end;
 
 implementation

--- a/bgrabitmap/bgrawritepng.pas
+++ b/bgrabitmap/bgrawritepng.pas
@@ -132,10 +132,12 @@ type
         AImage:TFPCustomImage;  // default image (may be as well in the animation)
         AAnimation: TPNGArrayOfFrameToWrite;
         ARepeatCount: integer = 0); // loop count (0 for infinite loop)
-      property GrayScale : boolean read FGrayscale write FGrayScale;
       property Indexed : boolean read FIndexed write FIndexed;
       property CustomPalette: TFPPalette read FCustomPalette write FCustomPalette;
       property CompressedText : boolean read FCompressedText write FCompressedText;
+
+    published
+      property GrayScale : boolean read FGrayscale write FGrayScale;
       property WordSized : boolean read FWordSized write FWordSized;
       property CompressionLevel : TCompressionLevel read FCompressionLevel write FCompressionLevel;
   end;

--- a/bgrabitmap/bgrawritetiff.pas
+++ b/bgrabitmap/bgrawritetiff.pas
@@ -98,6 +98,8 @@ type
     procedure Clear;
     procedure AddImage(Img: TFPCustomImage);
     procedure SaveToStream(Stream: TStream);
+
+  published
     property SaveCMYKAsRGB: boolean read FSaveCMYKAsRGB write FSaveCMYKAsRGB;
     property PremultiplyRGB: boolean read FPremultiplyRGB write FPremultiplyRGB;
   end;

--- a/bgrabitmap/bgrawritetiff.pas
+++ b/bgrabitmap/bgrawritetiff.pas
@@ -61,14 +61,19 @@ type
   end;
 
   {* Extends the TFPCustomImageWriter to write the TIFF image format }
+
+  { TBGRAWriterTiff }
+
   TBGRAWriterTiff = class(TFPCustomImageWriter)
-  private
+  protected
+    FCompression: boolean;
     FPremultiplyRGB: boolean;
     FSaveCMYKAsRGB: boolean;
     fStartPos: Int64;
     FEntries: TFPList; // list of TFPList of TTiffWriterEntry
     fStream: TStream;
     fPosition: LongWord;
+
     procedure ClearEntries;
     procedure WriteTiff;
     procedure WriteHeader;
@@ -79,7 +84,9 @@ type
     procedure WriteBuf(var Buf; Count: LongWord);
     procedure WriteWord(w: Word);
     procedure WriteDWord(d: LongWord);
-  protected
+
+    procedure SetImgExtrasFromProperties(Img: TFPCustomImage); virtual;
+
     procedure InternalWrite(Stream: TStream; Img: TFPCustomImage); override;
     procedure AddEntryString(Tag: word; const s: string);
     procedure AddEntryShort(Tag: word; Value: Word);
@@ -100,6 +107,7 @@ type
     procedure SaveToStream(Stream: TStream);
 
   published
+    property Compression: boolean read FCompression write FCompression; //MaxM: at this time only None or ZLib, maybe a enum
     property SaveCMYKAsRGB: boolean read FSaveCMYKAsRGB write FSaveCMYKAsRGB;
     property PremultiplyRGB: boolean read FPremultiplyRGB write FPremultiplyRGB;
   end;
@@ -228,6 +236,13 @@ begin
   if fStream<>nil then
     fStream.WriteDWord(d);
   inc(fPosition,4);
+end;
+
+procedure TBGRAWriterTiff.SetImgExtrasFromProperties(Img: TFPCustomImage);
+begin
+  if FCompression
+  then Img.Extra[TiffCompression]:= IntToStr(TiffCompressionDeflateZLib)
+  else Img.Extra[TiffCompression]:= IntToStr(TiffCompressionNone);
 end;
 
 procedure TBGRAWriterTiff.ClearEntries;
@@ -404,7 +419,7 @@ var
   IFD: TTiffIFD;
   GrayBits, RedBits, GreenBits, BlueBits, AlphaBits: Word;
   ImgWidth, ImgHeight: LongWord;
-  Compression: Word;
+  curCompression: Word;
   BitsPerSample: array[0..3] of Word;
   SamplesPerPixel: Integer;
   ExtraSample, defaultColorBits: Word;
@@ -574,7 +589,10 @@ begin
     CurEntries:=TFPList.Create;
     FEntries.Add(CurEntries);
 
+    SetImgExtrasFromProperties(Img);
+
     IFD.ReadFPImgExtras(Img);
+
     if SaveCMYKAsRGB and (IFD.PhotoMetricInterpretation=5) then
       IFD.PhotoMetricInterpretation:=2;
     if (Img.Extra[TiffPhotoMetric]='') and (Img is TCustomUniversalBitmap) then
@@ -583,8 +601,8 @@ begin
         IFD.PhotoMetricInterpretation := 8;
     end;
 
-    if Img.Extra[TiffCompression]='' then
-      IFD.Compression:= TiffCompressionDeflateZLib;
+//    if Img.Extra[TiffCompression]='' then
+//      IFD.Compression:= TiffCompressionDeflateZLib;
 
     if not (IFD.PhotoMetricInterpretation in [0,1,2,8,9]) then
       TiffError('PhotoMetricInterpretation="'+Img.Extra[TiffPhotoMetric]+'" not supported');
@@ -645,15 +663,15 @@ begin
 
     ImgWidth:=Img.Width;
     ImgHeight:=Img.Height;
-    Compression:=IFD.Compression;
-    case Compression of
+    curCompression:=IFD.Compression;
+    case curCompression of
     TiffCompressionNone,
     TiffCompressionDeflateZLib: ;
     else
       {$ifdef FPC_DEBUG_IMAGE}
       writeln('TBGRAWriterTiff.AddImage unsupported compression '+TiffCompressionName(Compression)+', using deflate instead.');
       {$endif}
-      Compression:=TiffCompressionDeflateZLib;
+      curCompression:=TiffCompressionDeflateZLib;
     end;
 
     if IFD.Orientation in [1..4] then begin
@@ -680,7 +698,7 @@ begin
     // required meta entries
     AddEntryShortOrLong(256,ImgWidth);
     AddEntryShortOrLong(257,ImgHeight);
-    AddEntryShort(259,Compression);
+    AddEntryShort(259,curCompression);
     AddEntryShort(262,IFD.PhotoMetricInterpretation);
     AddEntryShort(274,IFD.Orientation);
     AddEntryShort(296,IFD.ResolutionUnit);
@@ -850,7 +868,7 @@ begin
         end;
 
         // compress
-        case Compression of
+        case curCompression of
         TiffCompressionDeflateZLib: EncodeDeflate(Chunk,ChunkBytes);
         end;
 
@@ -977,6 +995,7 @@ constructor TBGRAWriterTiff.Create;
 begin
   inherited Create;
   FEntries:=TFPList.Create;
+  FCompression:= true;
   FSaveCMYKAsRGB:= true;
   FPremultiplyRGB:= false;
 end;

--- a/bgrabitmap/bgrawritewebp.pas
+++ b/bgrabitmap/bgrawritewebp.pas
@@ -17,14 +17,16 @@ type
     FLossless: boolean;
     FQualityPercent: Single;
     procedure InternalWrite(Stream: TStream; Img: TFPCustomImage); override;
+
   public
     constructor Create; override;
+
+  published
     {** Defines the quality when saving the file, 100 being the maximum but not
         necessarily lossless }
     property QualityPercent: single read FQualityPercent write FQualityPercent;
     {** If Lossless is set to True, the _QualityPercent_ property is ignored }
     property Lossless: boolean read FLossless write FLossless;
-
   end;
 
 implementation

--- a/bgrabitmap/geometrytypes.inc
+++ b/bgrabitmap/geometrytypes.inc
@@ -220,12 +220,19 @@ type
     ruPixelsPerCentimeter);
 {$ENDIF}
 
-   function ResolutionUnitConvert(ValueUnit, ResultUnit: TResolutionUnit;
+   {** Convert Size from/to Cm, Inch, Pixels }
+   function ResolutionConvertSize(ValueUnit, ResultUnit: TResolutionUnit;
                                   Value: Single; Resolution: Single=96): Single; overload;
-   procedure ResolutionUnitConvert(ValueUnit, ResultUnit: TResolutionUnit;
+   procedure ResolutionConvertSize(ValueUnit, ResultUnit: TResolutionUnit;
                                    var XValue, YValue: Single;
                                    XResolution: Single=96; YResolution: Single=96); overload;
 
+   {** Convert Pixels from/to pixel/Cm, pixel/Inch }
+   function ResolutionConvertPixels(ValueUnit, ResultUnit: TResolutionUnit;
+                                    Value: Single; Resolution: Single=96): Single; overload;
+   procedure ResolutionConvertPixels(ValueUnit, ResultUnit: TResolutionUnit;
+                                     var XValue, YValue: Single;
+                                     XResolution: Single=96; YResolution: Single=96); overload;
 
 type
   {* Pointer to a TRectF structure }
@@ -1567,15 +1574,15 @@ end;
 
 {********************** Size functions **************************}
 
-function ResolutionUnitConvert(ValueUnit, ResultUnit: TResolutionUnit;
+function ResolutionConvertSize(ValueUnit, ResultUnit: TResolutionUnit;
                                Value: Single; Resolution: Single): Single;
 begin
   if (ValueUnit <> ResultUnit) then
   begin
     if (ValueUnit = ruNone)
-    then Result:= Value/Resolution
+    then Result:= Value/Resolution                     //from Pixels to ResultUnit
     else Case ResultUnit of
-           ruNone: Result:= Value*Resolution;
+           ruNone: Result:= Value*Resolution;          //from ValueUnit to Pixels
            ruPixelsPerInch : Result:= Value/2.54;      //from Cm to Inch
            ruPixelsPerCentimeter: Result:= Value*2.54; //from Inch to Cm
          end;
@@ -1583,7 +1590,7 @@ begin
   else Result:= Value;
 end;
 
-procedure ResolutionUnitConvert(ValueUnit, ResultUnit: TResolutionUnit;
+procedure ResolutionConvertSize(ValueUnit, ResultUnit: TResolutionUnit;
                                 var XValue, YValue: Single;
                                 XResolution: Single; YResolution: Single);
 begin
@@ -1591,11 +1598,11 @@ begin
   begin
     if (ValueUnit = ruNone)
     then begin
-           XValue:= XValue/XResolution;
+           XValue:= XValue/XResolution; //from Pixels to ResultUnit
            XValue:= YValue/YResolution;
          end
     else Case ResultUnit of
-           ruNone: begin
+           ruNone: begin                //from ValueUnit to Pixels
              XValue:= XValue*XResolution;
              XValue:= YValue*YResolution;
            end;
@@ -1606,6 +1613,50 @@ begin
            ruPixelsPerCentimeter: begin //from Inch to Cm
              XValue:= XValue*2.54;
              YValue:= YValue*2.54;
+           end;
+         end;
+  end;
+end;
+
+function ResolutionConvertPixels(ValueUnit, ResultUnit: TResolutionUnit;
+                                 Value: Single; Resolution: Single): Single;
+begin
+  if (ValueUnit <> ResultUnit) then
+  begin
+    if (ValueUnit = ruNone)
+    then Result:= Value/Resolution                     //from Pixels to ResultUnit
+    else Case ResultUnit of
+           ruNone: Result:= Value*Resolution;          //from ValueUnit to Pixels
+           ruPixelsPerInch : Result:= Value*2.54;      //from pixel/Cm to pixel/Inch
+           ruPixelsPerCentimeter: Result:= Value/2.54; //from pixel/Inch to pixel/Cm
+         end;
+  end
+  else Result:= Value;
+end;
+
+procedure ResolutionConvertPixels(ValueUnit, ResultUnit: TResolutionUnit;
+                                  var XValue, YValue: Single;
+                                  XResolution: Single; YResolution: Single);
+begin
+  if (ValueUnit <> ResultUnit) then
+  begin
+    if (ValueUnit = ruNone)
+    then begin
+           XValue:= XValue/XResolution; //from Pixels to ResultUnit
+           XValue:= YValue/YResolution;
+         end
+    else Case ResultUnit of
+           ruNone: begin                //from ValueUnit to Pixels
+             XValue:= XValue*XResolution;
+             XValue:= YValue*YResolution;
+           end;
+           ruPixelsPerInch : begin      //from pixel/Cm to pixel/Inch
+             XValue:= XValue*2.54;
+             YValue:= YValue*2.54;
+           end;
+           ruPixelsPerCentimeter: begin //from pixel/Inch to pixel/Cm
+             XValue:= XValue/2.54;
+             YValue:= YValue/2.54;
            end;
          end;
   end;

--- a/bgrabitmap/geometrytypes.inc
+++ b/bgrabitmap/geometrytypes.inc
@@ -209,6 +209,24 @@ type
   end;
 {$ENDIF}
 
+{$IF FPC_FULLVERSION<30203}
+  {* Unit used to specify the resolution of a bitmap }
+  TResolutionUnit = (
+    {** No unit used, only aspect ratio specified }
+    ruNone,
+    {** Pixels per inch (DPI) }
+    ruPixelsPerInch,
+    {** Pixels per centimeters }
+    ruPixelsPerCentimeter);
+{$ENDIF}
+
+   function ResolutionUnitConvert(ValueUnit, ResultUnit: TResolutionUnit;
+                                  Value: Single; Resolution: Single=96): Single; overload;
+   procedure ResolutionUnitConvert(ValueUnit, ResultUnit: TResolutionUnit;
+                                   var XValue, YValue: Single;
+                                   XResolution: Single=96; YResolution: Single=96); overload;
+
+
 type
   {* Pointer to a TRectF structure }
   PRectF = ^TRectF;
@@ -1545,6 +1563,52 @@ begin
   result.top := top;
   result.right := left+width;
   result.bottom := top+height;
+end;
+
+{********************** Size functions **************************}
+
+function ResolutionUnitConvert(ValueUnit, ResultUnit: TResolutionUnit;
+                               Value: Single; Resolution: Single): Single;
+begin
+  if (ValueUnit <> ResultUnit) then
+  begin
+    if (ValueUnit = ruNone)
+    then Result:= Value/Resolution
+    else Case ResultUnit of
+           ruNone: Result:= Value*Resolution;
+           ruPixelsPerInch : Result:= Value/2.54;      //from Cm to Inch
+           ruPixelsPerCentimeter: Result:= Value*2.54; //from Inch to Cm
+         end;
+  end
+  else Result:= Value;
+end;
+
+procedure ResolutionUnitConvert(ValueUnit, ResultUnit: TResolutionUnit;
+                                var XValue, YValue: Single;
+                                XResolution: Single; YResolution: Single);
+begin
+  if (ValueUnit <> ResultUnit) then
+  begin
+    if (ValueUnit = ruNone)
+    then begin
+           XValue:= XValue/XResolution;
+           XValue:= YValue/YResolution;
+         end
+    else Case ResultUnit of
+           ruNone: begin
+             XValue:= XValue*XResolution;
+             XValue:= YValue*YResolution;
+           end;
+           ruPixelsPerInch : begin      //from Cm to Inch
+             XValue:= XValue/2.54;
+             YValue:= YValue/2.54;
+           end;
+           ruPixelsPerCentimeter: begin //from Inch to Cm
+             XValue:= XValue*2.54;
+             YValue:= YValue*2.54;
+           end;
+         end;
+  end;
 end;
 
 { Make a pen style. Need an even number of values. See TBGRAPenStyle }

--- a/bgrabitmap/unibitmap.inc
+++ b/bgrabitmap/unibitmap.inc
@@ -80,17 +80,6 @@ type
     PixelCenteredCoords: boolean;
   end;
 
-  {$IF FPC_FULLVERSION<30203}
-  {* Unit used to specify the resolution of a bitmap }
-  TResolutionUnit = (
-    {** No unit used, only aspect ratio specified }
-    ruNone,
-    {** Pixels per inch (DPI) }
-    ruPixelsPerInch,
-    {** Pixels per centimeters }
-    ruPixelsPerCentimeter);
-  {$ENDIF}
-
   {* Base class for the universal bitmap (of any colorspace) }
 
   { TCustomUniversalBitmap }

--- a/bgrabitmap/unibitmap.inc
+++ b/bgrabitmap/unibitmap.inc
@@ -229,13 +229,16 @@ type
     {** Clear all channels of transparent pixels }
     procedure ClearTransparentPixels; virtual;
 
+    {** Initializes a brush that erases (reduces the alpha channel) }
     class procedure EraseBrush(out {%H-}ABrush: TUniversalBrush; {%H-}AAlpha: Word); virtual;
+    {** Initializes a brush that sets the alpha channel }
     class procedure AlphaBrush(out {%H-}ABrush: TUniversalBrush; {%H-}AAlpha: Word); virtual;
     procedure SolidBrushBGRA(out ABrush: TUniversalBrush; ARed,AGreen,ABlue,AAlpha: Byte; ADrawMode: TDrawMode = dmDrawWithTransparency); overload; virtual;
     procedure SolidBrushBGRA(out ABrush: TUniversalBrush; AColor: TBGRAPixel; ADrawMode: TDrawMode = dmDrawWithTransparency); overload; virtual;
     procedure SolidBrushExpanded(out ABrush: TUniversalBrush; ARed,AGreen,ABlue,AAlpha: Word; ADrawMode: TDrawMode = dmDrawWithTransparency); overload; virtual;
     procedure SolidBrushExpanded(out ABrush: TUniversalBrush; AColor: TExpandedPixel; ADrawMode: TDrawMode = dmDrawWithTransparency); overload; virtual;
     procedure SolidBrushIndirect(out ABrush: TUniversalBrush; AColor: Pointer; ADrawMode: TDrawMode = dmDrawWithTransparency); virtual;
+    {** Initializes a brush that fills a texture from a scanner }
     class procedure ScannerBrush(out {%H-}ABrush: TUniversalBrush; {%H-}AScanner: IBGRAScanner; {%H-}ADrawMode: TDrawMode = dmDrawWithTransparency;
                                  {%H-}AOffsetX: integer = 0; {%H-}AOffsetY: integer = 0); virtual;
     class procedure MaskBrush(out {%H-}ABrush: TUniversalBrush; {%H-}AScanner: IBGRAScanner;

--- a/bgrabitmap/unibitmapgeneric.inc
+++ b/bgrabitmap/unibitmapgeneric.inc
@@ -27,8 +27,11 @@ type
     function Equals(const comp: TPixel): boolean; overload;
     function GetDifferenceBounds(ABitmap: TCustomUniversalBitmap): TRect;
 
+    {** Initializes a brush with a solid color provided indirectly by a reference }
     procedure SolidBrushIndirect(out ABrush: TUniversalBrush; AColor: Pointer; ADrawMode: TDrawMode = dmDrawWithTransparency); override;
+    {** Initializes a brush that has no effect }
     class procedure IdleBrush(out ABrush: TUniversalBrush); virtual;
+    {** Initializes a brush with a solid color }
     class procedure SolidBrush(out ABrush: TUniversalBrush; const AColor: TPixel; ADrawMode: TDrawMode = dmDrawWithTransparency); virtual;
 
     {** @abstract(Creates a brush texture with a specified style, pattern color, background color, dimensions, and pen width.)

--- a/dev/releaser/bgrabitmap.logic
+++ b/dev/releaser/bgrabitmap.logic
@@ -6,5 +6,8 @@ package bgrabitmappack.lpk
 package bgrabitmappack4fpgui.lpk
 package bgrabitmappack4nogui.lpk
 package bgrabitmappack4android.lpk
+package bgrabitmappack4android_freetype.lpk
+package bgrabitmappack4nolcl.lpk
+package bgrabitmappack4nolcl_freetype.lpk
 const bgrabitmaptypes.pas BGRABitmapVersion
 

--- a/libwebp/readme.md
+++ b/libwebp/readme.md
@@ -1,0 +1,65 @@
+# WebP Decoder DLLs for BGRABitmap
+
+This package provides precompiled DLLs for decoding WebP images. These DLLs are compiled directly from the official [libwebp](https://github.com/webmproject/libwebp) C library, with no wrapper included. The actual WebP reader/writer integration is handled by [BGRABitmap](https://github.com/bgrabitmap/bgrabitmap).
+
+## 📦 Included Files
+
+- `libwebp32.dll` — 32-bit version (dynamically linked, `/MD`)
+- `libwebp64.dll` — 64-bit version (dynamically linked, `/MD`)
+- `libwebp32_static.dll` *(otherwise)* — 32-bit version with statically linked C++ runtime (`/MT`)
+- `libwebp64_static.dll` *(otherwise)* — 64-bit version with statically linked C++ runtime (`/MT`)
+
+## 🔍 Dynamic vs Static
+
+| DLL Name                | Architecture | Static Runtime | VC++ Redist Needed | Updatable | Notes                        |
+|-------------------------|--------------|----------------|--------------------|-----------|------------------------------|
+| `libwebp32.dll`           | 32-bit       | ❌             | ✅ Yes              | ✅ Yes    | Default 32-bit               |
+| `libwebp64.dll`           | 64-bit       | ❌             | ✅ Yes              | ✅ Yes    | Default 64-bit               |
+| `libwebp32_static.dll`    | 32-bit       | ✅ Yes         | ❌ No               | ❌ No     | Must be renamed if used      |
+| `libwebp64_static.dll`    | 64-bit       | ✅ Yes         | ❌ No               | ❌ No     | Must be renamed if used      |
+
+⚠️ If you use the static versions, you'll need to **rename** them to `libwebp32.dll` or `libwebp64.dll`, removing the suffix.
+
+## 💡 Recommendation
+
+- Use the **dynamic DLLs** (`libwebp32/64.dll`) if you want smaller files and automatic runtime updates (but VC++ redist is required).
+- Use the **static versions** if you want to ensure it works out of the box, even on systems without the runtime.
+
+## 🔧 Dependencies
+
+For the dynamic versions, the following files must be present on the system:
+- `vcruntime140.dll`
+- `ucrtbase.dll`
+
+Most Windows 10/11 systems include them by default. If needed, you can download the official Visual C++ Redistributable here:
+
+📥 [https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist)
+
+### 🔁 Architecture-specific links:
+
+- For **64-bit systems**: https://aka.ms/vs/17/release/vc_redist.x64.exe  
+- For **32-bit systems**: https://aka.ms/vs/17/release/vc_redist.x86.exe
+
+## 🧪 Error Handling Example (Free Pascal / Lazarus)
+
+You can add a simple check using a `try...except` block to handle missing dependencies gracefully:
+
+```pascal
+uses BGRABitmap;
+
+try
+  bmp := TBGRABitmap.Create('image.webp');
+  try
+    // do something with the image    
+  except
+    // handle errors after the image is loaded
+  end;
+  Free;
+except
+  on E: Exception do
+    ShowMessage('Failed to load image. This library requires the Microsoft Visual C++ Redistributable.' + LineEnding +
+      'You can download it here:' + LineEnding +
+        {$IFDEF CPU64}'https://aka.ms/vs/17/release/vc_redist.x64.exe'
+        {$ELSE}       'https://aka.ms/vs/17/release/vc_redist.x86.exe'{$ENDIF});
+end;
+```

--- a/test/gammafactor/umain.pas
+++ b/test/gammafactor/umain.pas
@@ -45,17 +45,18 @@ begin
   UpdateLabelGamma;
   TrackBar_Gamma.Position := round(BGRAGetGamma*20);
   FInitialised:= true;
+  BGRAVirtualScreen1.BitmapAutoScale:= false;
 end;
 
 procedure TForm1.BGRAVirtualScreen1Redraw(Sender: TObject; Bitmap: TBGRABitmap);
-const stripSize = 20;
 var c: TBGRAPixel;
   pattern: TBGRABitmap;
-  i: Integer;
+  i, stripSize: Integer;
 begin
   c := clWhite;
   c.Lightness := 32768;
   pattern := TBGRABitmap.Create(2,2);
+  stripSize := round(20 * PixelsPerInch * GetCanvasScaleFactor / 96);
   pattern.SetPixel(0,0,BGRABlack);
   pattern.SetPixel(1,0,BGRAWhite);
   pattern.SetPixel(0,1,BGRAWhite);

--- a/update_BGRABitmap.json
+++ b/update_BGRABitmap.json
@@ -10,12 +10,12 @@
       "ForceNotify" : false,
       "InternalVersion" : 1,
       "Name" : "bgrabitmappack.lpk",
-      "Version" : "11.6.4.0"
+      "Version" : "11.6.5.0"
     }
   ],
   "UpdatePackageData" : {
     "DisableInOPM" : false,
-    "DownloadZipURL" : "https://github.com/bgrabitmap/bgrabitmap/archive/v11.6.4.zip",
+    "DownloadZipURL" : "https://github.com/bgrabitmap/bgrabitmap/archive/v11.6.5.zip",
     "Name" : "bgrabitmap-master"
   }
 }


### PR DESCRIPTION
Changes:
- visibility of image readers/writers properties changed to published (RTTI for dynamic interface, remembering options)
- added ConvertToGrayscalePalette
- improve BMP reader to handle more formats

@maxm74 I don't really understand ResolutionConvertSize function parameters. It seems the function change meaning depending on the TResolutionUnit parameters. Maybe what you would like to do could be expressed with 3 different functions:

```pascal
function ConvertUnits(AValue: Single; FromUnit, ToUnit: TResolutionUnit): Single;
begin
  if FromUnit = ToUnit then
    Result := AValue
  else if (FromUnit = ruInch) and (ToUnit = ruCentimeter) then
    Result := AValue * 2.54
  else if (FromUnit = ruCentimeter) and (ToUnit = ruInch) then
    Result := AValue / 2.54
  else
    raise Exception.Create('Unsupported unit conversion');
end;

function PixelsToPhysical(AValuePixels: Single; DPI: Single; AResolutionUnit: TResolutionUnit): Single;
begin
  case AResolutionUnit of
    ruInch: Result := AValuePixels / DPI;
    ruCentimeter: Result := (AValuePixels / DPI) * 2.54;
  else
    raise Exception.Create('Unsupported unit conversion');
  end;
end;

function PhysicalToPixels(AValue: Single; DPI: Single; AResolutionUnit: TResolutionUnit): Single;
begin
  case AResolutionUnit of
    ruInch: Result := AValue * DPI;
    ruCentimeter: Result := (AValue / 2.54) * DPI;
  else
    raise Exception.Create('Unsupported unit conversion');
  end;
end;
```

Regarding functions in BGRAResample, I suggest to rename for a clearer intent, for example:
```pascal
function FineResample(bmp: TBGRACustomBitmap; AResolutionUnit: TResolutionUnit;
  NewPhysicalWidth, NewPhysicalHeight: Single; ResampleFilter: TResampleFilter): TBGRACustomBitmap; overload;
```

What do you think?