### PR TITLE
support for ImageSize

### DIFF
--- a/bgrabitmap/avifbgra.pas
+++ b/bgrabitmap/avifbgra.pas
@@ -194,6 +194,8 @@ type
     property Lossless: boolean read GetLossless write SetLossless;
   end;
 
+{ Determines the size of the AVIF image without decoding the pixels }
+function AvifGetSizeFromStream(AStream: TStream): TPoint;
 { Load an AVIF image from the given stream }
 procedure AvifLoadFromStream(AStream: TStream; aBitmap: TBGRACustomBitmap);
 { Load an AVIF image from the given file }
@@ -273,6 +275,7 @@ type
   TAvifImageBase = class
   public
     procedure Init(aImagePtr: Pointer); virtual; abstract;
+    function GetSize: TPoint; virtual; abstract;
     function GetTransformFlags: longword; virtual; abstract;
     function GetImirMode: uint8; virtual; abstract;
     procedure SetColorPrimaries(AColorPrimaries: avifColorPrimaries); virtual; abstract;
@@ -283,12 +286,15 @@ type
     procedure SetImirMode(AIM: uint8); virtual; abstract;
   end;
 
+  { TAvifImage }
+
   generic TAvifImage<T> = class(TAvifImageBase)
   protected
     FImage: T;
   public
     constructor Create(aImagePtr: Pointer = nil);
     procedure Init(aImagePtr: Pointer); override;
+    function GetSize: TPoint; override;
     function GetTransformFlags: longword; override;
     function GetImirMode: uint8; override;
     procedure SetColorPrimaries(AColorPrimaries: avifColorPrimaries); override;
@@ -807,6 +813,11 @@ begin
   FImage := T(aImagePtr);
 end;
 
+function TAvifImage.GetSize: TPoint;
+begin
+  result := Point(FImage^.width, FImage^.Height);
+end;
+
 function TAvifImage.GetTransformFlags: longword;
 begin
   Result := FImage^.transformFlags;
@@ -934,6 +945,15 @@ begin
   exit(AVIF_RESULT_OK);
 end;
 
+function AvifImageGetSize(aAvifImage:PAvifImage): TPoint;
+var
+  imageWrap: TAvifImageBase;
+begin
+  imageWrap:=TAvifImageFactory(aAvifImage);
+  result := imageWrap.GetSize;
+  imageWrap.Free;
+end;
+
 procedure AvifImageToBGRABitmap(aAvifImage:PAvifImage; aBitmap: TBGRACustomBitmap);
 var
   res: avifResult;
@@ -1000,6 +1020,41 @@ begin
    end
   else
     raise EAvifException.Create('Avif Error: ' + avifResultToString(res));
+end;
+
+function AvifDecodeImageSize(decoderWrap: TDecoderBase): TPoint;
+var
+  res: avifResult;
+  image: PAvifImage;
+begin
+  result := Point(0, 0);
+  res := avifDecoderParse(decoderWrap.GetDecoder);
+  if res <> AVIF_RESULT_OK then exit;
+  res := avifDecoderNextImage(decoderWrap.GetDecoder);
+  if res <> AVIF_RESULT_OK then exit;
+  image := decoderWrap.GetImage;
+  if image = nil then exit;
+  result := AvifImageGetSize(image);
+end;
+
+function AvifGetSizeFromStream(AStream: TStream): TPoint;
+var
+  decoder: PavifDecoder;
+  res: avifResult;
+  decoderWrap: TDecoderBase;
+begin
+  result := Point(0, 0);
+  decoderWrap:= nil;
+  decoder := TAvifReader.CreateDecoder;
+  try
+    decoderWrap:=TDecoderFactory(decoder);
+    res := avifDecoderSetIOStream(decoderWrap, aStream);
+    if res = AVIF_RESULT_OK then
+      result := AvifDecodeImageSize(decoderWrap);
+  finally
+    decoderWrap.Free;
+    TAvifReader.DestroyDecoder(decoder);
+  end;
 end;
 
 procedure AvifLoadFromStream(AStream: TStream; aBitmap: TBGRACustomBitmap);

--- a/bgrabitmap/bgrabitmappack.lpk
+++ b/bgrabitmap/bgrabitmappack.lpk
@@ -21,6 +21,11 @@
           <VariablesInRegisters Value="True"/>
         </Optimizations>
       </CodeGeneration>
+      <Other>
+        <CompilerMessages>
+          <IgnoredMessages idx6058="True"/>
+        </CompilerMessages>
+      </Other>
     </CompilerOptions>
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>

--- a/bgrabitmap/bgrabitmappack.lpk
+++ b/bgrabitmap/bgrabitmappack.lpk
@@ -30,7 +30,7 @@
     <Description Value="Drawing routines with alpha blending and antialiasing"/>
     <License Value="modified LGPL"/>
     <Version Major="11" Minor="6" Release="6"/>
-    <Files Count="154">
+    <Files Count="155">
       <Item1>
         <Filename Value="bgraanimatedgif.pas"/>
         <UnitName Value="BGRAAnimatedGif"/>
@@ -649,6 +649,10 @@
         <Filename Value="bgrapdf.pas"/>
         <UnitName Value="BGRAPDF"/>
       </Item154>
+      <Item155>
+        <Filename Value="bgrareadpnm.pas"/>
+        <UnitName Value="bgrareadpnm"/>
+      </Item155>
     </Files>
     <CompatibilityMode Value="True"/>
     <RequiredPkgs Count="2">

--- a/bgrabitmap/bgrabitmappack.pas
+++ b/bgrabitmap/bgrabitmappack.pas
@@ -31,7 +31,7 @@ uses
   XYZABitmap, BGRAWriteTiff, WordXYZABitmap, ExpandedBitmap, libwebp, 
   linuxlib, BGRAReadWebP, BGRAWriteWebP, BGRAClasses, avifbgra, libavif, 
   BGRAWriteAvif, BGRAReadAvif, darwinlib, BGRAWriteJpeg, BGRAWriteBMP, 
-  BGRAWritePCX, BGRAPapers, BGRAPNGComn, BGRACustomTextFX, BGRAPDF;
+  BGRAWritePCX, BGRAPapers, BGRAPNGComn, BGRACustomTextFX, BGRAPDF, BGRAReadPNM;
 
 implementation
 

--- a/bgrabitmap/bgrabitmaptypes.pas
+++ b/bgrabitmap/bgrabitmaptypes.pas
@@ -161,11 +161,15 @@ var
   {** Detect the file format of a given file }
   function DetectFileFormat(AFilenameUTF8: string): TBGRAImageFormat;
   {** Detect the file format of a given stream. _ASuggestedExtensionUTF8_ can
-      be provided to guess the format }
+      be provided to guess the format. Stream position is unchanged. }
   function DetectFileFormat(AStream: TStream; ASuggestedExtensionUTF8: string = ''): TBGRAImageFormat;
   {** Returns the file format that is most likely to be stored in the
       given filename (according to its extension) }
   function SuggestImageFormat(AFilenameOrExtensionUTF8: string): TBGRAImageFormat;
+  {** Returns the image size of the given file }
+  function GetImageSizeInFile(AFilename: string): TPoint;
+  {** Returns the image size in the given stream (stream position is modified) }
+  function GetImageSizeInStream(AStream: TStream): TPoint;
   {** Returns a likely image extension for the format }
   function SuggestImageExtension(AFormat: TBGRAImageFormat): string;
   {** Create an image reader for the given format }
@@ -1204,7 +1208,7 @@ begin
   end;
 end;
 
-function DetectFileFormat(AStream: TStream; ASuggestedExtensionUTF8: string
+function DetectFileFormat(AStream: TStream; ASuggestedExtensionUTF8: string = ''
   ): TBGRAImageFormat;
 var
   scores: array[TBGRAImageFormat] of integer;
@@ -1470,6 +1474,40 @@ begin
   if (ext = '.webp') then result := ifWebP else
   if (ext = '.avif') then result := ifAvif;
 
+end;
+
+function GetImageSizeInFile(AFilename: string): TPoint;
+var
+  stream: TFileStreamUTF8;
+  imageFormat: TBGRAImageFormat;
+  reader: TFPCustomImageReader;
+begin
+  stream := nil;
+  reader := nil;
+  try
+    imageFormat := DetectFileFormat(AFilename);
+    reader := CreateBGRAImageReader(imageFormat);
+    stream := TFileStreamUTF8.Create(AFilename, fmOpenRead);
+    result := reader.ImageSize(stream);
+  finally
+    reader.Free;
+    stream.Free;
+  end;
+end;
+
+function GetImageSizeInStream(AStream: TStream): TPoint;
+var
+  imageFormat: TBGRAImageFormat;
+  reader: TFPCustomImageReader;
+begin
+  reader := nil;
+  try
+    imageFormat := DetectFileFormat(AStream);
+    reader := CreateBGRAImageReader(imageFormat);
+    result := reader.ImageSize(AStream);
+  finally
+    reader.Free;
+  end;
 end;
 
 function SuggestImageExtension(AFormat: TBGRAImageFormat): string;

--- a/bgrabitmap/bgrabitmaptypes.pas
+++ b/bgrabitmap/bgrabitmaptypes.pas
@@ -679,8 +679,9 @@ type
   TBGRAImageReader = class(TFPCustomImageReader)
     {** Return bitmap information (size, bit depth) }
     function GetQuickInfo(AStream: TStream): TQuickImageInfo; virtual; abstract;
-    {** Return a draft of the bitmap, the ratio may change compared to the original width and height (useful to make thumbnails) }
-    function GetBitmapDraft(AStream: TStream; AMaxWidth, AMaxHeight: integer; out AOriginalWidth,AOriginalHeight: integer): TBGRACustomBitmap; virtual; abstract;
+    {** Return a draft of the bitmap, the ratio may change compared to the original width and height (useful to make thumbnails).
+        Stream position is unchanged. }
+    function GetBitmapDraft(AStream: TStream; AMaxWidth, AMaxHeight: integer; out AOriginalWidth,AOriginalHeight: integer): TBGRACustomBitmap; virtual;
   end;
 
   {* Generic definition for a PNG writer with alpha option }
@@ -1066,6 +1067,27 @@ end;
 function TBGRACustomFontRenderer.HandlesTextPath: boolean;
 begin
   result := false;
+end;
+
+{ TBGRAImageReader }
+
+function TBGRAImageReader.GetBitmapDraft(AStream: TStream; AMaxWidth,
+  AMaxHeight: integer; out AOriginalWidth, AOriginalHeight: integer): TBGRACustomBitmap;
+var
+  prevPos: Int64;
+begin
+  // default implementation simply reads the image
+  // but a specific implementation can read only the relevant data
+  // to make an image of size AMaxWidth by AMaxHeight
+  result := BGRABitmapFactory.Create;
+  prevPos := AStream.Position;
+  try
+    result.LoadFromStream(AStream, self, []);
+  finally
+    AStream.Position := prevPos;
+  end;
+  AOriginalWidth:= result.Width;
+  AOriginalHeight:= result.Height;
 end;
 
 

--- a/bgrabitmap/bgrabitmaptypes.pas
+++ b/bgrabitmap/bgrabitmaptypes.pas
@@ -681,7 +681,7 @@ type
     function GetQuickInfo(AStream: TStream): TQuickImageInfo; virtual; abstract;
     {** Return a draft of the bitmap, the ratio may change compared to the original width and height (useful to make thumbnails).
         Stream position is unchanged. }
-    function GetBitmapDraft(AStream: TStream; AMaxWidth, AMaxHeight: integer; out AOriginalWidth,AOriginalHeight: integer): TBGRACustomBitmap; virtual;
+    function GetBitmapDraft(AStream: TStream; {%H-}AMaxWidth, {%H-}AMaxHeight: integer; out AOriginalWidth,AOriginalHeight: integer): TBGRACustomBitmap; virtual;
   end;
 
   {* Generic definition for a PNG writer with alpha option }
@@ -723,7 +723,7 @@ function ResourceFile(AFilename: string): string;
 implementation
 
 uses Math, SysUtils,
-  BGRAUTF8, BGRAUnits, FPWriteBMP, FPReadPNM, FPWritePNM, FPWriteXPM
+  BGRAUTF8, BGRAUnits, FPWriteBMP, BGRAReadPNM, FPWritePNM, FPWriteXPM
   {$IFNDEF BGRABITMAP_CORE},
   FPReadXwd, FPReadXPM, FPReadPcx,
   FPWriteJPEG, FPWritePCX,
@@ -1878,8 +1878,7 @@ initialization
   {$IFNDEF BGRABITMAP_CORE}
   BGRARegisterImageWriter(ifTarga, TFPWriterTarga, false, 'TARGA Format', 'tga');
   BGRARegisterImageWriter(ifXPixMap, TFPWriterXPM, false, 'XPM Format', 'xpm');
-  BGRARegisterImageHandlers(ifPortableAnyMap, TFPReaderPNM, TFPWriterPNM,
-    False, 'Netpbm Portable aNyMap', 'pnm;pbm;pgm;ppm');
+  BGRARegisterImageWriter(ifPortableAnyMap, TFPWriterPNM, false, 'Netpbm Portable aNyMap', 'pnm;pbm;pgm;ppm');
   BGRARegisterImageReader(ifXwd, TFPReaderXWD, false, 'XWD Format', 'xwd');
 
   //the other readers/writers are registered by their unit

--- a/bgrabitmap/bgracompressablebitmap.pas
+++ b/bgrabitmap/bgracompressablebitmap.pas
@@ -55,6 +55,7 @@ type
 
      procedure WriteToStream(AStream: TStream);
      procedure ReadFromStream(AStream: TStream);
+     class function ImageSize(AStream: TStream): TPoint;
      
      function UsedMemory: Int64;
      procedure Assign(Source: TBGRABitmap);
@@ -216,6 +217,20 @@ begin
 
   if FCompressedDataArray = nil then
     FUncompressedData := TMemoryStream.Create;
+end;
+
+class function TBGRACompressableBitmap.ImageSize(AStream: TStream): TPoint;
+var
+  prevPos: Int64;
+begin
+  prevPos := AStream.Position;
+  try
+    result.X := LEReadLongint(AStream);
+    result.Y := LEReadLongint(AStream);
+  except
+    result := Point(0, 0);
+  end;
+  AStream.Position:= prevPos;
 end;
 
 procedure TBGRACompressableBitmap.Decompress;

--- a/bgrabitmap/bgraiconcursor.pas
+++ b/bgrabitmap/bgraiconcursor.pas
@@ -239,11 +239,10 @@ begin
   case format of
   ifBmp:
     begin
-      reader := TBGRAReaderBMP.Create;
       bmp := BGRABitmapFactory.Create;
       try
         AContent.Position := 0;
-        imageInfo := reader.GetQuickInfo(AContent);
+        imageInfo := TBGRAReaderBMP.GetQuickInfoEx(AContent, bsfWithFileHeader);
         if (imageInfo.width <= 0) or (imageInfo.height <= 0) or
            (imageInfo.width > 256) or (imageInfo.height > 256) then
           raise exception.Create('Invalid image size');
@@ -284,7 +283,7 @@ begin
 
         //build mask
         tempStream.Position := tempStream.Size;
-        setlength(maskLine, maskStride);
+        setlength({%H-}maskLine, maskStride);
         for y := bmp.Height-1 downto 0 do
         begin
           maskBit := $80;
@@ -309,7 +308,6 @@ begin
         result := TBGRAIconCursorEntry.Create(AContainer, 'dib', imageInfo, tempStream);
       finally
         bmp.Free;
-        reader.Free;
       end;
     end;
   ifPng:
@@ -324,10 +322,7 @@ begin
     begin
       //assume headerless BMP
       AContent.Position := 0;
-      reader := TBGRAReaderBMP.Create;
-      imageInfo := reader.GetQuickInfo(AContent);
-      imageInfo.Height:= imageInfo.Height div 2; //mask size is included
-      reader.Free;
+      imageInfo := TBGRAReaderBMP.GetQuickInfoEx(AContent, bsfHeaderlessWithMask);
       if (imageInfo.width <= 0) or (imageInfo.height <= 0) or
          (imageInfo.width > 256) or (imageInfo.height > 256) then
         raise exception.Create('Invalid image size');
@@ -584,7 +579,7 @@ begin
       bmpXOR := BGRABitmapFactory.Create(ABitmap);
       try
         bitAndMaskRowSize := ((bmpXOR.Width+31) div 32)*4;
-        setlength(bitAndMask, bitAndMaskRowSize*bmpXOR.Height);
+        setlength({%H-}bitAndMask, bitAndMaskRowSize*bmpXOR.Height);
         for y := bmpXOR.Height-1 downto 0 do
         begin
           if assigned(ABitmap.XorMask) then
@@ -727,7 +722,7 @@ begin
     if header.ResourceType <> ExpectedMagic then
       raise exception.Create('Invalid resource type');
     Clear;
-    setlength(dir, header.ImageCount);
+    setlength({%H-}dir, header.ImageCount);
     AStream.ReadBuffer(dir[0], sizeof(TIconFileDirEntry)*length(dir));
     for i := 0 to high(dir) do
     begin
@@ -764,7 +759,7 @@ begin
   header.ResourceType:= ExpectedMagic;
   header.SwapIfNecessary;
   accSize := sizeof(header) + sizeof(TIconFileDirEntry)*Count;
-  setlength(dir, Count);
+  setlength({%H-}dir, Count);
   for i := 0 to Count-1 do
   begin
     if Width[i] >= 256

--- a/bgrabitmap/bgraopenraster.pas
+++ b/bgrabitmap/bgraopenraster.pas
@@ -59,6 +59,7 @@ type
     procedure LoadFlatImageFromStream(AStream: TStream;
               out ANbLayers: integer;
               out ABitmap: TBGRABitmap);
+    procedure FetchImageInfo(AStream: TStream; out ASize: TPoint; out ANbLayers: integer);
     procedure LoadFromStream(AStream: TStream); override;
     procedure LoadFromFile(const filenameUTF8: string); override;
     procedure SaveToStream(AStream: TStream); override;
@@ -68,12 +69,16 @@ type
   end;
 
   { Reader for ORA image format (flattened) }
+
+  { TFPReaderOpenRaster }
+
   TFPReaderOpenRaster = class(TFPCustomImageReader)
     private
       FWidth,FHeight,FNbLayers: integer;
     protected
       function InternalCheck(Stream: TStream): boolean; override;
       procedure InternalRead(Stream: TStream; Img: TFPCustomImage); override;
+      class function InternalSize(Str: TStream): TPoint; override;
     public
       property Width: integer read FWidth;
       property Height: integer read FHeight;
@@ -91,7 +96,7 @@ procedure RegisterOpenRasterFormat;
 implementation
 
 uses XMLRead, XMLWrite, BGRABitmapTypes, zstream, BGRAUTF8,
-  UnzipperExt, BGRASVGOriginal, BGRATransform, BGRASVGType, math;
+  UnzipperExt, BGRASVGOriginal, BGRATransform, BGRASVGType;
 
 const
   MergedImageFilename = 'mergedimage.png';
@@ -207,6 +212,21 @@ begin
       raise Exception.Create('Error while loading OpenRaster file. ' + ex.Message);
     end;
   end;
+end;
+
+class function TFPReaderOpenRaster.InternalSize(Str: TStream): TPoint;
+var
+  doc: TBGRAOpenRasterDocument;
+  sizeFound: TPoint;
+  nbLayersFound: integer;
+begin
+  doc := TBGRAOpenRasterDocument.Create;
+  try
+    doc.FetchImageInfo(Str, sizeFound, nbLayersFound);
+  finally
+    doc.Free;
+  end;
+  Result:= sizeFound;
 end;
 
 { TBGRAOpenRasterDocument }
@@ -1023,6 +1043,44 @@ begin
       if Assigned(stackNode) then
       begin
         ANbLayers:= 0;
+        for i := stackNode.ChildNodes.Length-1 downto 0 do
+        begin
+          if stackNode.ChildNodes[i].NodeName = 'layer' then
+            inc(ANbLayers);
+        end;
+      end;
+    end;
+
+  finally
+    fileList.Free;
+    ClearFiles;
+  end;
+end;
+
+procedure TBGRAOpenRasterDocument.FetchImageInfo(AStream: TStream; out
+  ASize: TPoint; out ANbLayers: integer);
+var fileList: TStringList;
+  stackStream: TMemoryStream;
+  imageNode, stackNode: TDOMNode;
+  i: integer;
+begin
+  fileList := TStringList.Create;
+  fileList.Add(LayerStackFilename);
+  ASize := Point(0, 0);
+  ANbLayers := 0;
+  try
+    UnzipFromStream(AStream, fileList);
+    stackStream := GetMemoryStream(LayerStackFilename);
+    ReadXMLFile(FStackXML, StackStream);
+    imageNode := StackXML.FindNode('image');
+    if Assigned(imagenode) then
+    begin
+      val(imageNode.Attributes.GetNamedItem('w').NodeValue, ASize.X);
+      val(imageNode.Attributes.GetNamedItem('h').NodeValue, ASize.Y);
+
+      stackNode := imageNode.FindNode('stack');
+      if Assigned(stackNode) then
+      begin
         for i := stackNode.ChildNodes.Length-1 downto 0 do
         begin
           if stackNode.ChildNodes[i].NodeName = 'layer' then

--- a/bgrabitmap/bgraphoxo.pas
+++ b/bgrabitmap/bgraphoxo.pas
@@ -60,6 +60,7 @@ type
     procedure SaveToFile(const filenameUTF8: string); override;
     class function CheckFormat(Stream: TStream; ARestorePosition: boolean): boolean; static;
     class function ReadBlock(Stream: TStream; out AHeader: TPhoxoBlockHeader; out ABlockData: PByte): boolean; static;
+    class function ImageSize(AStream: TStream): TPoint; static;
     property DPIX: integer read FDPIX;
     property DPIY: integer read FDPIY;
   end;
@@ -76,6 +77,7 @@ type
     procedure ReadResolutionValues(Img: TFPCustomImage);
     function InternalCheck(Stream: TStream): boolean; override;
     procedure InternalRead(Stream: TStream; Img: TFPCustomImage); override;
+    class function InternalSize(Str: TStream): TPoint; override;
   public
     property Width: integer read FWidth;
     property Height: integer read FHeight;
@@ -208,6 +210,11 @@ begin
   finally
     layeredImage.Free;
   end;
+end;
+
+class function TBGRAReaderOXO.InternalSize(Str: TStream): TPoint;
+begin
+  Result:= TBGRAPhoxoDocument.ImageSize(Str);
 end;
 
 { TBGRAPhoxoDocument }
@@ -360,7 +367,7 @@ begin
           begin
             if (blockHeader.blockSize >= 2) and (NbLayers > 0) then
             begin
-              setlength(wCaption, blockHeader.blockSize div 2);
+              setlength({%H-}wCaption, blockHeader.blockSize div 2);
               for i := 1 to length(wCaption) do
                 Word(wCaption[i]) := LEtoN((PWord(blockData)+i-1)^);
               if wCaption[1] = #1 then Delete(wCaption,1,1);
@@ -623,6 +630,28 @@ begin
     exit;
   end;
   result := true;
+end;
+
+class function TBGRAPhoxoDocument.ImageSize(AStream: TStream): TPoint;
+var blockHeader: TPhoxoBlockHeader;
+    blockData: PByte;
+begin
+  result := Point(0, 0);
+  if not CheckFormat(AStream,False) then exit;
+  blockData := nil;
+  repeat
+    if not ReadBlock(AStream, blockHeader, blockData) then
+      exit;
+    if blockHeader.blockType = PhoxoBlock_CanvasSize then
+    begin
+      if blockHeader.blockSize < 8 then exit;
+      result.X := LEtoN(PLongWord(blockData)^);
+      result.Y := LEtoN((PLongWord(blockData)+1)^);
+      FreeMem(blockData);
+      exit;
+    end;
+    FreeMem(blockData);
+  until blockHeader.blockType = PhoxoBlock_EndOfFile;
 end;
 
 end.

--- a/bgrabitmap/bgrapngcomn.pas
+++ b/bgrabitmap/bgrapngcomn.pas
@@ -29,6 +29,7 @@ type
     Width, height : LongWord;
     BitDepth, ColorType, Compression, Filter, Interlace : byte;
   end;
+  PHeaderCunk = ^THeaderChunk;
   { Array of 8 longwords }
   EightLong = PNGComn.EightLong;
 

--- a/bgrabitmap/bgrareadavif.pas
+++ b/bgrabitmap/bgrareadavif.pas
@@ -14,10 +14,14 @@ type
   { @abstract(Reader for AVIF still image format.)
 
     To read animations, use TAvifReader of AvifBGRA unit }
+
+  { TBGRAReaderAvif }
+
   TBGRAReaderAvif = class(TFPCustomImageReader)
   protected
     procedure InternalRead(Str: TStream; Img: TFPCustomImage); override;
     function InternalCheck(Str: TStream): boolean; override;
+    class function InternalSize(Str: TStream): TPoint; override;
   end;
 
 implementation
@@ -89,6 +93,11 @@ begin
   finally
     Str.Position:= OldPos;
   end;
+end;
+
+class function TBGRAReaderAvif.InternalSize(Str: TStream): TPoint;
+begin
+  Result:= AvifGetSizeFromStream(Str);
 end;
 
 initialization

--- a/bgrabitmap/bgrareadbmp.pas
+++ b/bgrabitmap/bgrareadbmp.pas
@@ -136,13 +136,18 @@ type
       procedure WriteMaskLine(Row : Integer; Img : TFPCustomImage); virtual;
 
       procedure ReadResolutionValues(Img: TFPCustomImage); virtual;
-      procedure ReadInfoHeader(Stream: TStream;
+      class procedure ReadInfoHeader(Stream: TStream;
+        AImageOffset: longint;
         out AInfoHeader: TBitmapinfoHeaderV4;
         out APaletteEntrySize, APaletteByteCount: integer);
 
       // required by TFPCustomImageReader
       procedure InternalRead  (Stream:TStream; Img:TFPCustomImage); override;
+      class function InternalSize(Str: TStream): TPoint; override;
+      class function InternalSizeEx(Str: TStream; ASubFormat: TBitmapSubFormat): TPoint;
       function  InternalCheck (Stream:TStream) : boolean; override;
+      class function StaticCheck(Stream: TStream; ASubFormat: TBitmapSubFormat;
+        out AFileHeader: TBitMapFileHeader; out AHotspot: TPoint): boolean;
       procedure InitReadBuffer(AStream: TStream; ASize: integer);
       procedure CloseReadBuffer;
       function GetNextBufferByte: byte;
@@ -162,6 +167,7 @@ type
       property OutputHeight: integer read FOutputHeight;
       property TransparencyOption: TBMPTransparencyOption read FTransparencyOption write FTransparencyOption;
       function GetQuickInfo(AStream: TStream): TQuickImageInfo; override;
+      class function GetQuickInfoEx(AStream: TStream; ASubFormat: TBitmapSubFormat): TQuickImageInfo;
       function GetBitmapDraft(AStream: TStream; {%H-}AMaxWidth, AMaxHeight: integer; out AOriginalWidth,AOriginalHeight: integer): TBGRACustomBitmap; override;
   end;
 
@@ -292,57 +298,47 @@ begin
 end;
 
 function TBGRAReaderBMP.GetQuickInfo(AStream: TStream): TQuickImageInfo;
-var headerSize: LongWord;
-  os2header: TOS2BitmapHeader;
-  minHeader: TMinimumBitmapHeader;
-  totalDepth: integer;
-  headerPos: int64;
+var
+  oldPos: Int64;
+begin
+  oldPos := AStream.Position;
+  result := GetQuickInfoEx(AStream, bsfWithFileHeader);
+  if (result.Width = 0) and (result.Height = 0) then
+  begin
+    AStream.Position:= oldPos;
+    result := GetQuickInfoEx(AStream, bsfHeaderless);
+  end;
+end;
+
+class function TBGRAReaderBMP.GetQuickInfoEx(AStream: TStream;
+  ASubFormat: TBitmapSubFormat): TQuickImageInfo;
+var
+  fileHeader: TBitMapFileHeader;
+  tempHotSpot: TPoint;
+  infoHeader: TBitmapinfoHeaderV4;
+  paletteEntrySize, paletteByteCount: integer;
+  totalDepth: Word;
 begin
   {$PUSH}{$HINTS OFF}fillchar({%H-}result, sizeof({%H-}result), 0);{$POP}
-  headerPos := AStream.Position;
-  if AStream.Read({%H-}headerSize, sizeof(headerSize)) <> sizeof(headerSize) then exit;
-  headerSize := LEtoN(headerSize);
 
-  //check presence of file header
-  if (headerSize and $ffff) = BMmagic then
-  begin
-    inc(headerPos, sizeof(TBitMapFileHeader));
-    AStream.Position := headerPos;
-    if AStream.Read(headerSize, sizeof(headerSize)) <> sizeof(headerSize) then exit;
-    headerSize := LEtoN(headerSize);
-  end;
+  if not StaticCheck(AStream, ASubFormat, fileHeader, tempHotSpot) then
+    exit;
 
-  AStream.Position := headerPos;
+  ReadInfoHeader(AStream, fileHeader.bfOffset, infoHeader, paletteEntrySize, paletteByteCount);
 
-  if headerSize = sizeof(TOS2BitmapHeader) then //OS2 1.x
-  begin
-    if AStream.Read({%H-}os2header, sizeof(os2header)) <> sizeof(os2header) then exit;
-    result.width := LEtoN(os2header.bcWidth);
-    result.height := LEtoN(os2header.bcHeight);
-    result.colorDepth := LEtoN(os2header.bcBitCount);
-    result.alphaDepth := 0;
-  end
+  result.width := infoHeader.Width;
+  if ASubFormat = bsfHeaderlessWithMask then
+    result.height := infoHeader.Height div 2
   else
-  if headerSize >= sizeof(minHeader) then
+    result.height := infoHeader.Height;
+  totalDepth := infoHeader.BitCount;
+  if totalDepth > 24 then
   begin
-    if AStream.Read({%H-}minHeader, sizeof(minHeader)) <> sizeof(minHeader) then exit;
-    result.width := LEtoN(minHeader.Width);
-    result.height := LEtoN(minHeader.Height);
-    totalDepth := LEtoN(minHeader.BitCount);
-    if totalDepth > 24 then
-    begin
-      result.colorDepth:= 24;
-      result.alphaDepth:= 8;
-    end else
-    begin
-      result.colorDepth := totalDepth;
-      result.alphaDepth:= 0;
-    end;
+    result.colorDepth:= 24;
+    result.alphaDepth:= 8;
   end else
   begin
-    result.width := 0;
-    result.height:= 0;
-    result.colorDepth:= 0;
+    result.colorDepth := totalDepth;
     result.alphaDepth:= 0;
   end;
 end;
@@ -521,7 +517,7 @@ begin
   begin
     GetMem(FPalette, nPalette*SizeOf(TFPColor));
     GetMem(FBGRAPalette, nPalette*SizeOf(TBGRAPixel));
-    SetLength(ColInfo, nPalette);
+    SetLength({%H-}ColInfo, nPalette);
     if BFI.ClrUsed>0 then
       colorPresent:= min(BFI.ClrUsed,nPalette)
     else
@@ -532,7 +528,7 @@ begin
 
     if FPaletteEntrySize = 3 then
     begin
-      setlength(ColInfo3, nPalette);
+      setlength({%H-}ColInfo3, nPalette);
       Stream.Read(ColInfo3[0],colorPresent*SizeOf(TColorRGB));
       for i := 0 to colorPresent-1 do
         ColInfo[i].RGB := ColInfo3[i];
@@ -560,7 +556,8 @@ begin
   end;
 end;
 
-procedure TBGRAReaderBMP.ReadInfoHeader(Stream: TStream;
+class procedure TBGRAReaderBMP.ReadInfoHeader(Stream: TStream;
+  AImageOffset: longint;
   out AInfoHeader: TBitmapinfoHeaderV4;
   out APaletteEntrySize, APaletteByteCount: integer);
 var
@@ -594,7 +591,7 @@ begin
   deltaPos := headerSize - sizeof(longword) { size field } - headerByteCount;
   if deltaPos <> 0 then
     Stream.Position:=Stream.Position + deltaPos;
-  APaletteByteCount := BFH.bfOffset - sizeof(BFH) - headerSize;
+  APaletteByteCount := AImageOffset - sizeof(TBitMapFileHeader) - headerSize;
 end;
 
 procedure TBGRAReaderBMP.InternalRead(Stream:TStream; Img:TFPCustomImage);
@@ -609,7 +606,7 @@ begin
   Progress(psStarting,0,false,EmptyRect,'',shouldContinue);
   if not shouldContinue then exit;
 
-  ReadInfoHeader(Stream, BFI, FPaletteEntrySize, paletteByteCount);
+  ReadInfoHeader(Stream, BFH.bfOffset, BFI, FPaletteEntrySize, paletteByteCount);
   with BFI do
   begin
     BadCompression:=false;
@@ -694,6 +691,17 @@ begin
   finally
     FreeBufs;
   end;
+end;
+
+class function TBGRAReaderBMP.InternalSize(Str: TStream): TPoint;
+begin
+  result := InternalSizeEx(Str, bsfWithFileHeader);
+end;
+
+class function TBGRAReaderBMP.InternalSizeEx(Str: TStream; ASubFormat: TBitmapSubFormat): TPoint;
+begin
+  with GetQuickInfoEx(Str, ASubFormat) do
+    result := Point(Width, Height);
 end;
 
 procedure TBGRAReaderBMP.ExpandRLE8ScanLine(Row : Integer; Stream : TStream);
@@ -1073,24 +1081,29 @@ begin
 
 function  TBGRAReaderBMP.InternalCheck (Stream:TStream) : boolean;
 begin
-  fillchar(BFH, sizeof(BFH), 0);
-  if Subformat in [bsfHeaderless,bsfHeaderlessWithMask] then
+  exit(StaticCheck(Stream, SubFormat, BFH, Hotspot));
+end;
+
+class function  TBGRAReaderBMP.StaticCheck (Stream:TStream; ASubFormat: TBitmapSubFormat;
+                                            out AFileHeader: TBitMapFileHeader; out AHotspot: TPoint) : boolean;
+begin
+  fillchar({%H-}AFileHeader, sizeof(AFileHeader), 0);
+  if ASubFormat in [bsfHeaderless,bsfHeaderlessWithMask] then
   begin
    result := true;
-   Hotspot := Point(0,0);
+   AHotspot := Point(0,0);
   end else
   begin
-    if stream.Read(BFH,SizeOf(BFH)) < sizeof(BFH) then
+    if stream.Read(AFileHeader,SizeOf(AFileHeader)) < sizeof(AFileHeader) then
     begin
       result := false;
       exit;
     end;
-    Hotspot := Point(LEtoN(PWord(@BFH.bfReserved)^),LEtoN((PWord(@BFH.bfReserved)+1)^));
+    AHotspot := Point(LEtoN(PWord(@AFileHeader.bfReserved)^),LEtoN((PWord(@AFileHeader.bfReserved)+1)^));
     {$IFDEF ENDIAN_BIG}
-    SwapBMPFileHeader(BFH);
+    SwapBMPFileHeader(fileHeader);
     {$ENDIF}
-    With BFH do
-      Result:=(bfType=BMmagic); // Just check magic number
+    Result:= AFileHeader.bfType=BMmagic; // Just check magic number
   end;
 end;
 

--- a/bgrabitmap/bgrareadbmpmiomap.pas
+++ b/bgrabitmap/bgrareadbmpmiomap.pas
@@ -27,9 +27,11 @@ type
   { Reader for iGO bitmap format (MioMap) }
   TBGRAReaderBmpMioMap = class(TFPCustomImageReader)
   private
-    function ReadHeader(Stream: TStream; out header: TMioHeader): boolean;
+    class function ReadHeader(Stream: TStream; out header: TMioHeader): boolean;
     function ReadPalette(Stream: TStream; nbColors: integer; alphaChannel: boolean): TPixelArray;
     procedure UncompressChunks(Stream: TStream; nbChunks: integer; palette: TPixelArray; img: TFPCustomImage);
+  protected
+    class function InternalSize(Str: TStream): TPoint; override;
   public
     procedure InternalRead  (Stream:TStream; Img:TFPCustomImage); override;
     function  InternalCheck (Stream:TStream) : boolean; override;
@@ -75,7 +77,7 @@ end;
 
 { TBGRAReaderBmpMioMap }
 
-function TBGRAReaderBmpMioMap.ReadHeader(Stream: TStream; out header: TMioHeader
+class function TBGRAReaderBmpMioMap.ReadHeader(Stream: TStream; out header: TMioHeader
   ): boolean;
 begin
   result := false;
@@ -98,8 +100,8 @@ var mioPalette: packed array of word;
   colorValue: word;
   alphaPalette: packed array of byte;
 begin
-  setlength(mioPalette, nbColors);
-  setlength(result,nbColors);
+  setlength({%H-}mioPalette, nbColors);
+  {$PUSH}{$WARNINGS OFF}setlength({%H-}result,nbColors);{$POP}
   nbColorsRead:= Stream.Read({%H-}mioPalette[0], nbColors*2) div 2;
   for i := 0 to nbColorsRead-1 do
   begin
@@ -110,7 +112,7 @@ begin
     result[i] := BGRAPixelTransparent;
   if alphaChannel then
   begin
-    setlength(alphaPalette,nbColors);
+    setlength({%H-}alphaPalette,nbColors);
     Stream.Read(alphaPalette[0],nbColors);
     for i := 0 to nbColors-1 do
       if mioPalette[i] <> MioMapTransparentColor then
@@ -168,7 +170,7 @@ begin
   if (img.Width = 0) or (img.Height = 0) or (palLen = 0) then exit;
 
   maxChunkSize := 1;
-  setlength(chunkSizes, nbChunks);
+  setlength({%H-}chunkSizes, nbChunks);
   for i := 0 to nbChunks-1 do
   begin
     if stream.read({%H-}b,1)=0 then b := 0;
@@ -186,7 +188,7 @@ begin
       maxChunkSize := chunkSizes[i];
   end;
 
-  setlength(chunkData, maxChunkSize);
+  setlength({%H-}chunkData, maxChunkSize);
   x := 0;
   y := 0;
   w := img.Width;
@@ -231,6 +233,16 @@ begin
       end;
     end;
   end;
+end;
+
+class function TBGRAReaderBmpMioMap.InternalSize(Str: TStream): TPoint;
+var
+  h: TMioHeader;
+begin
+  if ReadHeader(Str, h) then
+    result := Point(h.width, h.Height)
+  else
+    result := Point(0, 0);
 end;
 
 procedure TBGRAReaderBmpMioMap.InternalRead(Stream: TStream; Img: TFPCustomImage);

--- a/bgrabitmap/bgrareadgif.pas
+++ b/bgrabitmap/bgrareadgif.pas
@@ -26,6 +26,12 @@ type
   protected
     procedure ReadPaletteAtOnce(Stream: TStream; Size: integer);
     procedure InternalRead(Stream: TStream; Img: TFPCustomImage); override;
+    class function InternalSize(Str: TStream): TPoint; override;
+    class function ReadHeader(Str: TStream; out AHeader: TGIFHeader;
+      out AColorTableSize: integer): boolean;
+    class function ReadDescriptor(Str: TStream; out ADescriptor: TGifImageDescriptor;
+      out AColorTableSize: integer): boolean;
+    class function IgnoreExtensionBlock(Str: TStream): byte;
     function ReadScanLine(Stream: TStream): boolean; override;
     function WriteScanLineBGRA(Img: TFPCustomImage): Boolean; virtual;
   end;
@@ -76,48 +82,24 @@ begin
     FPalette := TFPPalette.Create(0);
 
     Stream.Position:=0;
-    // header
-    Stream.Read(FHeader,SizeOf(FHeader));
+    if not ReadHeader(Stream, FHeader, ColorTableSize) then
+      raise Exception.Create('Unknown/Unsupported GIF image type');
     Progress(psRunning, 0, False, Rect(0,0,0,0), '', ContProgress);
     if not ContProgress then exit;
 
-    // Endian Fix Mantis 8541. Gif is always little endian
-    {$IFDEF ENDIAN_BIG}
-      with FHeader do
-        begin
-          ScreenWidth := LEtoN(ScreenWidth);
-          ScreenHeight := LEtoN(ScreenHeight);
-        end;
-    {$ENDIF}
     // global palette
-    if (FHeader.Packedbit and $80) <> 0 then
-    begin
-      ColorTableSize := FHeader.Packedbit and 7 + 1;
-      ReadPaletteAtOnce(stream, 1 shl ColorTableSize);
-    end;
+    if ColorTableSize > 0 then
+      ReadPaletteAtOnce(stream, ColorTableSize);
 
     // skip extensions
     Repeat
       Introducer:=SkipBlock(Stream);
     until (Introducer = $2C) or (Introducer = $3B);
 
-    // descriptor
-    Stream.Read(FDescriptor, SizeOf(FDescriptor));
-    {$IFDEF ENDIAN_BIG}
-      with FDescriptor do
-        begin
-          Left := LEtoN(Left);
-          Top := LEtoN(Top);
-          Width := LEtoN(Width);
-          Height := LEtoN(Height);
-        end;
-    {$ENDIF}
+    if not ReadDescriptor(Stream, FDescriptor, ColorTableSize) then exit;
     // local palette
-    if (FDescriptor.Packedbit and $80) <> 0 then
-    begin
-      ColorTableSize := FDescriptor.Packedbit and 7 + 1;
-      ReadPaletteAtOnce(stream, 1 shl ColorTableSize);
-    end;
+    if ColorTableSize > 0 then
+      ReadPaletteAtOnce(stream, ColorTableSize);
 
     // parse header
     if not AnalyzeHeader then exit;
@@ -143,7 +125,115 @@ begin
   Progress(FPimage.psEnding, 100, false, Rect(0,0,FWidth,FHeight), '', ContProgress);
 end;
 
-function TBGRAReaderGif.ReadScanLine(Stream: TStream): Boolean;
+class function TBGRAReaderGif.ReadHeader(Str: TStream; out AHeader: TGIFHeader;
+  out AColorTableSize: integer): boolean;
+begin
+  fillchar({%H-}AHeader, sizeof(AHeader), 0);
+  result :=
+    (Str.Read(AHeader, SizeOf(AHeader)) = SizeOf(AHeader))
+    and (AHeader.Signature = 'GIF')
+    and ((AHeader.Version = '87a') or (AHeader.Version = '89a'));
+
+  {$IFDEF ENDIAN_BIG}
+  with AHeader do
+  begin
+    ScreenWidth := LEtoN(ScreenWidth);
+    ScreenHeight := LEtoN(ScreenHeight);
+  end;
+  {$ENDIF}
+
+  if (AHeader.Packedbit and $80) <> 0 then
+    AColorTableSize := 1 shl (AHeader.Packedbit and 7 + 1)
+  else
+    AColorTableSize := 0;
+end;
+
+class function TBGRAReaderGif.ReadDescriptor(Str: TStream; out
+  ADescriptor: TGifImageDescriptor; out AColorTableSize: integer): boolean;
+begin
+  fillchar({%H-}ADescriptor, sizeof(ADescriptor), 0);
+  // descriptor
+  result := Str.Read(ADescriptor, SizeOf(ADescriptor)) = SizeOf(ADescriptor);
+  {$IFDEF ENDIAN_BIG}
+  with ADescriptor do
+  begin
+    Left := LEtoN(Left);
+    Top := LEtoN(Top);
+    Width := LEtoN(Width);
+    Height := LEtoN(Height);
+  end;
+  {$ENDIF}
+  // local palette
+  if (ADescriptor.Packedbit and $80) <> 0 then
+    AColorTableSize := 1 shl (ADescriptor.Packedbit and 7 + 1)
+  else
+    AColorTableSize := 0;
+end;
+
+class function TBGRAReaderGif.IgnoreExtensionBlock(Str: TStream): byte;
+var
+  Introducer,
+  Labels,
+  SkipByte : byte;
+begin
+  Introducer := 0;
+  Str.read(Introducer,1);
+  if Introducer = $21 then
+  begin
+     Labels := 0;
+     Str.read(Labels,1);
+     Case Labels of
+       $FE, $FF :     // Comment Extension block or Application Extension block
+            while true do
+            begin
+              SkipByte := 0;
+              Str.Read(SkipByte, 1);
+              if SkipByte = 0 then Break;
+              Str.Seek(SkipByte, soFromCurrent);
+            end;
+       $F9 :         // Graphics Control Extension block
+            begin
+              Str.Seek(SizeOf(TGifGraphicsControlExtension), soFromCurrent);
+            end;
+       $01 :        // Plain Text Extension block
+            begin
+              SkipByte := 0;
+              Str.Read(SkipByte, 1);
+              Str.Seek(SkipByte, soFromCurrent);
+              while true do
+              begin
+                SkipByte := 0;
+                Str.Read(SkipByte, 1);
+                if SkipByte = 0 then Break;
+                Str.Seek(SkipByte, soFromCurrent);
+              end;
+            end;
+      end;
+  end;
+  Result:=Introducer;
+end;
+
+
+class function TBGRAReaderGif.InternalSize(Str: TStream): TPoint;
+var h: TGIFHeader;
+  colorTableSize: integer;
+  d: TGifImageDescriptor;
+  Introducer: Byte;
+begin
+  result := Point(0, 0);
+  if not ReadHeader(Str, h, colorTableSize) then exit;
+  // skip palette
+  if colorTableSize > 0 then
+     Str.Seek(sizeof(TGifRGB)*colorTableSize, soCurrent);
+  // skip extensions
+  Repeat
+    Introducer:= IgnoreExtensionBlock(Str);
+  until (Introducer = $2C) or (Introducer = $3B);
+  if not ReadDescriptor(Str, d, colorTableSize) then exit;
+  result := Point(d.Width, d.Height);
+end;
+
+function TBGRAReaderGif.ReadScanLine(Stream: TStream): boolean;
 var
   OldPos,
   UnpackedSize,

--- a/bgrabitmap/bgrareadico.pas
+++ b/bgrabitmap/bgrareadico.pas
@@ -6,22 +6,30 @@ unit BGRAReadIco;
 {$mode objfpc}{$H+}
 {$i bgrabitmap.inc}
 
+{$IFDEF BGRABITMAP_USE_LCL}
+  {$DEFINE USE_LCL_ICON_READER}
+{$ENDIF}
+
 interface
 
 uses
-  BGRAClasses, SysUtils, FPimage{$IFDEF BGRABITMAP_USE_LCL}, Graphics{$ENDIF};
+  BGRAClasses, SysUtils, FPimage{$IFDEF USE_LCL_ICON_READER}, Graphics{$ENDIF};
 
 type
-  {$IFDEF BGRABITMAP_USE_LCL}TCustomIconClass = class of TCustomIcon;{$ENDIF}
+  {$IFDEF USE_LCL_ICON_READER}TCustomIconClass = class of TCustomIcon;{$ENDIF}
   TByteSet = set of byte;
 
   { Image reader for ICO and CUR format }
+
+  { TBGRAReaderIcoOrCur }
+
   TBGRAReaderIcoOrCur = class(TFPCustomImageReader)
   protected
     procedure InternalRead({%H-}Str: TStream; {%H-}Img: TFPCustomImage); override;
     function InternalCheck(Str: TStream): boolean; override;
     function ExpectedMagic: TByteSet; virtual; abstract;
-    {$IFDEF BGRABITMAP_USE_LCL}function LazClass: TCustomIconClass; virtual; abstract;{$ENDIF}
+    class function InternalSize(Str: TStream): TPoint; override;
+    {$IFDEF USE_LCL_ICON_READER}class function LazClass: TCustomIconClass; virtual; abstract;{$ENDIF}
   public
     WantedWidth, WantedHeight : integer;
   end;
@@ -30,19 +38,19 @@ type
   TBGRAReaderIco = class(TBGRAReaderIcoOrCur)
   protected
     function ExpectedMagic: TByteSet; override;
-    {$IFDEF BGRABITMAP_USE_LCL}function LazClass: TCustomIconClass; override;{$ENDIF}
+    {$IFDEF USE_LCL_ICON_READER}class function LazClass: TCustomIconClass; override;{$ENDIF}
   end;
 
   { Image reader for CUR format }
   TBGRAReaderCur = class(TBGRAReaderIcoOrCur)
   protected
     function ExpectedMagic: TByteSet; override;
-    {$IFDEF BGRABITMAP_USE_LCL}function LazClass: TCustomIconClass; override;{$ENDIF}
+    {$IFDEF USE_LCL_ICON_READER}class function LazClass: TCustomIconClass; override;{$ENDIF}
   end;
 
 implementation
 
-uses BGRABitmapTypes{$IFNDEF BGRABITMAP_USE_LCL}, BGRAIconCursor{$ENDIF};
+uses BGRABitmapTypes{$IFNDEF USE_LCL_ICON_READER}, BGRAIconCursor{$ENDIF};
 
 { TBGRAReaderCur }
 
@@ -51,7 +59,7 @@ begin
   result := [2];
 end;
 
-{$IFDEF BGRABITMAP_USE_LCL}function TBGRAReaderCur.LazClass: TCustomIconClass;
+{$IFDEF USE_LCL_ICON_READER}class function TBGRAReaderCur.LazClass: TCustomIconClass;
 begin
   result := TCursorImage;
 end;{$ENDIF}
@@ -63,18 +71,46 @@ begin
   result := [1,2];
 end;
 
-{$IFDEF BGRABITMAP_USE_LCL}function TBGRAReaderIco.LazClass: TCustomIconClass;
+{$IFDEF USE_LCL_ICON_READER}class function TBGRAReaderIco.LazClass: TCustomIconClass;
 begin
   result := TIcon;
+end;{$ENDIF}
+
+{$IFDEF USE_LCL_ICON_READER}function FindBestIndex(AIcon: TCustomIcon;
+  AWantedWidth, AWantedHeight: integer): integer;
+var
+  i, bestIdx: integer;
+  width, height, bestWidth, bestHeight: word;
+  format, maxFormat: TPixelFormat;
+begin
+  bestIdx := -1;
+  bestHeight := 0;
+  bestWidth := 0;
+  maxFormat := pfDevice;
+  for i := 0 to AIcon.Count-1 do
+  begin
+    AIcon.GetDescription(i, format, height, width);
+    if (bestIdx = -1) or
+      (abs(height-AWantedHeight) + abs(width-AWantedWidth)
+      < abs(bestHeight-AWantedHeight) + abs(bestWidth-AWantedWidth)) or
+      ((height = bestHeight) and (width = bestWidth) and (format > maxFormat)) then
+    begin
+      bestIdx := i;
+      bestHeight := height;
+      bestWidth := width;
+      maxFormat := format;
+    end;
+  end;
+  if (bestWidth = 0) or (bestHeight = 0) then
+    bestIdx := -1;
+  result := bestIdx;
 end;{$ENDIF}
 
 { TBGRAReaderIcoOrCur }
 
 procedure TBGRAReaderIcoOrCur.InternalRead(Str: TStream; Img: TFPCustomImage);
-{$IFDEF BGRABITMAP_USE_LCL}
-var ico: TCustomIcon; i,bestIdx: integer;
-    height,width: word; format:TPixelFormat;
-    bestHeight,bestWidth: integer; maxFormat: TPixelFormat;
+{$IFDEF USE_LCL_ICON_READER}
+var ico: TCustomIcon; bestIdx: integer;
     compWidth,compHeight: integer;
 begin
   if WantedWidth > 0 then compWidth:= WantedWidth else compWidth:= 65536;
@@ -82,23 +118,8 @@ begin
   ico := LazClass.Create;
   try
     ico.LoadFromStream(Str);
-    bestIdx := -1;
-    bestHeight := 0;
-    bestWidth := 0;
-    maxFormat := pfDevice;
-    for i := 0 to ico.Count-1 do
-    begin
-      ico.GetDescription(i,format,height,width);
-      if (bestIdx = -1) or (abs(height-compHeight)+abs(width-compWidth) < abs(bestHeight-compHeight)+abs(bestWidth-compWidth)) or
-      ((height = bestHeight) and (width = bestWidth) and (format > maxFormat)) then
-      begin
-        bestIdx := i;
-        bestHeight := height;
-        bestWidth := width;
-        maxFormat := format;
-      end;
-    end;
-    if (bestIdx = -1) or (bestWidth = 0) or (bestHeight = 0) then
+    bestIdx := FindBestIndex(ico, compWidth, compHeight);
+    if bestIdx = -1 then
       raise exception.Create('No adequate icon found') else
     begin
       ico.Current := bestIdx;
@@ -140,6 +161,40 @@ begin
     result := (magic[0] = $00) and (magic[1] = $00) and (magic[2] in ExpectedMagic) and (magic[3] = $00) and
              (magic[4] + (magic[5] shl 8) > 0);
 end;
+
+class function TBGRAReaderIcoOrCur.InternalSize(Str: TStream): TPoint;
+{$IFDEF USE_LCL_ICON_READER}
+var ico: TCustomIcon; bestIdx: integer;
+begin
+  result := Point(0, 0);
+  ico := LazClass.Create;
+  try
+    ico.LoadFromStream(Str);
+    bestIdx := FindBestIndex(ico, 65536, 65536);
+    if bestIdx <> -1 then
+    begin
+      ico.Current := bestIdx;
+      result := Point(ico.Width, ico.Height);
+    end;
+  finally
+    ico.free;
+  end;
+end;
+{$ELSE}
+var
+  icoCur: TBGRAIconCursor;
+  bestIdx: Integer;
+begin
+  result := Point(0, 0);
+  icoCur := TBGRAIconCursor.Create(Str);
+  try
+    bestIdx := icoCur.GetBestFitIndex(65536,65536);
+    if bestIdx <> -1 then
+      result := Point(icoCur.Width[bestIdx], icoCur.Height[bestIdx]);
+  finally
+    icoCur.Free;
+  end;
+end;{$ENDIF}
 
 initialization
   BGRARegisterImageReader(ifIco, TBGRAReaderIco, True, 'Icon Format', 'ico');

--- a/bgrabitmap/bgrareadlzp.pas
+++ b/bgrabitmap/bgrareadlzp.pas
@@ -32,6 +32,7 @@ type
     procedure InternalReadLayers({%H-}str: TStream;{%H-}Img: TFPCustomImage); virtual;
     procedure InternalReadCompressableBitmap(str: TStream; Img: TFPCustomImage); virtual;
     function InternalCheck(Str: TStream): boolean; override;
+    class function InternalSize(Str: TStream): TPoint; override;
   public
     class procedure LoadRLEImage(Str: TStream; Img: TFPCustomImage; out ACaption: string); static;
     property Width: integer read FWidth;
@@ -178,6 +179,29 @@ begin
   result := (copy(magicAsText,1,8) = 'LazPaint') or
     (((magic[0] <> 0) or (magic[1] <> 0)) and (magic[2] = 0) and (magic[3] = 0) and
      ((magic[4] <> 0) or (magic[5] <> 0)) and (magic[6] = 0) and (magic[7] = 0));
+end;
+
+class function TBGRAReaderLazPaint.InternalSize(Str: TStream): TPoint;
+var h: TLazPaintImageHeader;
+begin
+  result := Point(0, 0);
+
+  fillchar({%H-}h, sizeof(h), 0);
+  str.ReadBuffer(h.magic,sizeof(h.magic));
+  if h.magic = LAZPAINT_MAGIC_HEADER then
+  begin
+    str.Read(h.zero1, sizeof(h)-sizeof(h.magic));
+    LazPaintImageHeader_SwapEndianIfNeeded(h);
+    // check format
+    if (h.zero1 <> 0) or (h.zero2 <> 0) or
+       (h.headerSize < $30) then exit;
+
+    result := Point(h.width, h.height);
+  end else
+  begin
+    str.Seek(-sizeof(h.magic), soFromCurrent);
+    result := TBGRACompressableBitmap.ImageSize(Str);
+  end;
 end;
 
 class procedure TBGRAReaderLazPaint.LoadRLEImage(Str: TStream; Img: TFPCustomImage; out ACaption: string);

--- a/bgrabitmap/bgrareadpcx.pas
+++ b/bgrabitmap/bgrareadpcx.pas
@@ -18,7 +18,7 @@ unit BGRAReadPCX;
 
 interface
 
-uses FPImage, BGRAClasses, SysUtils, FPReadPCX;
+uses FPImage, BGRAClasses, SysUtils, FPReadPCX, pcxcomn;
 
 type
   { Reader for PCX image format }
@@ -34,6 +34,8 @@ type
     function GetBitsPerPixel: byte;
     function GetGrayScale: Boolean;
     function InternalCheck(Stream: TStream): boolean; override;
+    class function TryReadHeader(Stream: TStream; out AHeader: TPCXHeader): boolean;
+    class function InternalSize(Str: TStream): TPoint; override;
     procedure ReadResolutionValues(Img: TFPCustomImage);
     procedure InternalRead(Stream: TStream; Img: TFPCustomImage); override;
     procedure ReadScanLine({%H-}Row: integer; Stream: TStream); override;
@@ -118,7 +120,7 @@ begin
   emptyRect := rect(0,0,0,0);
   continue    := True;
   Progress(psStarting, 0, False, emptyRect, '', continue);
-  Stream.Read(Header, SizeOf(Header));
+  Stream.ReadBuffer(Header, SizeOf(Header));
   AnalyzeHeader(Img);
   ReadResolutionValues(Img);
   case BytesPerPixel of
@@ -259,14 +261,54 @@ end;
 
 function TBGRAReaderPCX.InternalCheck({%H-}Stream: TStream): boolean;
 var
-  {%H-}magic: packed array[0..3] of byte;
   oldPos: Int64;
+  h: TPCXHeader;
 begin
   oldPos:= stream.Position;
-  result := stream.Read({%H-}magic,SizeOf(magic)) = sizeof(magic);
+  result := TryReadHeader(stream, h);
   stream.Position:= oldPos;
-  if result then
-    result := (magic[0] in[$0a,$0c,$cd]) and (magic[1] in [0,2,3,4,5]) and (magic[2] in[0,1]) and (magic[3] in[1,2,4,8])
+end;
+
+class function TBGRAReaderPCX.TryReadHeader(Stream: TStream; out AHeader: TPCXHeader): boolean;
+
+  procedure LittleEndian(var {%H-}AWord: word);
+  begin
+    {$IFDEF ENDIAN_BIG}
+    AWord := swap(AWord);
+    {$ENDIF}
+  end;
+
+begin
+  result := true;
+  fillchar({%H-}AHeader, sizeof(AHeader), 0);
+  if Stream.Read(AHeader, sizeof(AHeader)) <> sizeof(AHeader) then result := false;
+  if not (AHeader.FileID in [$0a,$0c,$cd]) or
+    not (AHeader.Version in [0,2,3,4,5]) or
+    not (AHeader.Encoding in [0,1]) or
+    not (AHeader.BitsPerPixel in [1,2,4,8,24]) then
+    result := false;
+
+  with AHeader do
+  begin
+    LittleEndian(XMin);
+    LittleEndian(YMin);
+    LittleEndian(XMax);
+    LittleEndian(YMax);
+    LittleEndian(HRes);
+    LittleEndian(VRes);
+    LittleEndian(BytesPerLine);
+    LittleEndian(PaletteType);
+  end;
+end;
+
+class function TBGRAReaderPCX.InternalSize(Str: TStream): TPoint;
+var
+  h: TPCXHeader;
+begin
+  if TryReadHeader(Str, h) then
+    result := Point(h.XMax - h.XMin + 1, h.YMax - h.YMin + 1)
+  else
+    result := Point(0, 0);
 end;
 
 initialization

--- a/bgrabitmap/bgrareadpng.pas
+++ b/bgrabitmap/bgrareadpng.pas
@@ -285,15 +285,18 @@ function TBGRAReaderPNG.GetBitmapDraft(AStream: TStream; AMaxWidth,
   AMaxHeight: integer; out AOriginalWidth, AOriginalHeight: integer): TBGRACustomBitmap;
 var
   png: TBGRAReaderPNG;
+  oldPos: Int64;
 begin
   png:= TBGRAReaderPNG.Create;
   result := BGRABitmapFactory.Create;
+  oldPos := AStream.Position;
   try
     png.MinifyHeight := AMaxHeight;
     result.LoadFromStream(AStream, png);
     AOriginalWidth:= png.OriginalWidth;
     AOriginalHeight:= png.OriginalHeight;
   finally
+    AStream.Position:= oldPos;
     png.Free;
   end;
 end;

--- a/bgrabitmap/bgrareadpng.pas
+++ b/bgrabitmap/bgrareadpng.pas
@@ -80,7 +80,7 @@ Type
       function GetOriginalHeight: integer;
       function GetOriginalWidth: integer;
       function GetVerticalShrinkFactor: integer;
-      function ReadChunk: boolean;
+      class function ReadChunk(AStream: TStream; var AChunk: TChunk): boolean;
       procedure InvalidChunkLength;
       function ColorGray1 (const CD:TColorData) : TFPColor;
       function ColorGray2 (const CD:TColorData) : TFPColor;
@@ -147,8 +147,10 @@ Type
       function DecideSetPixel : TSetPixelProc; virtual;
       property ConvertColor : TConvertColorProc read FConvertColor;
 
-      procedure InternalRead  ({%H-}Str:TStream; Img:TFPCustomImage); override;
+      procedure InternalRead  ({%H-}Str:TStream; {%H-}Img:TFPCustomImage); override;
       function  InternalCheck (Str:TStream) : boolean; override;
+      class function InternalSize(Str: TStream): TPoint; override;
+      class function TryReadHeader(Str: TStream; var AChunk: TChunk): boolean;
 
       property Header : THeaderChunk read FHeader;
       property CurrentPass : byte read FCurrentPass;
@@ -158,6 +160,7 @@ Type
       constructor Create; override;
       destructor Destroy; override;
       function GetQuickInfo(AStream: TStream): TQuickImageInfo; override;
+      class function ClassGetQuickInfo(AStream: TStream): TQuickImageInfo;
       function GetBitmapDraft(AStream: TStream; {%H-}AMaxWidth, AMaxHeight: integer;
         out AOriginalWidth,AOriginalHeight: integer): TBGRACustomBitmap; override;
       procedure LoadFrame(AIndex: integer; AImage: TFPCustomImage);
@@ -218,45 +221,64 @@ begin
   FTargetImage := nil;
 end;
 
+class procedure FreeChunk(var AChunk: TChunk);
+begin
+  with AChunk do
+    if acapacity > 0 then
+    begin
+      freemem (data);
+      acapacity := 0;
+    end;
+end;
+
 destructor TBGRAReaderPNG.Destroy;
 begin
-  with chunk do
-    if acapacity > 0 then
-      freemem (data);
+  FreeChunk(chunk);
   FFrames.Free;
   FPalette.Free;
   inherited;
 end;
 
 function TBGRAReaderPNG.GetQuickInfo(AStream: TStream): TQuickImageInfo;
-const headerChunkSize = 13;
-var
-  {%H-}FileHeader : packed array[0..7] of byte;
-  {%H-}ChunkHeader : TChunkHeader;
-  {%H-}HeaderChunk : THeaderChunk;
 begin
-  {$PUSH}{$HINTS OFF}fillchar({%H-}result, sizeof({%H-}result), 0);{$POP}
-  if (AStream.Read({%H-}FileHeader, sizeof(FileHeader)) <> sizeof(FileHeader))
-    or not CheckSignature(FileHeader) then exit;
-  if AStream.Read({%H-}ChunkHeader, sizeof(ChunkHeader)) <> sizeof(ChunkHeader) then exit;
-  if ChunkHeader.CType <> GetChunkCode(ctIHDR) then exit;
-  if BEtoN(ChunkHeader.CLength) < headerChunkSize then exit;
-  if AStream.Read({%H-}HeaderChunk, headerChunkSize) <> headerChunkSize then exit;
-  result.width:= BEtoN(HeaderChunk.Width);
-  result.height:= BEtoN(HeaderChunk.height);
-  case HeaderChunk.ColorType and 3 of
-    0,3: {grayscale, palette}
-      if HeaderChunk.BitDepth > 8 then
-        result.colorDepth := 8
-      else
-        result.colorDepth := HeaderChunk.BitDepth;
+  result := ClassGetQuickInfo(AStream);
+end;
 
-    2: {color} result.colorDepth := HeaderChunk.BitDepth*3;
+class function TBGRAReaderPNG.ClassGetQuickInfo(AStream: TStream): TQuickImageInfo;
+var
+  sigCheck: TPNGSignature;
+  headerChunk: TChunk;
+  pHeader: PHeaderCunk;
+begin
+  {$PUSH}{$HINTS OFF}fillchar({%H-}result, sizeof(result), 0);{$POP}
+
+  // Check Signature
+  fillchar({%H-}sigCheck, sizeof(sigCheck), 0);
+  if (AStream.Read(sigCheck, SizeOf(sigCheck)) <> sizeof(sigCheck)) or
+    not CheckSignature(sigCheck) then
+    exit;
+
+  fillchar({%H-}headerChunk, sizeof(headerChunk), 0);
+  if TryReadHeader(AStream, headerChunk) then
+  begin
+    pHeader := PHeaderCunk(headerChunk.data);
+    result.width:= pHeader^.Width;
+    result.height:= pHeader^.height;
+    case pHeader^.ColorType and 3 of
+      0,3: {grayscale, palette}
+        if pHeader^.BitDepth > 8 then
+          result.colorDepth := 8
+        else
+          result.colorDepth := pHeader^.BitDepth;
+
+      2: {color} result.colorDepth := pHeader^.BitDepth*3;
+    end;
+    if (pHeader^.ColorType and 4) = 4 then
+      result.alphaDepth := pHeader^.BitDepth
+    else
+      result.alphaDepth := 0;
   end;
-  if (HeaderChunk.ColorType and 4) = 4 then
-    result.alphaDepth := HeaderChunk.BitDepth
-  else
-    result.alphaDepth := 0;
+  FreeChunk(headerChunk);
 end;
 
 function TBGRAReaderPNG.GetBitmapDraft(AStream: TStream; AMaxWidth,
@@ -282,16 +304,16 @@ begin
     DoLoadImage(AImage, FrameData, FrameControl.Width, FrameControl.Height);
 end;
 
-function TBGRAReaderPNG.ReadChunk: boolean;
+class function TBGRAReaderPNG.ReadChunk(AStream: TStream; var AChunk: TChunk): boolean;
 var {%H-}ChunkHeader : TChunkHeader;
     readCRC : LongWord;
     l : LongWord;
     readCount: integer;
 begin
-  readCount := TheStream.Read ({%H-}ChunkHeader,sizeof(ChunkHeader));
+  readCount := AStream.Read ({%H-}ChunkHeader,sizeof(ChunkHeader));
   if readCount <> sizeof(TChunkHeader) then
     raise PNGImageException.Create('Unexpected end of stream when reading next chunk');
-  with chunk do
+  with AChunk do
     begin
     // chunk header
     with ChunkHeader do
@@ -313,11 +335,11 @@ begin
       GetMem (data, alength);
       acapacity := alength;
       end;
-    l := TheStream.read (data^, alength);
+    l := AStream.read (data^, alength);
     if l <> alength then
       raise PNGImageException.Create ('Length exceeds stream length for ' + GetChunkCode(aType) + ' chunk');
     readCRC := 0;
-    TheStream.Read (readCRC, sizeof(ReadCRC));
+    AStream.Read (readCRC, sizeof(ReadCRC));
     l := CalculateChunkCRC(ReadType, data, alength);
     {$IFDEF ENDIAN_LITTLE}
     l := swap(l);
@@ -1612,7 +1634,7 @@ begin
     EndOfFile := false;
     while not EndOfFile do
       begin
-      if ReadChunk then
+      if ReadChunk(TheStream, Chunk) then
         HandleChunk;
       end;
 
@@ -1632,7 +1654,6 @@ end;
 
 function  TBGRAReaderPNG.InternalCheck (Str:TStream) : boolean;
 var {%H-}SigCheck : TPNGSignature;
-    r : integer;
 begin
   try
     // Check Signature
@@ -1640,24 +1661,44 @@ begin
       raise PNGImageException.Create('This is not PNG-data');
     if not CheckSignature(SigCheck) then
         raise PNGImageException.Create('This is not PNG-data');
-    // Check IHDR
-    ReadChunk;
-    if chunk.aType <> ctIHDR then
-      raise PNGImageException.Create('Header chunk expected but '+chunk.ReadType+' found');
+
+    if not TryReadHeader(Str, chunk) then
+      raise PNGImageException.Create('Header chunk expected but '+chunk.ReadType+' of size '+IntToStr(chunk.alength)+' found');
+
+    // Store header and check its values
     fillchar(FHeader, sizeof(FHeader), 0);
-    move (chunk.data^, FHeader, min(sizeof(Header), chunk.alength));
-    with header do
-      begin
-      {$IFDEF ENDIAN_LITTLE}
-      Width := swap(width);
-      height := swap (height);
-      {$ENDIF}
+    move (chunk.data^, FHeader, min(sizeof(FHeader), chunk.alength));
+    with FHeader do
       result := (width > 0) and (height > 0) and (compression = 0)
                 and (filter = 0) and (Interlace in [0,1]);
-      end;
   except
     result := false;
   end;
+end;
+
+class function TBGRAReaderPNG.InternalSize(Str: TStream): TPoint;
+begin
+  with ClassGetQuickInfo(Str) do
+    Result := Point(Width, Height);
+end;
+
+class function TBGRAReaderPNG.TryReadHeader(Str: TStream; var AChunk: TChunk): boolean;
+var
+  pHeader: PHeaderCunk;
+begin
+  ReadChunk(Str, AChunk);
+  if (AChunk.aType = ctIHDR) and
+     (AChunk.alength >= sizeof(LongWord)*2) then
+  begin
+    pHeader := PHeaderCunk(AChunk.data);
+    {$IFDEF ENDIAN_LITTLE}
+    pHeader^.Width := Swap(pHeader^.Width);
+    pHeader^.Height := Swap(pHeader^.Height);
+    {$ENDIF}
+    exit(true);
+  end
+  else
+    exit(false);
 end;
 
 initialization

--- a/bgrabitmap/bgrareadpnm.pas
+++ b/bgrabitmap/bgrareadpnm.pas
@@ -1,0 +1,67 @@
+unit BGRAReadPNM;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  BGRAClasses, SysUtils, FPReadPNM, FPimage, BGRABitmapTypes;
+
+type
+  { Reader for P?M image format }
+
+  { TBGRAReaderPNM }
+
+  TBGRAReaderPNM = class(TFPReaderPNM)
+    protected
+      class function InternalSize(Str: TStream): TPoint; override;
+  end;
+
+implementation
+
+{ TBGRAReaderPNM }
+
+class function TBGRAReaderPNM.InternalSize(Str: TStream): TPoint;
+var lst: TStringList;
+  valuesLine: String;
+  w, h, errPos, valuesIndex: integer;
+begin
+  result := Point(0, 0);
+  lst := TStringList.Create;
+  try
+    lst.LoadFromStream(Str);
+    if (lst.Count > 0) and (length(lst[0]) = 2) and lst[0].StartsWith('P')
+      and (lst[0][2] in ['1'..'7']) then
+    begin
+      valuesIndex := 1;
+      while (valuesIndex < lst.Count) and (lst[valuesIndex].StartsWith('#')) do
+       inc(valuesIndex);
+      if valuesIndex < lst.Count then
+      begin
+        valuesLine := lst[valuesIndex];
+        lst.Clear;
+        lst.Delimiter:= ' ';
+        lst.DelimitedText:= valuesLine;
+        if lst.Count >= 2 then
+        begin
+          val(lst[0], w, errPos);
+          if errPos = 0 then
+          begin
+            val(lst[1], h, errPos);
+            if errPos = 0 then
+              result := Point(w, h);
+          end;
+        end;
+      end;
+    end;
+  finally
+    lst.Free;
+  end;
+end;
+
+initialization
+
+  BGRARegisterImageReader(ifPortableAnyMap, TBGRAReaderPNM, False, 'Netpbm Portable aNyMap', 'pnm;pbm;pgm;ppm');
+
+end.
+

--- a/bgrabitmap/bgrareadpsd.pas
+++ b/bgrabitmap/bgrareadpsd.pas
@@ -194,14 +194,15 @@ type
       end;
     FOutputHeight: integer;
     function ReadPalette(Stream: TStream): boolean;
-    procedure AnalyzeHeader;
-
+    procedure ReadHeaderAndAllocate(Stream: TStream);
+    class function TryReadHeader(Stream: TStream; out AHeader: TPSDHeader): boolean;
     procedure ReadResourceBlockData(Img: TFPCustomImage; blockID:Word;
-                                    blockName:ShortString; Size:LongWord; Data:Pointer);{$IF FPC_FULLVERSION<30203}virtual;{$ELSE}override;{$ENDIF}
+                                    {%H-}blockName:ShortString; Size:LongWord; Data:Pointer);{$IF FPC_FULLVERSION<30203}virtual;{$ELSE}override;{$ENDIF}
     procedure InternalRead(Stream: TStream; Img: TFPCustomImage); override;
     function ReadScanLine(Stream: TStream; AInputSize: PtrInt; AChannel: integer): boolean; overload;
     procedure WriteScanLine(Img: TFPCustomImage; Row: integer); overload;
     function  InternalCheck(Stream: TStream) : boolean; override;
+    class function InternalSize(Str: TStream): TPoint; override;
   public
     MinifyHeight,WantedHeight: integer;
     constructor Create; override;
@@ -347,27 +348,39 @@ begin
   Result:=True;
 end;
 
-procedure TBGRAReaderPSD.AnalyzeHeader;
+procedure TBGRAReaderPSD.ReadHeaderAndAllocate(Stream: TStream);
 var channel: integer;
 begin
+  if not TryReadHeader(Stream, FHeader) then
+    Raise Exception.Create('Unknown/Unsupported PSD image type');
   With FHeader do
   begin
-    Depth:=BEtoN(Depth);
-    if (Signature <> '8BPS') then
-      Raise Exception.Create('Unknown/Unsupported PSD image type');
-    Channels:=BEtoN(Channels);
     if Channels > 4 then
       FBytesPerPixel:=Depth*4
     else
       FBytesPerPixel:=Depth*Channels;
-    Mode:=BEtoN(Mode);
-    FWidth:=BEtoN(Columns);
-    FHeight:=BEtoN(Rows);
+    FWidth:=Columns;
+    FHeight:=Rows;
     FChannelCount:=Channels;
     FLineSize:=(PtrInt(FWidth)*Depth+7) div 8;
     setlength(FScanLines, FChannelCount);
     for channel := 0 to FChannelCount-1 do
       GetMem(FScanLines[channel],FLineSize);
+  end;
+end;
+
+class function TBGRAReaderPSD.TryReadHeader(Stream: TStream; out AHeader: TPSDHeader
+  ): boolean;
+begin
+  result := Stream.Read({%H-}AHeader, sizeof(AHeader)) = sizeof(AHeader);
+  With AHeader do
+  begin
+    Depth:=BEtoN(Depth);
+    if (Signature <> '8BPS') then result := false;
+    Channels:=BEtoN(Channels);
+    Mode:=BEtoN(Mode);
+    Columns:=BEtoN(Columns);
+    Rows:=BEtoN(Rows);
   end;
 end;
 
@@ -383,7 +396,7 @@ begin
   {$IF FPC_FULLVERSION<30203}
   case blockID of
   PSD_RESN_INFO:begin
-          if (Img is TCustomUniversalBitmap) then
+          if (Img is TCustomUniversalBitmap) and (Size >= sizeof(TResolutionInfo)) then
           with TCustomUniversalBitmap(Img) do
           begin
             PsdResolution :=TResolutionInfo(Data^);
@@ -434,7 +447,7 @@ var
 
   begin
     //MaxM: Do NOT Remove the Casts after BEToN
-    Stream.Read(TotalBlockSize, 4);
+    Stream.ReadBuffer({%H-}TotalBlockSize, 4);
     TotalBlockSize :=BEtoN(DWord(TotalBlockSize));
     GetMem(blockData, TotalBlockSize);
     try
@@ -486,12 +499,9 @@ begin
     ContProgress:=true;
     Progress(FPimage.psStarting, 0, False, Rect(0,0,0,0), '', ContProgress);
     if not ContProgress then exit;
-    // read header
-    Stream.Read(FHeader, SizeOf(FHeader));
+    ReadHeaderAndAllocate(Stream);
     Progress(FPimage.psRunning, 0, False, Rect(0,0,0,0), '', ContProgress);
     if not ContProgress then exit;
-    AnalyzeHeader;
-
     //  color palette
     ReadPalette(Stream);
 
@@ -511,7 +521,7 @@ begin
     ReadResourceBlocks;
 
     //  mask
-    Stream.Read(BufSize, SizeOf(BufSize));
+    Stream.ReadBuffer({%H-}BufSize, SizeOf(BufSize));
     BufSize:=BEtoN(BufSize);
     Stream.Seek(BufSize, soCurrent);
     //  compression type
@@ -895,6 +905,16 @@ begin
   except
     Result:=False;
   end;
+end;
+
+class function TBGRAReaderPSD.InternalSize(Str: TStream): TPoint;
+var
+  h: TPSDHeader;
+begin
+  if not TryReadHeader(Str, h) then
+    result := Point(0, 0)
+  else
+    result := Point(h.Columns, h.Rows);
 end;
 
 constructor TBGRAReaderPSD.Create;

--- a/bgrabitmap/bgrareadtga.pas
+++ b/bgrabitmap/bgrareadtga.pas
@@ -41,6 +41,7 @@ type
     procedure InitReadBuffer(AStream: TStream; ASize: integer);
     procedure CloseReadBuffer;
     function GetNextBufferByte: byte;
+    class function InternalSize(Str: TStream): TPoint; override;
 
   published
     property GrayScale: Boolean read GetGrayScale;
@@ -64,7 +65,9 @@ end;
 
 function TBGRAReaderTarga.GetCompressed: boolean;
 begin
+  {$PUSH}{$WARNINGS OFF}
   Result:= TFPReaderTarga_Access(Self).Compressed;
+  {$POP}
 end;
 
 function TBGRAReaderTarga.GetGrayScale: Boolean;
@@ -216,6 +219,23 @@ begin
       inc(FBufferPos);
     end else
       result := 0;
+  end;
+end;
+
+class function TBGRAReaderTarga.InternalSize(Str: TStream): TPoint;
+var h: TTargaHeader;
+begin
+  result := Point(0, 0);
+  if Str.Read({%H-}h, sizeof(h)) <> sizeof(h) then
+    exit;
+
+  With h do
+  begin
+    if not (ImgType in [1, 2, 3, 9, 10, 11]) and
+       not (PixelSize in [8, 16, 24, 32]) then
+       exit;
+
+    result := Point(ToWord(Width), ToWord(Height));
   end;
 end;
 

--- a/bgrabitmap/bgrareadtiff.pas
+++ b/bgrabitmap/bgrareadtiff.pas
@@ -72,6 +72,9 @@ type
     );
 
   { Reader for TIFF format }
+
+  { TBGRAReaderTiff }
+
   TBGRAReaderTiff = class(TFPCustomImageReader)
   private
     FCheckIFDOrder: TTiffCheckIFDOrder;
@@ -120,6 +123,8 @@ type
     procedure InternalRead(Str: TStream; AnImage: TFPCustomImage); override;
     function InternalCheck(Str: TStream): boolean; override;
     procedure DoCreateImage(ImgFileDir: TTiffIFD); virtual;
+    class function InternalSize(Str: TStream): TPoint; override;
+    function ReadBiggestSize(Str: TStream): TPoint;
   public
     constructor Create; override;
     destructor Destroy; override;
@@ -2530,6 +2535,33 @@ procedure TBGRAReaderTiff.DoCreateImage(ImgFileDir: TTiffIFD);
 begin
   if Assigned(OnCreateImage) then
     OnCreateImage(Self,ImgFileDir);
+end;
+
+class function TBGRAReaderTiff.InternalSize(Str: TStream): TPoint;
+var
+  subReader: TBGRAReaderTiff;
+begin
+  subReader := TBGRAReaderTiff.Create;
+  try
+    result := subReader.ReadBiggestSize(Str);
+  finally
+    subReader.Free;
+  end;
+end;
+
+function TBGRAReaderTiff.ReadBiggestSize(Str: TStream): TPoint;
+var
+  BestIFD: TTiffIFD;
+begin
+  try
+    Clear;
+    LoadHeaderFromStream(Str);
+    LoadIFDsFromStream;
+    BestIFD := GetBiggestImage;
+    result := Point(BestIFD.ImageWidth , BestIFD.ImageHeight);
+  except
+    result := Point(0, 0);
+  end;
 end;
 
 constructor TBGRAReaderTiff.Create;

--- a/bgrabitmap/bgrareadwebp.pas
+++ b/bgrabitmap/bgrareadwebp.pas
@@ -24,6 +24,7 @@ type
     function ReadHeader(Str: TStream): TWebPHeader;
     procedure InternalRead(Str: TStream; Img: TFPCustomImage); override;
     function InternalCheck(Str: TStream): boolean; override;
+    class function InternalSize(Str: TStream): TPoint; override;
   end;
 
 implementation
@@ -47,7 +48,7 @@ end;
 
 function TBGRAReaderWebP.ReadHeader(Str: TStream): TWebPHeader;
 begin
-  fillchar({%H-}result, sizeof({%H-}result), 0);
+  {$PUSH}{$HINTS OFF}fillchar({%H-}result, sizeof(result), 0);{$POP}
   Str.Read(result, sizeof(result));
   result.FileSize:= LEtoN(result.FileSize);
 end;
@@ -57,7 +58,7 @@ const
   CopySize = 65536;
 var
   header: TWebPHeader;
-  oldPos: Int64;
+  oldPos, physicalSize: Int64;
   mem, p: PByte;
   totalSize, remain: LongWord;
   toRead, w, h, x, y: integer;
@@ -73,6 +74,9 @@ begin
     raise exception.Create('Invalid header');
   Str.Position:= OldPos;
   totalSize := header.FileSize+8;
+  physicalSize := Str.Size - Str.Position;
+  if physicalSize < totalSize then
+    totalSize := physicalSize;
   getmem(mem, totalSize);
   loadInto := nil;
   try
@@ -135,6 +139,19 @@ begin
   finally
     Str.Position:= OldPos;
   end;
+end;
+
+class function TBGRAReaderWebP.InternalSize(Str: TStream): TPoint;
+var
+  buffer: array[0..1023] of byte;
+  bytesRead: LongInt;
+  w, h: integer;
+begin
+  result := Point(0, 0);
+  NeedLibWebP;
+  bytesRead:= Str.Read({%H-}buffer, sizeof(buffer));
+  if WebPGetInfo(@buffer, bytesRead, @w, @h) <> 0 then
+    result := Point(w, h);
 end;
 
 initialization

--- a/bgrabitmap/bgrareadxpm.pas
+++ b/bgrabitmap/bgrareadxpm.pas
@@ -16,6 +16,7 @@ type
     protected
       procedure InternalRead(Str: TStream; Img: TFPCustomImage); override;
       function InternalCheck(Str: TStream): boolean; override;
+      class function InternalSize(Str: TStream): TPoint; override;
     public
       class procedure ConvertToXPM3(ASource: TStream; ADestination: TStream); static;
   end;
@@ -56,6 +57,53 @@ begin
     if not result then result := inherited InternalCheck(Str)
   except
     result := false;
+  end;
+end;
+
+class function TBGRAReaderXPM.InternalSize(Str: TStream): TPoint;
+var
+  lst: TStringList;
+  valuesLine: string;
+  startQuote, endQuote, w, h, i, errPos: Integer;
+begin
+  result := Point(0, 0);
+  valuesLine := '';
+  lst := TStringList.Create;
+  try
+    lst.LoadFromStream(Str);
+    if (lst[0] = '! XPM2') and (lst.Count > 1) then
+      valuesLine := lst[1]
+    else if (lst[0] = '/* XPM */') then
+    begin
+      for i := 1 to lst.Count-1 do
+      begin
+        startQuote := lst[i].IndexOf('"');
+        endQuote := lst[i].LastIndexOf('"');
+        if endQuote > startQuote then
+        begin
+          valuesLine := lst[i].Substring(startQuote + 1, endQuote-startQuote - 1);
+          break;
+        end;
+      end;
+    end;
+    if valuesLine <> '' then
+    begin
+      lst.Clear;
+      lst.Delimiter := ' ';
+      lst.DelimitedText := valuesLine;
+      if lst.Count >= 2 then
+      begin
+        val(lst[0], w, errPos);
+        if errPos = 0 then
+        begin
+          val(lst[1], h, errPos);
+          if errPos = 0 then
+            result := Point(w, h);
+        end;
+      end;
+    end;
+  finally
+    lst.Free;
   end;
 end;
 

--- a/bgrabitmap/bgrasvg.pas
+++ b/bgrabitmap/bgrasvg.pas
@@ -319,6 +319,9 @@ end;
     protected
       function InternalCheck(Stream: TStream): boolean; override;
       procedure InternalRead(Stream: TStream; Img: TFPCustomImage); override;
+      class function InternalSize(Stream: TStream): TPoint; override;
+      class function InternalSizeEx(Stream: TStream; ARenderDPI: integer; AScale: single): TPoint;
+      class function GetRenderSize(ASVG: TBGRASVG; AScale: single): TPointF;
     public
       constructor Create; override;
       function GetQuickInfo(AStream: TStream): TQuickImageInfo; override;
@@ -356,7 +359,6 @@ end;
 procedure TFPReaderSVG.InternalRead(Stream: TStream; Img: TFPCustomImage);
 var
   svg: TBGRASVG;
-  vsize: TPointF;
   bgra: TBGRACustomBitmap;
   c2d: TBGRACanvas2D;
   y, x: Integer;
@@ -370,10 +372,8 @@ begin
       bgra := TBGRACustomBitmap(Img)
     else
       bgra := BGRABitmapFactory.Create;
-    if svg.preserveAspectRatio.Preserve then
-      vsize := svg.GetViewSize(cuPixel)
-      else vsize := PointF(svg.WidthAsPixel, svg.HeightAsPixel);
-    bgra.SetSize(ceil(vsize.x*scale),ceil(vsize.y*scale));
+    with GetRenderSize(svg, Scale).Ceiling do
+      bgra.SetSize(X, Y);
     bgra.FillTransparent;
     c2d := TBGRACanvas2D.Create(bgra);
     svg.StretchDraw(c2d, 0,0,bgra.Width,bgra.Height, true);
@@ -399,6 +399,35 @@ begin
   end;
 end;
 
+class function TFPReaderSVG.InternalSize(Stream: TStream): TPoint;
+begin
+  Result:= InternalSizeEx(Stream, 96, 1);
+end;
+
+class function TFPReaderSVG.InternalSizeEx(Stream: TStream; ARenderDPI: integer; AScale: single): TPoint;
+var
+  svg: TBGRASVG;
+begin
+  Result:= Point(0, 0);
+  svg := TBGRASVG.Create(Stream);
+  try
+    svg.DefaultDpi:= ARenderDPI;
+    result := GetRenderSize(svg, AScale).Ceiling;
+  finally
+    svg.Free;
+  end;
+end;
+
+class function TFPReaderSVG.GetRenderSize(ASVG: TBGRASVG; AScale: single): TPointF;
+var
+  vsize: TPointF;
+begin
+  if ASVG.preserveAspectRatio.Preserve then
+    vsize := ASVG.GetViewSize(cuPixel)
+  else vsize := PointF(ASVG.WidthAsPixel, ASVG.HeightAsPixel);
+  result := PointF(vsize.x*AScale, vsize.y*AScale);
+end;
+
 constructor TFPReaderSVG.Create;
 begin
   inherited Create;
@@ -413,10 +442,13 @@ var
 begin
   svg := TBGRASVG.Create(AStream);
   svg.DefaultDpi:= RenderDpi;
-  vsize := svg.GetViewSize(cuPixel);
+  vsize := GetRenderSize(svg, 1);
   svg.Free;
-  result.Width:= ceil(vsize.x);
-  result.Height:= ceil(vsize.y);
+  with vsize.Ceiling do
+  begin
+    result.Width:= X;
+    result.Height:= Y;
+  end;
   result.AlphaDepth:= 8;
   result.ColorDepth:= 24;
 end;
@@ -433,9 +465,7 @@ begin
   result := nil;
   try
     svg.DefaultDpi:= RenderDpi;
-    if svg.preserveAspectRatio.Preserve then
-      vsize := svg.GetViewSize(cuPixel)
-      else vsize := PointF(svg.WidthAsPixel, svg.HeightAsPixel);
+    vsize := GetRenderSize(svg, Scale);
     AOriginalWidth:= ceil(vsize.x);
     AOriginalHeight:= ceil(vsize.y);
     if (vsize.x = 0) or (vsize.y = 0) then exit;
@@ -769,7 +799,7 @@ var str: TMemoryStream;
 begin
   str := TMemoryStream.Create;
   SaveToStream(str);
-  setlength(result, str.Size);
+  setlength({%H-}result, str.Size);
   str.Position := 0;
   str.Read(result[1], length(result));
   str.Free;

--- a/bgrabitmap/bgrasvg.pas
+++ b/bgrabitmap/bgrasvg.pas
@@ -460,7 +460,9 @@ var
   vsize: TPointF;
   c2d: TBGRACanvas2D;
   ratio: Single;
+  oldPos: Int64;
 begin
+  oldPos := AStream.Position;
   svg := TBGRASVG.Create(AStream);
   result := nil;
   try
@@ -479,6 +481,7 @@ begin
     end;
   finally
     svg.Free;
+    AStream.Position:= oldPos;
   end;
 end;
 

--- a/bgrabitmap/bgrathumbnail.pas
+++ b/bgrabitmap/bgrathumbnail.pas
@@ -261,7 +261,7 @@ var
   reader: TBGRAReaderLazPaint;
 begin
   reader:= TBGRAReaderLazPaint.Create;
-  reader.WantThumbnail := true;
+  reader.IncludeThumbnail := true;
   result := GetStreamThumbnail(AStream,reader,AWidth,AHeight,ABackColor,ACheckers,ADest);
   reader.Free;
 end;

--- a/bgrabitmap/bgrawritebmpmiomap.pas
+++ b/bgrabitmap/bgrawritebmpmiomap.pas
@@ -336,13 +336,13 @@ var
   alphas: packed array of byte;
   i: Int32or64;
 begin
-  setlength(Colors, FHeader.nbColors);
+  setlength({%H-}Colors, FHeader.nbColors);
   for i := 0 to FHeader.nbColors-1 do
     colors[i] := NtoLE(FPalette[i].ColorValue);
   Str.WriteBuffer(colors[0], length(Colors)*sizeof(word));
   if FPaletteAlpha then
   begin
-    setlength(alphas, FHeader.nbColors);
+    setlength({%H-}alphas, FHeader.nbColors);
     for i := 0 to FHeader.nbColors-1 do
       alphas[i] := FPalette[i].AlphaValue;
     Str.WriteBuffer(alphas[0], length(alphas)*sizeof(byte));


### PR DESCRIPTION
Issue #300: implementing `InternalSize` function of `TFPCustomImageReader`, accessible via `ImageSize` function

Test project with sample images: [testsize.zip](https://github.com/user-attachments/files/26244022/testsize.zip)

<img width="1055" height="352" alt="image" src="https://github.com/user-attachments/assets/f36102f5-3298-4c28-a3d7-ed0d9e7a7555" />

Sample images:

<img width="1659" height="719" alt="image" src="https://github.com/user-attachments/assets/3a5b19f3-cea9-4c3a-90a2-07baeccbbc2b" />

Note that to check for AVIF and WebP you need the appropriate Dll / package. For Windows, you can find in the [release folder](https://github.com/bgrabitmap/lazpaint/tree/master/lazpaint/release/windows) of LazPaint repository.