### PR TITLE
One more TGradientDirection disambiguation

### DIFF
--- a/bgrabitmap/bgracanvas.pas
+++ b/bgrabitmap/bgracanvas.pas
@@ -1497,7 +1497,7 @@ begin
     if (Right <= Left) or (Bottom <= Top) then
       Exit;
 
-  if ADirection = gdVertical then
+  if ADirection = TGradientDirection.gdVertical then
     Count := ARect.Bottom - ARect.Top
   else
     Count := ARect.Right - ARect.Left;


### PR DESCRIPTION
This is a follow-up to 63d747ff4ab33d4743b25ad45a4f4c7cbc47e94b. Said commit mixed one occurrence of `gdVertical`.

This fixes building with fpc-3.2.4-rc2.