### PR TITLE
#298 dom tag

### DIFF
--- a/bgrabitmap/bgrasvgshapes.pas
+++ b/bgrabitmap/bgrasvgshapes.pas
@@ -2440,7 +2440,7 @@ end;
 
 class function TSVGClipPath.GetDOMTag: string;
 begin
-  Result:= 'clippath';
+  Result:= 'clipPath';
 end;
 
 { TSVGColorProfile }


### PR DESCRIPTION
[`TSVGClipPath.GetDOMTag`](https://github.com/bgrabitmap/bgrabitmap/blame/9e2414f4e86f10cac4865781fa6b7279eb716be8/bgrabitmap/bgrasvgshapes.pas#L2443) should return `clipPath`, but the second `P` isn't capitalized, yielding an invalid SVG element.

