### PR TITLE
change all compiler directives relative to FPC 3.2.3

### DIFF
--- a/bgrabitmap/bgradefaultbitmap.pas
+++ b/bgrabitmap/bgradefaultbitmap.pas
@@ -1215,7 +1215,7 @@ begin
 
     if ACopyProperties then
     begin
-      {$IF FPC_FULLVERSION>=30203}
+      {$IF FPC_FULLVERSION>30203}
       //Resolution
       ResolutionUnit:=TFPCustomImage(Source).ResolutionUnit;
       ResolutionX:=TFPCustomImage(Source).ResolutionX;

--- a/bgrabitmap/bgraphoxo.pas
+++ b/bgrabitmap/bgraphoxo.pas
@@ -150,7 +150,7 @@ end;
 
 procedure TBGRAReaderOXO.ReadResolutionValues(Img: TFPCustomImage);
 begin
-  {$IF FPC_FULLVERSION<30203}
+  {$IF FPC_FULLVERSION<=30203}
   if (Img is TCustomUniversalBitmap) then
   with TCustomUniversalBitmap(Img) do
   begin

--- a/bgrabitmap/bgrareadbmp.pas
+++ b/bgrabitmap/bgrareadbmp.pas
@@ -1048,7 +1048,7 @@ end;
 
 procedure TBGRAReaderBMP.ReadResolutionValues(Img: TFPCustomImage);
 begin
-  {$IF FPC_FULLVERSION<30203}
+  {$IF FPC_FULLVERSION<=30203}
   if (Img is TCustomUniversalBitmap) then
   with TCustomUniversalBitmap(Img) do
   {$ELSE}

--- a/bgrabitmap/bgrareadjpeg.pas
+++ b/bgrabitmap/bgrareadjpeg.pas
@@ -49,7 +49,7 @@ type
   TBGRAReaderJpeg = class(TFPReaderJPEG)
     constructor Create; override;
   protected
-    {$IF FPC_FULLVERSION<30203}
+    {$IF FPC_FULLVERSION<=30203}
     CompressInfo: jpeg_decompress_struct;
     FError: jpeg_error_mgr;
 
@@ -102,7 +102,7 @@ begin
   Performance := jpBestQuality;
 end;
 
-{$IF FPC_FULLVERSION<30203}
+{$IF FPC_FULLVERSION<=30203}
 procedure TBGRAReaderJpeg.ReadResolutionValues(Img: TFPCustomImage);
 begin
   if (Img is TCustomUniversalBitmap) then

--- a/bgrabitmap/bgrareadpcx.pas
+++ b/bgrabitmap/bgrareadpcx.pas
@@ -94,7 +94,7 @@ end;
 
 procedure TBGRAReaderPCX.ReadResolutionValues(Img: TFPCustomImage);
 begin
-  {$IF FPC_FULLVERSION<30203}
+  {$IF FPC_FULLVERSION<=30203}
   if (Img is TCustomUniversalBitmap) then
   with TCustomUniversalBitmap(Img) do
   begin

--- a/bgrabitmap/bgrareadpng.pas
+++ b/bgrabitmap/bgrareadpng.pas
@@ -545,7 +545,7 @@ end;
 
 procedure TBGRAReaderPNG.AssignResolutionValues;
 begin
-  {$IF FPC_FULLVERSION<30203}
+  {$IF FPC_FULLVERSION<=30203}
   if (FTargetImage is TCustomUniversalBitmap) then
   with TCustomUniversalBitmap(FTargetImage) do
   {$ELSE}

--- a/bgrabitmap/bgrareadpsd.pas
+++ b/bgrabitmap/bgrareadpsd.pas
@@ -26,12 +26,12 @@ interface
 
 uses
   BGRAClasses, BGRABitmapTypes, SysUtils, FPimage, FPReadPSD
-  {$IF FPC_FULLVERSION>=30203}
+  {$IF FPC_FULLVERSION>30203}
    , PSDcomn
   {$ENDIF}
   ;
 
-{$IF FPC_FULLVERSION<30203}
+{$IF FPC_FULLVERSION<=30203}
 const
   { Image color modes  }
   PSD_BITMAP = 0;       { Bitmap image  }
@@ -164,7 +164,7 @@ const
 type
   { TBGRAReaderPSD }
 
-  {$IF FPC_FULLVERSION<30203}
+  {$IF FPC_FULLVERSION<=30203}
   { Image Resource Blocks }
   TPSDResourceBlock = packed record
     Types : array[0..3] of Char;   // Always "8BIM"
@@ -197,7 +197,7 @@ type
     procedure AnalyzeHeader;
 
     procedure ReadResourceBlockData(Img: TFPCustomImage; blockID:Word;
-                                    blockName:ShortString; Size:LongWord; Data:Pointer);{$IF FPC_FULLVERSION<30203}virtual;{$ELSE}override;{$ENDIF}
+                                    blockName:ShortString; Size:LongWord; Data:Pointer);{$IF FPC_FULLVERSION<=30203}virtual;{$ELSE}override;{$ENDIF}
     procedure InternalRead(Stream: TStream; Img: TFPCustomImage); override;
     function ReadScanLine(Stream: TStream; AInputSize: PtrInt; AChannel: integer): boolean; overload;
     procedure WriteScanLine(Img: TFPCustomImage; Row: integer); overload;
@@ -209,7 +209,7 @@ type
     property OutputHeight: integer read FOutputHeight;
   end;
 
-{$IF FPC_FULLVERSION<30203}
+{$IF FPC_FULLVERSION<=30203}
 function PSDResolutionUnitToResolutionUnit(APSDResolutionUnit: Word): TResolutionUnit;
 function ResolutionUnitToPSdResolutionUnit(AResolutionUnit: TResolutionUnit): Word;
 {$ENDIF}
@@ -270,7 +270,7 @@ begin
   result := LabToRGB(L,(Lab.a-128)/127,(Lab.b-128)/127);
 end;
 
-{$IF FPC_FULLVERSION<30203}
+{$IF FPC_FULLVERSION<=30203}
 function PSDResolutionUnitToResolutionUnit(APSDResolutionUnit: Word): TResolutionUnit;
 begin
   Case APSDResolutionUnit of
@@ -380,7 +380,7 @@ var
   VResolutionUnit:TResolutionUnit;
 
 begin
-  {$IF FPC_FULLVERSION<30203}
+  {$IF FPC_FULLVERSION<=30203}
   case blockID of
   PSD_RESN_INFO:begin
           if (Img is TCustomUniversalBitmap) then

--- a/bgrabitmap/bgrareadtiff.pas
+++ b/bgrabitmap/bgrareadtiff.pas
@@ -1991,7 +1991,7 @@ var
 
   procedure ReadResolutionValues;
   begin
-    {$IF FPC_FULLVERSION<30203}
+    {$IF FPC_FULLVERSION<=30203}
     if (CurFPImg is TCustomUniversalBitmap) then
     with TCustomUniversalBitmap(CurFPImg) do
     {$ELSE}
@@ -3242,7 +3242,7 @@ var
 
   procedure ReadResolutionValues;
   begin
-    {$IF FPC_FULLVERSION<30203}
+    {$IF FPC_FULLVERSION<=30203}
     if (CurFPImg is TCustomUniversalBitmap) then
     with TCustomUniversalBitmap(CurFPImg) do
     {$ELSE}

--- a/bgrabitmap/bgraresample.pas
+++ b/bgrabitmap/bgraresample.pas
@@ -9,11 +9,7 @@ unit BGRAResample;
 interface
 
 uses
-  SysUtils, BGRABitmapTypes, BGRAUnits
-  {$if FPC_FULLVERSION>30202}
-  , FpImage
-  {$endif}
-  ;
+  SysUtils, BGRABitmapTypes, BGRAUnits;
 
 {------------------------------- Simple stretch ------------------------------------}
 

--- a/bgrabitmap/bgrawritebmp.pas
+++ b/bgrabitmap/bgrawritebmp.pas
@@ -52,7 +52,7 @@ end;
 
 function TBGRAWriterBMP.SaveHeader(Stream:TStream; Img : TFPCustomImage):boolean;
 begin
-  {$IF FPC_FULLVERSION<30203}
+  {$IF FPC_FULLVERSION<=30203}
   if (Img is TCustomUniversalBitmap) then
   with TCustomUniversalBitmap(Img) do
   begin

--- a/bgrabitmap/bgrawritejpeg.pas
+++ b/bgrabitmap/bgrawritejpeg.pas
@@ -15,7 +15,7 @@ interface
 uses
   Classes, SysUtils, FPImage, FPReadJPEG, FPWriteJPEG
 
-  {$IF FPC_FULLVERSION<30203}, JPEGLib, JcAPIstd, JcAPImin, JDataDst, JcParam, JError{$ENDIF};
+  {$IF FPC_FULLVERSION<=30203}, JPEGLib, JcAPIstd, JcAPImin, JDataDst, JcParam, JError{$ENDIF};
 
 type
   TFPJPEGCompressionQuality = 1..100;   // 100 = best quality, 25 = pretty awful
@@ -23,7 +23,7 @@ type
   {* Extends the TFPWriterJPEG to save resolution }
   TBGRAWriterJPEG = class(TFPWriterJPEG)
   protected
-    {$IF FPC_FULLVERSION<30203}
+    {$IF FPC_FULLVERSION<=30203}
     ACompressInfo: jpeg_compress_struct;
     FError: jpeg_error_mgr;
     FProgressMgr: TFPJPEGProgressManager;
@@ -43,7 +43,7 @@ implementation
 
 uses BGRABitmapTypes;
 
-{$IF FPC_FULLVERSION<30203}
+{$IF FPC_FULLVERSION<=30203}
 function ResolutionUnitTodensity_unit(AResolutionUnit: TResolutionUnit): UINT8;
 begin
   Case AResolutionUnit of
@@ -230,7 +230,7 @@ end;
 {$ENDIF}
 
 initialization
-  {$IF FPC_FULLVERSION<30203}
+  {$IF FPC_FULLVERSION<=30203}
   with jpeg_std_error do begin
     error_exit:=@JPEGError;
     emit_message:=@EmitMessage;

--- a/bgrabitmap/bgrawritepcx.pas
+++ b/bgrabitmap/bgrawritepcx.pas
@@ -18,7 +18,7 @@ type
   {* Extends the TFPWriterPCX to save resolution }
   TBGRAWriterPCX = class(TFPWriterPCX)
   protected
-    {$IF FPC_FULLVERSION<30203}
+    {$IF FPC_FULLVERSION<=30203}
     function SaveHeader(Stream: TStream; Img: TFPCustomImage): boolean; override;
     {$ENDIF}
 
@@ -32,7 +32,7 @@ type
 
 implementation
 
-{$IF FPC_FULLVERSION<30203}
+{$IF FPC_FULLVERSION<=30203}
 uses pcxcomn;
 
 function TBGRAWriterPCX.SaveHeader(Stream: TStream; Img: TFPCustomImage): boolean;

--- a/bgrabitmap/bgrawritepng.pas
+++ b/bgrabitmap/bgrawritepng.pas
@@ -766,7 +766,7 @@ end;
 
 procedure TBGRAWriterPNG.WriteResolutionValues;
 begin
-  {$IF FPC_FULLVERSION<30203}
+  {$IF FPC_FULLVERSION<=30203}
   if (TheImage is TCustomUniversalBitmap) then
   with TCustomUniversalBitmap(TheImage) do
   {$ELSE}

--- a/bgrabitmap/bgrawritetiff.pas
+++ b/bgrabitmap/bgrawritetiff.pas
@@ -560,7 +560,7 @@ var
 
   procedure WriteResolutionValues;
   begin
-    {$IF FPC_FULLVERSION<30203}
+    {$IF FPC_FULLVERSION<=30203}
     if (Img is TCustomUniversalBitmap) then
     with TCustomUniversalBitmap(Img) do
     {$ELSE}

--- a/bgrabitmap/geometrytypes.inc
+++ b/bgrabitmap/geometrytypes.inc
@@ -209,7 +209,7 @@ type
   end;
 {$ENDIF}
 
-{$IF FPC_FULLVERSION<30203}
+{$IF FPC_FULLVERSION<=30203}
   {* Unit used to specify the resolution of a bitmap }
   TResolutionUnit = (
     {** No unit used, only aspect ratio specified }
@@ -1839,7 +1839,7 @@ begin
   result.y := pt1.y+pt2.y;
 end;
 
-{$if FPC_FULLVERSION < 30203}
+{$if FPC_FULLVERSION <= 30203}
 // keep alias for backward compatibility
 operator *(const pt1, pt2: TPointF): single;
 begin

--- a/bgrabitmap/unibitmap.inc
+++ b/bgrabitmap/unibitmap.inc
@@ -118,7 +118,7 @@ type
         antialiased shapes }
     FAntialiasingDrawMode: TDrawMode;
 
-    {$IF FPC_FULLVERSION<30203}
+    {$IF FPC_FULLVERSION<=30203}
     //Resolution
     FResolutionUnit: TResolutionUnit;
     FResolutionX,
@@ -543,7 +543,7 @@ type
     {** Current reference white used for color conversion }
     property ReferenceWhite: PXYZReferenceWhite read FReferenceWhite write FReferenceWhite;
 
-    {$IF FPC_FULLVERSION<30203}
+    {$IF FPC_FULLVERSION<=30203}
     //Resolution
     property ResolutionUnit: TResolutionUnit read FResolutionUnit write SetResolutionUnit;
     property ResolutionX: Single read FResolutionX write FResolutionX;
@@ -2184,7 +2184,7 @@ begin
   FLineOrder:= AValue;
 end;
 
-{$IF FPC_FULLVERSION<30203}
+{$IF FPC_FULLVERSION<=30203}
 procedure TCustomUniversalBitmap.SetResolutionUnit(AResolutionUnit: TResolutionUnit);
 begin
   if (AResolutionUnit<>FResolutionUnit) then
@@ -2541,7 +2541,7 @@ begin
 
     if ACopyProperties then
     begin
-      {$IF FPC_FULLVERSION>=30203}
+      {$IF FPC_FULLVERSION>30203}
       //Resolution
       ResolutionUnit:=TFPCustomImage(Source).ResolutionUnit;
       ResolutionX:=TFPCustomImage(Source).ResolutionX;


### PR DESCRIPTION
Compiler directives relative to FPC 3.2.3 basically need to consider 3.2.3 to be the same as 3.2.2, because changes visible to user code are only in version 3.2.4 or more.